### PR TITLE
native improvements 3 - memory leak fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Quix streams is a library specialized in processing <b>high-frequency data</b>, 
 You can install the library for amd64 platforms using the package manager for Python Packages:
 
 ```shell
-python3 -m pip install --extra-index-url https://test.pypi.org/simple/ quixstreams==0.5.0.dev16 --user
+python3 -m pip install --extra-index-url https://test.pypi.org/simple/ quixstreams==0.5.0.dev17 --user
 ```
 
 ### Installing on M1/M2 Mac
@@ -124,7 +124,7 @@ To install Quix Streams on apple silicon (M1 and M2-based) Macs, rosetta amd64 e
 19. Install Quix Streams:
 
     ```
-    python3 -m pip install --extra-index-url https://test.pypi.org/simple/ quixstreams==0.5.0.dev16 --user
+    python3 -m pip install --extra-index-url https://test.pypi.org/simple/ quixstreams==0.5.0.dev17 --user
     ```
 
 20. You can now run your code that uses Quix Streams:

--- a/docs/read.md
+++ b/docs/read.md
@@ -686,7 +686,7 @@ This is a minimal code example you can use to read data from a topic using the Q
 === "Python"
     
     ``` python
-    from quixstream import *
+    from quixstreams import *
     from quixstreams.app import App
     
     # Quix injects credentials automatically to the client. Alternatively, you can always pass an SDK token manually as an argument.

--- a/src/CsharpClient/Quix.Sdk.Transport.Kafka/KafkaInput.cs
+++ b/src/CsharpClient/Quix.Sdk.Transport.Kafka/KafkaInput.cs
@@ -41,9 +41,9 @@ namespace Quix.Sdk.Transport.Kafka
         /// <param name="topicConfiguration">The topic configuration</param>
         public KafkaInput(PublisherConfiguration publisherConfiguration, InputTopicConfiguration topicConfiguration)
         {
-            SetConfigId(topicConfiguration);
             Action hbAction = null;
             this.config = publisherConfiguration.ToProducerConfig();
+            SetConfigId(topicConfiguration);
             if (topicConfiguration.Partition == Partition.Any)
             {
                 this.produce = (key, value, handler, _) => this.producer.Produce(topicConfiguration.Topic, new Message<string, byte[]> { Key = key, Value = value }, handler);

--- a/src/CsharpClient/Quix.Sdk.Transport.Kafka/KafkaInput.cs
+++ b/src/CsharpClient/Quix.Sdk.Transport.Kafka/KafkaInput.cs
@@ -119,6 +119,15 @@ namespace Quix.Sdk.Transport.Kafka
             logBuilder.AppendLine("=================== Kafka Producer Configuration =====================");
             logBuilder.AppendLine("= Configuration Id: " + this.configId);
             logBuilder.AppendLine($"= Topic: {topicConfiguration.Topic}{topicConfiguration.Partition}");
+            foreach (var keyValuePair in this.config)
+            {
+                if (keyValuePair.Key?.IndexOf("password", StringComparison.InvariantCultureIgnoreCase) > -1 ||
+                    keyValuePair.Key?.IndexOf("username", StringComparison.InvariantCultureIgnoreCase) > -1)
+                {
+                    logBuilder.AppendLine($"= {keyValuePair.Key}: [REDACTED]");
+                }
+                else logBuilder.AppendLine($"= {keyValuePair.Key}: {keyValuePair.Value}");
+            }
             logBuilder.Append("======================================================================");
             this.logger.LogDebug(logBuilder.ToString());
         }

--- a/src/CsharpClient/Quix.Sdk.Transport.Kafka/KafkaOutput.cs
+++ b/src/CsharpClient/Quix.Sdk.Transport.Kafka/KafkaOutput.cs
@@ -142,7 +142,17 @@ namespace Quix.Sdk.Transport.Kafka
                 {
                     logBuilder.AppendLine($"= ConsumerInstanceId: {this.config.GroupInstanceId}");    
                 }
-            } 
+            }
+
+            foreach (var keyValuePair in this.config)
+            {
+                if (keyValuePair.Key?.IndexOf("password", StringComparison.InvariantCultureIgnoreCase) > -1 ||
+                    keyValuePair.Key?.IndexOf("username", StringComparison.InvariantCultureIgnoreCase) > -1)
+                {
+                    logBuilder.AppendLine($"= {keyValuePair.Key}: [REDACTED]");
+                }
+                else logBuilder.AppendLine($"= {keyValuePair.Key}: {keyValuePair.Value}");
+            }
             logBuilder.Append("======================================================================");
             this.logger.LogDebug(logBuilder.ToString());
         }

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
@@ -198,20 +198,20 @@ public class InteropUtils
         return ptrStart;
     }
     
-    public static T FromUPtr<T>(IntPtr ptr)
+    public static T FromUPtr<T>(IntPtr uptr)
     {
-        return (T)FromUPtr(ptr, typeof(T));
+        return (T)FromUPtr(uptr, typeof(T));
     }
     
-    public static object FromUPtr(IntPtr ptr, Type objectType)
+    public static object FromUPtr(IntPtr uptr, Type objectType)
     {
-        if (ptr == IntPtr.Zero) return null;
+        if (uptr == IntPtr.Zero) return null;
 
         object obj;
         if (typeof(Array).IsAssignableFrom(objectType))
         {
             var elementType = objectType.GetElementType();
-            obj = FromArrayUPtr(ptr, elementType);
+            return FromArrayUPtr(uptr, elementType);
         }
         else
         {
@@ -219,20 +219,19 @@ public class InteropUtils
             var underlyingNullable = Nullable.GetUnderlyingType(objectType);
             if (underlyingNullable != null)
             {
-                return FromNullableUPtr(ptr, underlyingNullable);
+                return FromNullableUPtr(uptr, underlyingNullable);
             }
-            var size = Marshal.SizeOf(objectType);
-            // Copy the struct to the memory block
-            obj = Marshal.PtrToStructure(ptr, objectType);
+            obj = Marshal.PtrToStructure(uptr, objectType);
         }
         
-        LogDebug("Converted UPtr: {0}, type: {1}, {2}", ptr, objectType.FullName, "is not null");
+        LogDebug("Converted UPtr: {0}, type: {1}, {2}", uptr, objectType.FullName, "is not null");
+        FreeUPtr(uptr);
         return obj;
     }
 
-    public static Array FromArrayUPtr(IntPtr ptr, Type elementType)
+    public static Array FromArrayUPtr(IntPtr uptr, Type elementType)
     {
-        if (ptr == IntPtr.Zero) return null;
+        if (uptr == IntPtr.Zero) return null;
         if (elementType == null)
         {
             LogDebug(new System.Diagnostics.StackTrace().ToString());
@@ -241,17 +240,17 @@ public class InteropUtils
         var underlyingNullable = Nullable.GetUnderlyingType(elementType);
         if (underlyingNullable != null)
         {
-            return FromNullableArrayUPtr(ptr, underlyingNullable);
+            return FromNullableArrayUPtr(uptr, underlyingNullable);
         }
         // not checking for blittable, let the framework deal with it
         const int countSize = 4;
         var elementSize = Marshal.SizeOf(elementType);
-        var length = Marshal.PtrToStructure<int>(ptr);
-        var currentPtr = ptr + countSize;
-        var ptrEnd = ptr + countSize + elementSize * length;
+        var length = Marshal.PtrToStructure<int>(uptr);
+        var currentPtr = uptr + countSize;
+        var ptrEnd = uptr + countSize + elementSize * length;
         var array = Array.CreateInstance(elementType, length);
         
-        LogDebug($"Array length: {array.Length} at ptr {ptr}, array starting at {ptr+countSize}, ending at {ptrEnd} with element size {elementSize} | aa9d");
+        LogDebug($"Array length: {array.Length} at ptr {uptr}, array starting at {uptr+countSize}, ending at {ptrEnd} with element size {elementSize} | aa9d");
         
         // Marshalling element by element because in native AOT we're limited in what we can do
         // and System.Byte[] refused to marshal for me. Maybe there is a fix?
@@ -262,31 +261,21 @@ public class InteropUtils
             currentPtr += elementSize;
         }
 
+        FreeUPtr(uptr);
         return array;
     }
     
-    private static IntPtr FromNullableUPtr(object obj, Type underlyingType)
+    private static object FromNullableUPtr(IntPtr uptr, Type underlyingType)
     {
-        var elementSize = NullableHasValuePrefixSize;
+        var hasValue = Marshal.PtrToStructure<bool>(uptr);
+        var nullablePtr =  uptr + NullableHasValuePrefixSize;
+        var value = hasValue ? Marshal.PtrToStructure(nullablePtr, underlyingType) : null;
         
-        // not checking for blittable, let the framework deal with it
-        var underlyingElementSize = Marshal.SizeOf(underlyingType);
-        elementSize += underlyingElementSize;
-        var ptr = Marshal.AllocHGlobal(elementSize);
-
-        var currentPtr = ptr;
-        var hasValue = obj != null; 
-        Marshal.StructureToPtr(hasValue, currentPtr, false);
-        if (hasValue)
-        {
-            var actual = Convert.ChangeType(obj, underlyingType);
-            Marshal.StructureToPtr(actual, currentPtr, false);
-        }
-
-        return ptr;
+        FreeUPtr(uptr);
+        return value;
     }
     
-    private static Array FromNullableArrayUPtr(IntPtr ptr, Type underlyingType)
+    private static Array FromNullableArrayUPtr(IntPtr uptr, Type underlyingType)
     {
         var elementSize = NullableHasValuePrefixSize;
         
@@ -294,16 +283,16 @@ public class InteropUtils
         const int countSize = 4;
         var underlyingElementSize = Marshal.SizeOf(underlyingType);
         elementSize += underlyingElementSize;
-        var length = Marshal.PtrToStructure<int>(ptr);
-        var currentPtr = ptr + countSize;
-        var ptrEnd = ptr + countSize + elementSize * length;
+        var length = Marshal.PtrToStructure<int>(uptr);
+        var currentPtr = uptr + countSize;
+        var ptrEnd = uptr + countSize + elementSize * length;
         var array = Array.CreateInstance(underlyingType, length);
 
         if (DebugMode)
         {
-            LogDebug($"Array length: {array.Length} at ptr {ptr}, array starting at {ptr + countSize}, ending at {ptrEnd} with element size {elementSize} for underlying type {underlyingType} | 283a");
-            var bytes = new byte[(long)ptrEnd - (long)ptr];
-            Marshal.Copy(ptr, bytes, 0, bytes.Length);
+            LogDebug($"Array length: {array.Length} at ptr {uptr}, array starting at {uptr + countSize}, ending at {ptrEnd} with element size {elementSize} for underlying type {underlyingType} | 283a");
+            var bytes = new byte[(long)ptrEnd - (long)uptr];
+            Marshal.Copy(uptr, bytes, 0, bytes.Length);
             LogDebug($"Bytes: {BitConverter.ToString(bytes).Replace("-", "")} | 283a");
         }
 
@@ -320,7 +309,8 @@ public class InteropUtils
 
             currentPtr += underlyingElementSize;
         }
-        LogDebug($"Array done");
+        
+        FreeUPtr(uptr);
         return array;
     }
     
@@ -426,6 +416,11 @@ public class InteropUtils
     /// Free unmanaged memory pointer
     /// </summary>
     [UnmanagedCallersOnly(EntryPoint = "interoputils_free_uptr")]
+    public static void UnmanagedFreeUPtr(IntPtr ptr)
+    {
+        FreeUPtr(ptr);
+    }
+    
     public static void FreeUPtr(IntPtr ptr)
     {
         LogDebug("Invoked interoputils_free_uptr with UPtr: {0}", ptr);
@@ -439,18 +434,17 @@ public class InteropUtils
     /// Allocated unmanaged memory pointer of the desired size
     /// </summary>
     [UnmanagedCallersOnly(EntryPoint = "interoputils_alloc_uptr")]
+    public static IntPtr UnmanagedAllocateUPtr(int size)
+    {
+        return AllocateUPtr(size);
+    }
+    
     public static IntPtr AllocateUPtr(int size)
     {
         LogDebug("Allocating UPtr with size {0}", size);
         var ptr = Marshal.AllocHGlobal(size);
         LogDebug("Allocated UPtr: {0}, type: {1}, {2}", ptr, "UNMANAGED", "is not null");
         return ptr;
-    }
-
-    public static void PrintStrPtr(IntPtr ptr)
-    {
-        if (ptr == IntPtr.Zero) return;
-        Console.Write(Marshal.PtrToStringUTF8(ptr));
     }
 
     public static IntPtr Utf8StringToUPtr(in string str)
@@ -464,10 +458,12 @@ public class InteropUtils
         return pointer;
     }
 
-    public static string PtrToStringUTF8(IntPtr pointer)
+    public static string PtrToStringUTF8(IntPtr uptr)
     {
-        if (pointer == IntPtr.Zero) return null;
-        return Marshal.PtrToStringUTF8(pointer);
+        if (uptr == IntPtr.Zero) return null;
+        var res =  Marshal.PtrToStringUTF8(uptr);
+        FreeUPtr(uptr);
+        return res;
     }
     
     public static IntPtr ObjectToPtr(object obj)

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
@@ -452,7 +452,7 @@ public class InteropUtils
         if (str == null) return IntPtr.Zero;
         var bytes = Encoding.UTF8.GetBytes(str);
         var pointer = Marshal.AllocHGlobal(bytes.Length + 1);  // +1 due to being null terminated string
-        LogDebug("Allocated UPtr: {0}, type: {1}, {2}", pointer, typeof(byte[]), "is not null");
+        LogDebug("Allocated UPtr: {0}, type: {1}, {2}{3}", pointer, typeof(byte[]), "is not null", $",value {str}");
         Marshal.Copy(bytes, 0, pointer, bytes.Length);
         Marshal.WriteByte(pointer + bytes.Length, 0);
         return pointer;
@@ -462,6 +462,7 @@ public class InteropUtils
     {
         if (uptr == IntPtr.Zero) return null;
         var res =  Marshal.PtrToStringUTF8(uptr);
+        LogDebug("Converting UPtr->Str: {0}->{1}", uptr, res);
         FreeUPtr(uptr);
         return res;
     }

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/ExternalTypes/System/Dictionary.py
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/ExternalTypes/System/Dictionary.py
@@ -38,6 +38,8 @@ class Dictionary:
         """
          Writes dictionary into unmanaged memory, returning a pointer with structure [[keys],[values]], each array with a 4 byte length prefix
          """
+        if dictionary is None:
+            return None
         keys = key_converter(dictionary.keys())
         values = value_converter(dictionary.values())
         return Array.WritePointers([keys, values])

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/InteropUtils.py
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/InteropUtils.py
@@ -57,8 +57,10 @@ class InteropUtils(object):
             return None
         # TODO this can likely be done eaiser with c_char_p or sth, but it has to be freeable using Marshal.FreeHGlobal
         str_bytes = string.encode('utf-8')
-        uptr = InteropUtils.allocate_uptr(len(str_bytes))
+        uptr = InteropUtils.allocate_uptr(len(str_bytes) + 1) # must be null terminated
         ctypes.memmove(uptr, str_bytes, len(str_bytes))
+        null_terminator = ctypes.c_ubyte.from_address(uptr.value + len(str_bytes))
+        null_terminator.value = 0 # allocate_uptr doesn't guarantee memory with all 0, must set manually
         return uptr
 
 

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/InteropUtils.py
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/InteropUtils.py
@@ -55,7 +55,11 @@ class InteropUtils(object):
     def utf8_to_ptr(string) -> ctypes.c_char_p:
         if string is None:
             return None
-        return ctypes.c_char_p(string.encode('utf-8'))
+        # TODO this can likely be done eaiser with c_char_p or sth, but it has to be freeable using Marshal.FreeHGlobal
+        str_bytes = string.encode('utf-8')
+        uptr = InteropUtils.allocate_uptr(len(str_bytes))
+        ctypes.memmove(uptr, str_bytes, len(str_bytes))
+        return uptr
 
 
     @staticmethod

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -33,9 +33,9 @@ def rec_incl_with_filter(directory, filters, trim):
                     break
 
 
-rec_incl_with_filter('src/quixstreams', [r'.*\.py$'], 'src/quixstreams') # include all python files
+rec_incl_with_filter('src/quixstreams', [r'.*\.py$'], 'src/quixstreams')  # include all python files
 plat = platform.uname()
-platname = f"{plat.system}-{plat.machine}".lower()  # If changes, update build scriptts and __init__.py
+platname = f"{plat.system}-{plat.machine}".lower()  # If changes, update build scripts and __init__.py
 platpath = 'src/quixstreams/native/' + platname
 print("Platform {} build".format(plat))
 if plat.system.upper() == "WINDOWS":

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.0.dev16"
+package_version = "0.5.0.dev17"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/src/quixstreams/builders/parameterdatabuilder.py
+++ b/src/PythonClient/src/quixstreams/builders/parameterdatabuilder.py
@@ -59,13 +59,10 @@ class ParameterDataBuilder(object):
                 self._interop = new
         elif val_type is bytes:
             arr_ptr = Array.WriteBytes(value)
-            try:
-                new = pdbi(self._interop.AddValue3(parameter_id, arr_ptr))
-                if new != self._interop:
-                    self._interop.dispose_ptr__()
-                    self._interop = new
-            finally:
-                InteropUtils.free_uptr(arr_ptr)
+            new = pdbi(self._interop.AddValue3(parameter_id, arr_ptr))
+            if new != self._interop:
+                self._interop.dispose_ptr__()
+                self._interop = new
         else:
             raise Exception("Invalid type " + str(val_type) + " passed as parameter value.")
         return self

--- a/src/PythonClient/src/quixstreams/models/parameterdataraw.py
+++ b/src/PythonClient/src/quixstreams/models/parameterdataraw.py
@@ -258,7 +258,7 @@ class ParameterDataRaw(object):
                             _add_string(panda_col_label, row_index, str_val)
 
         parameter_data_raw.set_values(
-            epoch=epoch, 
+            epoch=epoch,
             timestamps=timestamps,
             numeric_values=numeric_values,
             string_values=string_values,
@@ -296,43 +296,28 @@ class ParameterDataRaw(object):
         #set timestamps
         self._timestamps = timestamps
         ts_uptr = Array.WriteLongs(timestamps)
-        try:
-            self._interop.set_Timestamps(ts_uptr)
-        finally:
-            InteropUtils.free_uptr(ts_uptr)
+        self._interop.set_Timestamps(ts_uptr)
 
         #set numeric values
         self._numeric_values = numeric_values
         nv_uptr = Dictionary.WriteStringNullableDoublesArray(numeric_values)
-        try:
-            self._interop.set_NumericValues(nv_uptr)
-        finally:
-            InteropUtils.free_uptr(nv_uptr)
+        self._interop.set_NumericValues(nv_uptr)
 
 
         #set string values
         self._string_values = string_values
         sv_uptr = Dictionary.WriteStringStringsArray(string_values)
-        try:
-            self._interop.set_StringValues(sv_uptr)
-        finally:
-            InteropUtils.free_uptr(sv_uptr)
+        self._interop.set_StringValues(sv_uptr)
 
         #set byte values
         self._binary_values = binary_values
         bv_uptr = Dictionary.WriteStringBytesArray(binary_values)
-        try:
-            self._interop.set_BinaryValues(bv_uptr)
-        finally:
-            InteropUtils.free_uptr(bv_uptr)
+        self._interop.set_BinaryValues(bv_uptr)
 
         #set tags values
         self._tag_values = tag_values
         tv_uptr = Dictionary.WriteStringStringsArray(tag_values)
-        try:
-            self._interop.set_TagValues(tv_uptr)
-        finally:
-            InteropUtils.free_uptr(tv_uptr)
+        self._interop.set_TagValues(tv_uptr)
 
     @property
     def epoch(self) -> int:

--- a/src/PythonClient/src/quixstreams/models/parameterdatatimestamp.py
+++ b/src/PythonClient/src/quixstreams/models/parameterdatatimestamp.py
@@ -154,10 +154,7 @@ class ParameterDataTimestamp:
                 self._interop = new
         elif val_type is bytearray or val_type is bytes:
             uptr = ai.WriteBytes(value)
-            try:
-                new = pdti(self._interop.AddValue3(parameter_id, uptr))
-            finally:
-                iu.free_uptr(uptr)
+            new = pdti(self._interop.AddValue3(parameter_id, uptr))
             if new != self._interop:
                 self._interop.dispose_ptr__()
                 self._interop = new

--- a/src/PythonClient/src/quixstreams/models/parametervalue.py
+++ b/src/PythonClient/src/quixstreams/models/parametervalue.py
@@ -109,10 +109,7 @@ class ParameterValue(object):
         self._value = value
 
         uptr = ai.WriteBytes(value)
-        try:
-            self._interop.set_BinaryValue(uptr)
-        finally:
-            InteropUtils.free_uptr(uptr)
+        self._interop.set_BinaryValue(uptr)
 
     @property
     def type(self) -> ParameterValueType:

--- a/src/PythonClient/src/quixstreams/models/streamreader/streamparametersreader.py
+++ b/src/PythonClient/src/quixstreams/models/streamreader/streamparametersreader.py
@@ -214,9 +214,6 @@ class StreamParametersReader(object):
         else:
             buffer = ParametersBufferReader(self._stream_reader, self._interop.CreateBuffer2(actual_filters_uptr))
 
-        if actual_filters_uptr is not None:
-            InteropUtils.free_uptr(actual_filters_uptr)
-
         self._buffers.append(buffer)
         return buffer
 

--- a/src/PythonClient/src/quixstreams/models/streamwriter/parametersbufferwriter.py
+++ b/src/PythonClient/src/quixstreams/models/streamwriter/parametersbufferwriter.py
@@ -71,11 +71,8 @@ class ParametersBufferWriter(ParametersBuffer):
             finally:
                 InteropUtils.free_hptr(netdate_hptr)  # dotnet will hold a reference to it, we no longer need it
         if isinstance(time, timedelta):
-            try:
-                nettimespan_uptr = dtc.timedelta_to_dotnet(time)
-                return ParameterDataBuilder(self._interop.AddTimestamp2(nettimespan_uptr))
-            finally:
-                InteropUtils.free_uptr(nettimespan_uptr)  # dotnet will hold a reference to it, we no longer need it
+            nettimespan_uptr = dtc.timedelta_to_dotnet(time)
+            return ParameterDataBuilder(self._interop.AddTimestamp2(nettimespan_uptr))
         raise ValueError("'time' must be either datetime or timedelta")
 
     def add_timestamp_nanoseconds(self, nanoseconds: int) -> ParameterDataBuilder:

--- a/src/PythonClient/tests/quixstreams/manual/write_manual_test.py
+++ b/src/PythonClient/tests/quixstreams/manual/write_manual_test.py
@@ -3,14 +3,13 @@ import random
 
 import pandas as pd
 
-from quixstreams.native.Python.InteropHelpers.InteropUtils import InteropUtils
+from src.quixstreams.native.Python.InteropHelpers.InteropUtils import InteropUtils
 #InteropUtils.enable_debug()
 
-import quixstreams as qx
-from quixstreams.models.parametervalue import ParameterValueType
+from src import quixstreams as qx
+from src.quixstreams.models.parametervalue import ParameterValueType
 qx.logging.Logging.update_factory(qx.logging.LogLevel.Debug)
-client = qx.QuixStreamingClient('sdk-9e70ee4d555145af8431abdf1ccc34fb', debug=False)
-client.api_url = "https://portal-api.dev.quix.ai"
+client = qx.KafkaStreamingClient('127.0.0.1:9092', None)
 commit_settings = qx.CommitOptions()
 commit_settings.commit_every = 10000
 commit_settings.commit_interval = None

--- a/src/PythonClient/tests/quixstreams/unittests/models/test_eventdata.py
+++ b/src/PythonClient/tests/quixstreams/unittests/models/test_eventdata.py
@@ -16,9 +16,9 @@ class EventDataTests(unittest.TestCase):
         event_data = EventData("abcde", 123) \
           .add_tags({"tag1": "val1", "tag2": "val2"})
         # Assert
-        self.assertEqual(len(event_data.tags), 2)
-        self.assertEqual(event_data.tags["tag1"], "val1")
-        self.assertEqual(event_data.tags["tag2"], "val2")
+        self.assertEqual(2, len(event_data.tags))
+        self.assertEqual("val1", event_data.tags["tag1"])
+        self.assertEqual("val2", event_data.tags["tag2"])
 
     def test_constructor_with_time_as_nanoseconds_int(self):
         # Act


### PR DESCRIPTION
- Fix memory leak with set_values. (Was affecting any dictionary and possibly some arrays). UPTR will be now considered consumed when passing between C#/Python, each will be freed when converted to managed.
- Add better Kafka consumer/producer logs
