### PR TITLE
Improve type handling on adding values to timeseries

### DIFF
--- a/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
@@ -149,13 +149,13 @@ class TimeseriesDataTimestamp:
         """
         return dtc.timespan_to_python(self._interop.get_TimestampAsTimeSpan())
 
-    def add_value(self, parameter_id: str, value: Union[float, str, int, bytearray, bytes]) -> 'TimeseriesDataTimestamp':
+    def add_value(self, parameter_id: str, value: Union[numbers.Number, str, bytearray, bytes]) -> 'TimeseriesDataTimestamp':
         """
         Adds a new value for the specified parameter.
 
         Args:
             parameter_id: The parameter id to add the value for.
-            value: The value to add. Can be float, string, int, bytearray, or bytes.
+            value: The value to add. Can be a number, string, bytearray, or bytes.
 
         Returns:
             TimeseriesDataTimestamp: The updated TimeseriesDataTimestamp instance.
@@ -164,7 +164,7 @@ class TimeseriesDataTimestamp:
         if value is None:
             return self
 
-        if issubclass(value, numbers.Number):
+        if issubclass(type(value), numbers.Number):
             value = float(value)
 
         val_type = type(value)

--- a/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
@@ -1,4 +1,5 @@
 import ctypes
+import numbers
 from datetime import datetime, timedelta
 from typing import Union, Dict
 
@@ -160,7 +161,10 @@ class TimeseriesDataTimestamp:
             TimeseriesDataTimestamp: The updated TimeseriesDataTimestamp instance.
         """
 
-        if type(value) is int:
+        if value is None:
+            return self
+
+        if issubclass(value, numbers.Number):
             value = float(value)
 
         val_type = type(value)

--- a/src/PythonClient/tests/quixstreams/unittests/models/test_timeseriesdata.py
+++ b/src/PythonClient/tests/quixstreams/unittests/models/test_timeseriesdata.py
@@ -3,6 +3,7 @@ import unittest
 from datetime import datetime, timezone, timedelta
 
 import pandas
+import numpy as np
 from src.quixstreams.helpers.timeconverter import TimeConverter
 from src.quixstreams import TimeseriesData
 
@@ -27,6 +28,36 @@ class TimeseriesDataTests(unittest.TestCase):
 
         # Act
         self.assertEqual(4, len(timeseries_data.timestamps))
+
+    def test_adding_null_value_is_silently_ignored(self):
+        # Arrange
+        timeseries_data = TimeseriesData()
+        timeseries_data.add_timestamp_nanoseconds(1) \
+            .add_value("param1", 1) \
+            .add_value("param1", None)
+
+        # Act
+        self.assertEqual(1, timeseries_data.timestamps[0].parameters["param1"].value)
+
+    def test_any_number_type_is_converted_to_float(self):
+        # Arrange
+        npy_float64 = np.float64(42.0)
+        npy_int64 = np.int64(42)
+        native_int = 42
+        native_float = 42.0
+
+        timeseries_data = TimeseriesData()
+        timeseries_data.add_timestamp_nanoseconds(1) \
+            .add_value("npy_float64", npy_float64) \
+            .add_value("npy_int64", npy_int64) \
+            .add_value("native_int", native_int) \
+            .add_value("native_float", native_float)
+
+        # Act
+        self.assertEqual(float(42), timeseries_data.timestamps[0].parameters["npy_float64"].value)
+        self.assertEqual(float(42), timeseries_data.timestamps[0].parameters["npy_int64"].value)
+        self.assertEqual(float(42), timeseries_data.timestamps[0].parameters["native_int"].value)
+        self.assertEqual(float(42), timeseries_data.timestamps[0].parameters["native_float"].value)
 
     def test_convert_from_timeseries_data_to_panda_data_frame(self):
         # Arrange

--- a/src/PythonClient/tests/requirements.txt
+++ b/src/PythonClient/tests/requirements.txt
@@ -1,3 +1,4 @@
 testcontainers~=3.7.0
 pytest
 psutil
+numpy==1.24.3


### PR DESCRIPTION
* Add automatic type conversion, now supporting any number type (numpy.int64 for example) and not just built-in python types

* Null values are not throwing an exception anymore. They are just ignored