### PR TITLE
Update documentation generation README.md

### DIFF
--- a/src/builds/README.md
+++ b/src/builds/README.md
@@ -14,6 +14,10 @@ After building the Quix Streams library, please follow the following steps to ge
     ```
     rm -r docs/api-reference/csharp/*
     ```
+- Build QuixStreams.Streaming project
+    ```
+    dotnet build src/CsharpClient/QuixStreams.Streaming -c Release -f netstandard2.0
+    ```
 -  Run the following command from the root directory (or adjust the `-a` and `-o` flags accordingly):
     ```
     defaultdocumentation -s Public -a src/CsharpClient/QuixStreams.Streaming/bin/Release/netstandard2.0/QuixStreams.Streaming.dll -o docs/api-reference/csharp/ --FileNameFactory Name


### PR DESCRIPTION
I noticed that the QuixStreams.Streaming project has to be built before starting to generate the docs using the `defaultdocumentation`

 But even if the project is already built, its good to rebuild it so we know for sure its the latest version