### PR TITLE
Fix typo in Python event data code

### DIFF
--- a/docs/subscribe.md
+++ b/docs/subscribe.md
@@ -423,7 +423,7 @@ Consuming events from a stream is as easy as consuming timeseries data. In this 
     ``` python
     def on_event_data_received_handler(stream: StreamConsumer, data: EventData):
         with data:
-            print("Event consumed for stream. Event Id: " + data.Id)
+            print("Event consumed for stream. Event Id: " + data.id)
     
     stream_received.events.on_data_received = on_event_data_received_handler
     ```


### PR DESCRIPTION
## Description

There's a small typo in the Python event handler code. Shown is `data.Id` but it should be `data.id`.

I tested the fix with both Intellisense and working code:

```
def on_event_data_received_handler(stream_consumer: qx.StreamConsumer, data: qx.EventData):
    print('Event data received handler')
    print('DATA ID (data.id): ---> ', data.id)
```

This displays the data id correctly.

I also grepped the codebase (`*.md`) to locate other instances, but this seems to be the only occurrence.