### PR TITLE
Improve type handling on adding values to timeseries builder as well

### DIFF
--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -773,7 +773,7 @@ class TestIntegration(unittest.TestCase):
         print(f"---- Write second stream {output_stream.stream_id} ----")
 
         # Assert
-        self.waitforresult(event)
+        self.waitforresult(event, 30)
 
         self.assertEqual(last_stream_read.stream_id, output_stream.stream_id)
 
@@ -911,7 +911,9 @@ class TestIntegration(unittest.TestCase):
 # region timeseries data integration tests
     def test_timeseries_builder_works_with_any_number_type_and_none(self):
         # Arrange
-        stream = qx.KafkaStreamingClient(TestIntegration.broker_list, None).get_topic_producer("topic").create_stream()
+        print("Starting Integration test {}".format(sys._getframe().f_code.co_name))
+        topic_name = sys._getframe().f_code.co_name  # current method name
+        stream = qx.KafkaStreamingClient(TestIntegration.broker_list, None).get_topic_producer(topic_name).create_stream()
 
         # Act
         stream.timeseries.buffer \
@@ -920,7 +922,7 @@ class TestIntegration(unittest.TestCase):
             .add_value("npy_int64", np.int64(42)) \
             .add_value("native_int", int(42)) \
             .add_value("native_float", float(42)) \
-            .add_value("none", None) \
+            .add_value("none", None)
 
         # Assert that no exception got raised
 

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -3,6 +3,7 @@ from typing import List
 import unittest
 import threading
 import pandas as pd
+import numpy as np
 from src.quixstreams import Logging, LogLevel, AutoOffsetReset
 
 from testcontainers.core.container import DockerContainer
@@ -908,6 +909,21 @@ class TestIntegration(unittest.TestCase):
 # endregion
 
 # region timeseries data integration tests
+    def test_timeseries_builder_works_with_any_number_type_and_none(self):
+        # Arrange
+        stream = qx.KafkaStreamingClient(TestIntegration.broker_list, None).get_topic_producer("topic").create_stream()
+
+        # Act
+        stream.timeseries.buffer \
+            .add_timestamp_nanoseconds(1) \
+            .add_value("npy_float64", np.float64(42.0)) \
+            .add_value("npy_int64", np.int64(42)) \
+            .add_value("native_int", int(42)) \
+            .add_value("native_float", float(42)) \
+            .add_value("none", None) \
+
+        # Assert that no exception got raised
+
     def test_parameters_write_binary_read_binary_is_of_bytes(self):
         # Arrange
         print("Starting Integration test {}".format(sys._getframe().f_code.co_name))

--- a/src/PythonClient/tests/quixstreams/unittests/models/test_timeseriesdatatimestamp.py
+++ b/src/PythonClient/tests/quixstreams/unittests/models/test_timeseriesdatatimestamp.py
@@ -8,56 +8,68 @@ class TimeseriesDataTimestampTests(unittest.TestCase):
 
     def test_add_double(self):
         # Arrange
-        pd = TimeseriesData()
+        td = TimeseriesData()
 
         # Act
-        pd.add_timestamp_nanoseconds(100) \
+        td.add_timestamp_nanoseconds(100) \
             .add_value("double", 1.232)
 
         # Assert
-        self.assertEqual(1.232, pd.timestamps[0].parameters["double"].numeric_value)
+        self.assertEqual(1.232, td.timestamps[0].parameters["double"].numeric_value)
 
     def test_add_string(self):
         # Arrange
-        pd = TimeseriesData()
+        td = TimeseriesData()
 
         # Act
-        pd.add_timestamp_nanoseconds(100) \
+        td.add_timestamp_nanoseconds(100) \
             .add_value("str", "value")
 
         # Assert
-        asdf = pd.timestamps[0]
+        asdf = td.timestamps[0]
         param = asdf.parameters
-        self.assertEqual(pd.timestamps[0].parameters["str"].string_value, "value")
+        self.assertEqual(td.timestamps[0].parameters["str"].string_value, "value")
 
     def test_add_bytes(self):
         # Arrange
-        pd = TimeseriesData()
+        td = TimeseriesData()
         expected = bytes("some bytes", "utf-8")
 
         # Act
-        pd.add_timestamp_nanoseconds(100) \
+        td.add_timestamp_nanoseconds(100) \
             .add_value("bytes", expected)
 
         # Assert
-        self.assertEqual(expected, pd.timestamps[0].parameters["bytes"].binary_value)
+        self.assertEqual(expected, td.timestamps[0].parameters["bytes"].binary_value)
+
+    def test_add_bytearray(self):
+        # Arrange
+        td = TimeseriesData()
+        expected = bytearray("some bytes", "utf-8")
+
+        # Act
+        td.add_timestamp_nanoseconds(100) \
+            .add_value("bytearray", expected)
+
+        # Assert
+        self.assertEqual(expected, td.timestamps[0].parameters["bytearray"].binary_value)
 
     def test_add_tag(self):
         # Arrange
-        pd = TimeseriesData()
-        pd.add_timestamp_nanoseconds(100)
-        pdts = pd.timestamps[0]
-        pdts.add_tag("a", "b")
+        td = TimeseriesData()
+        td.add_timestamp_nanoseconds(100)
+        tdts = td.timestamps[0]
+        tdts.add_tag("a", "b")
 
         # Act
-        pd.add_timestamp_nanoseconds(200)
-        pdts2 = pd.timestamps[1]
-        pdts.add_tag("b", "c")
-        pdts2.add_tags(pdts.tags)
+        td.add_timestamp_nanoseconds(200)
+        tdts2 = td.timestamps[1]
+        tdts.add_tag("b", "c")
+        tdts2.add_tags(tdts.tags)
 
         # Assert
-        self.assertEqual(pdts2.tags["a"], "b")
-        self.assertEqual(pdts2.tags["b"], "c")
+        self.assertEqual(tdts2.tags["a"], "b")
+        self.assertEqual(tdts2.tags["b"], "c")
 
     def test_add_tags(self):
         # Act


### PR DESCRIPTION
We had this added when converting panda dataframe -> TimeseriesData format, but this PR improves number type handling and None values when using a timeseries builder 

* Add automatic type conversion, now supporting any number type (numpy.int64 for example) and not just built-in python types

* Null values are not throwing an exception anymore. They are just ignored