### PR TITLE
Correct admonition rendering

### DIFF
--- a/docs/features/message-splitting.md
+++ b/docs/features/message-splitting.md
@@ -10,4 +10,4 @@ This feature gives you currently 255 times the broker message size limit, indepe
 
 !!! warning
 
-While this feature is undeniably useful, effort should be made to stay within your broker's limit to avoid complex commit limitations and increased memory footprint in the consumer. If you consistently have huge messages, should consider uploading to external storage and only sending a reference using the broker.
+    While this feature is undeniably useful, effort should be made to stay within your broker's limit to avoid complex commit limitations and increased memory footprint in the consumer. If you consistently have huge messages, should consider uploading to external storage and only sending a reference using the broker.

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,4 +1,4 @@
-# Publishing time-series data
+# Publishing data
 
 Quix Streams allows you to publish data using stream context to your topic. It lets you create new streams, append data to existing streams, organize streams in folders, and add context to the streams.
 


### PR DESCRIPTION
## Description

* Bug fix to correct admonition rendering.
* Checked all admonitions (search `!!!`) to make sure they were all tabbed correctly.
* Minor correction to heading as topic covers both time-series data and event data.

## Review

* A small fix so the diff can be checked. The text should be tabbed in to display the admonition correctly.