### PR TITLE
Lower signal exception to warning when running on non-main thread

### DIFF
--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.2.dev7"
+package_version = "0.5.2.dev8"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/src/quixstreams/app.py
+++ b/src/PythonClient/src/quixstreams/app.py
@@ -102,6 +102,10 @@ class App:
         try:
             signal.signal(signal.SIGINT, keyboard_interrupt_handler)
         except ValueError as ex:
+            # If this exception happens, it means the signal handling is running on non-main thread.
+            # The end result is that keyboard or shutdown interruption will not work here or in C# interop.
+            # While that is not optimal, it is still better to let the application at least function
+            # and log the exception + warning than completely block it from functioning.
             traceback.print_exc()
             logging.log(logging.WARNING, "Shutdown may not work as expected. See error.")
 

--- a/src/PythonClient/src/quixstreams/app.py
+++ b/src/PythonClient/src/quixstreams/app.py
@@ -1,4 +1,5 @@
 import ctypes
+import logging
 import traceback
 import signal
 from typing import Callable
@@ -98,7 +99,12 @@ class App:
         # the interop, there is no need to throw an exception that is impossible to handle anyway
         def keyboard_interrupt_handler(signal, frame):
             pass
-        signal.signal(signal.SIGINT, keyboard_interrupt_handler)
+        try:
+            signal.signal(signal.SIGINT, keyboard_interrupt_handler)
+        except ValueError as ex:
+            traceback.print_exc()
+            logging.log(logging.WARNING, "Shutdown may not work as expected. See error.")
+
 
         try:
             if cancellation_token is not None:

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.2.0"
-informal_version = "0.5.2.0-dev7"
-nuget_version = "0.5.2.0-dev7"
+informal_version = "0.5.2.0-dev8"
+nuget_version = "0.5.2.0-dev8"
 
 
 def updatecsproj(projfilepath):


### PR DESCRIPTION
Lower signal exception to warning, so the application continues to function while still giving the developer a logged exception and a warning so they can fix the issue