### PR TITLE
#79 - Handle KeyboardInterrupt signal when using app.run

### DIFF
--- a/src/PythonClient/src/quixstreams/app.py
+++ b/src/PythonClient/src/quixstreams/app.py
@@ -1,5 +1,6 @@
 import ctypes
 import traceback
+import signal
 from typing import Callable
 
 from .native.Python.QuixStreamsStreaming.App import App as ai
@@ -69,6 +70,14 @@ class App():
                     before_shutdown()
                 except:
                     traceback.print_exc()
+
+        # do nothing when the keyboard interrupt happens.
+        # without this, the callback function invoked from interop would check for exceptions before anything else
+        # resulting in a KeyboardInterrupt before any try/catch can be done. Given we're already handling this inside
+        # the interop, there is no need to throw an exception that is impossible to handle anyway
+        def keyboard_interrupt_handler(signal, frame):
+            pass
+        signal.signal(signal.SIGINT, keyboard_interrupt_handler)
 
         try:
             if cancellation_token is not None:


### PR DESCRIPTION
Catch the keyboard interrupt signal, so it can be handled by doing nothing instead of throwing an exception in a context where try/catch is not able to deal with it.

![image](https://user-images.githubusercontent.com/79838809/228240144-f4f895a3-2a47-44d4-92dc-3328196688fb.png)
