### PR TITLE
Add note on when raw data is used

### DIFF
--- a/docs/subscribe.md
+++ b/docs/subscribe.md
@@ -272,6 +272,8 @@ In addition to the `TimeseriesData` and pandas `DataFrame` formats (Python only)
 	};
     ```
 
+If you are developing in Python you will typically use either `TimeseriesData` or `DataFrame`. In C# `TimeseriesDataRaw` is mainly used for optimizing performance.
+
 ### Using a Buffer
 
 Quix Streams provides you with an optional programmable buffer which you can configure to your needs. Using buffers to consume data enables you to process data in batches according to your needs. The buffer also helps you to develop models with a high-performance throughput.


### PR DESCRIPTION
## Description

Looks like I'd partially addressed this on a previous occasion, here:

https://quix.io/docs/client-library/subscribe.html#raw-data-format

Asking Peter on use cases for `TimeseriesDataRaw`, he said:

"in python they would use pandas df, not raw (pandas uses raw underneath)
in c#, performance."

So I've added this comment to the above section.

I also already mentioned it here:

https://quix.io/docs/client-library/using.html#stream-data-formats

and went on to talk about registering callbacks etc.