### PR TITLE
Add Flush method to the Stream

### DIFF
--- a/docs/api-reference/csharp/IStreamProducer.Flush().md
+++ b/docs/api-reference/csharp/IStreamProducer.Flush().md
@@ -1,0 +1,10 @@
+#### [QuixStreams.Streaming](index.md 'index')
+### [QuixStreams.Streaming](QuixStreams.Streaming.md 'QuixStreams.Streaming').[IStreamProducer](IStreamProducer.md 'QuixStreams.Streaming.IStreamProducer')
+
+## IStreamProducer.Flush() Method
+
+Flush the pending data to stream.
+
+```csharp
+void Flush();
+```

--- a/docs/api-reference/csharp/IStreamProducer.md
+++ b/docs/api-reference/csharp/IStreamProducer.md
@@ -24,6 +24,7 @@ Implements [System.IDisposable](https://docs.microsoft.com/en-us/dotnet/api/Syst
 | Methods | |
 | :--- | :--- |
 | [Close(StreamEndType)](IStreamProducer.Close(StreamEndType).md 'QuixStreams.Streaming.IStreamProducer.Close(QuixStreams.Telemetry.Models.StreamEndType)') | Close the stream and flush the pending data to stream. |
+| [Flush()](IStreamProducer.Flush().md 'QuixStreams.Streaming.IStreamProducer.Flush()') | Flush the pending data to stream. |
 
 | Events | |
 | :--- | :--- |

--- a/docs/api-reference/python/quixstreams.md
+++ b/docs/api-reference/python/quixstreams.md
@@ -473,6 +473,7 @@
     * [get\_Properties](#quixstreams.native.Python.QuixStreamsStreaming.IStreamProducer.IStreamProducer.get_Properties)
     * [get\_Timeseries](#quixstreams.native.Python.QuixStreamsStreaming.IStreamProducer.IStreamProducer.get_Timeseries)
     * [get\_Events](#quixstreams.native.Python.QuixStreamsStreaming.IStreamProducer.IStreamProducer.get_Events)
+    * [Flush](#quixstreams.native.Python.QuixStreamsStreaming.IStreamProducer.IStreamProducer.Flush)
     * [Close](#quixstreams.native.Python.QuixStreamsStreaming.IStreamProducer.IStreamProducer.Close)
     * [add\_OnWriteException](#quixstreams.native.Python.QuixStreamsStreaming.IStreamProducer.IStreamProducer.add_OnWriteException)
     * [remove\_OnWriteException](#quixstreams.native.Python.QuixStreamsStreaming.IStreamProducer.IStreamProducer.remove_OnWriteException)
@@ -1701,6 +1702,7 @@
     * [properties](#quixstreams.streamproducer.StreamProducer.properties)
     * [timeseries](#quixstreams.streamproducer.StreamProducer.timeseries)
     * [events](#quixstreams.streamproducer.StreamProducer.events)
+    * [flush](#quixstreams.streamproducer.StreamProducer.flush)
     * [close](#quixstreams.streamproducer.StreamProducer.close)
 * [quixstreams.topicconsumer](#quixstreams.topicconsumer)
   * [TopicConsumer](#quixstreams.topicconsumer.TopicConsumer)
@@ -5895,8 +5897,8 @@ Gets the timestamp in timespan format.
 
 ```python
 def add_value(
-    parameter_id: str, value: Union[float, str, int, bytearray,
-                                    bytes]) -> 'TimeseriesDataTimestamp'
+    parameter_id: str, value: Union[numbers.Number, str, bytearray, bytes]
+) -> 'TimeseriesDataTimestamp'
 ```
 
 Adds a new value for the specified parameter.
@@ -5904,7 +5906,7 @@ Adds a new value for the specified parameter.
 **Arguments**:
 
 - `parameter_id` - The parameter id to add the value for.
-- `value` - The value to add. Can be float, string, int, bytearray, or bytes.
+- `value` - The value to add. Can be a number, string, bytearray, or bytes.
   
 
 **Returns**:
@@ -8411,6 +8413,22 @@ Returns
 
 c_void_p:
     GC Handle Pointer to .Net type StreamEventsProducer
+
+<a id="quixstreams.native.Python.QuixStreamsStreaming.IStreamProducer.IStreamProducer.Flush"></a>
+
+#### Flush
+
+```python
+def Flush() -> None
+```
+
+Parameters
+----------
+
+Returns
+-------
+None:
+    Underlying .Net type is void
 
 <a id="quixstreams.native.Python.QuixStreamsStreaming.IStreamProducer.IStreamProducer.Close"></a>
 
@@ -29757,6 +29775,16 @@ Gets the producer for publishing event related information of the stream such as
 **Returns**:
 
 - `StreamEventsProducer` - The producer for publishing event related information of the stream.
+
+<a id="quixstreams.streamproducer.StreamProducer.flush"></a>
+
+#### flush
+
+```python
+def flush()
+```
+
+Flushes the pending data to stream.
 
 <a id="quixstreams.streamproducer.StreamProducer.close"></a>
 

--- a/src/CsharpClient/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
+++ b/src/CsharpClient/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
@@ -11,9 +11,10 @@ namespace QuixStreams.Streaming.UnitTests
         private TelemetryKafkaConsumer telemetryKafkaConsumer;
         private Func<string, TelemetryKafkaProducer> createKafkaProducer;
 
-        public TestStreamingClient(CodecType codec = CodecType.Protobuf)
+
+        public TestStreamingClient(CodecType codec = CodecType.Protobuf, TimeSpan publishDelay = default)
         {
-            this.testBroker = new TestBroker();
+            this.testBroker = new TestBroker(publishDelay: publishDelay);
 
             CodecRegistry.Register(codec);
         }

--- a/src/CsharpClient/QuixStreams.Streaming/IStreamProducer.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/IStreamProducer.cs
@@ -35,6 +35,11 @@ namespace QuixStreams.Streaming
         StreamEventsProducer Events { get; }
 
         /// <summary>
+        /// Flush the pending data to stream.  
+        /// </summary>
+        void Flush();
+
+        /// <summary>
         /// Close the stream and flush the pending data to stream.
         /// </summary>
         /// <param name="streamState">Stream closing state</param>

--- a/src/CsharpClient/QuixStreams.Telemetry.Common.Test/TestBroker.cs
+++ b/src/CsharpClient/QuixStreams.Telemetry.Common.Test/TestBroker.cs
@@ -16,11 +16,12 @@ namespace QuixStreams.Telemetry.Common.Test
         /// Initializes a new instance of <see cref="TestBroker"/>
         /// </summary>
         /// <param name="generateExceptions">The test broker generates exceptions when it receives data</param>
-        public TestBroker(bool generateExceptions = false)
+        /// <param name="publishDelay">Delay when publishing to simulate a real broker delay</param>
+        public TestBroker(bool generateExceptions = false, TimeSpan publishDelay = default)
         {
             this.Consumer = new TestBrokerConsumer();
             // Connection between Transport Input and Output simulating a real broker
-            this.Producer = new TestBrokerProducer(Consumer, generateExceptions); 
+            this.Producer = new TestBrokerProducer(Consumer, generateExceptions, publishDelay); 
         }
 
         /// <summary>
@@ -42,16 +43,21 @@ namespace QuixStreams.Telemetry.Common.Test
     {
         private readonly TestBrokerConsumer testConsumer;
         private readonly bool generateExceptions;
+        private readonly TimeSpan publishDelay;
 
-        public TestBrokerProducer(TestBrokerConsumer testConsumer, bool generateExceptions = false)
+        public TestBrokerProducer(TestBrokerConsumer testConsumer, bool generateExceptions = false, TimeSpan publishDelay = default)
         {
             this.testConsumer = testConsumer;
             this.generateExceptions = generateExceptions;
+            this.publishDelay = publishDelay;
         }
 
         public async Task Publish(Package package, CancellationToken cancellationToken = default)
         {
             if (generateExceptions) throw new Exception("Test broker generated exception.");
+            
+            await Task.Delay(this.publishDelay, cancellationToken); // Simulating a real broker delay
+            
             await this.testConsumer.Send(package); // Redirecting to Output all the messages arriving from the Input
         }
     }

--- a/src/PythonClient/src/quixstreams/streamproducer.py
+++ b/src/PythonClient/src/quixstreams/streamproducer.py
@@ -179,6 +179,12 @@ class StreamProducer(object):
             self._streamEventsProducer = StreamEventsProducer(self._interop.get_Events())
         return self._streamEventsProducer
 
+    def flush(self):
+        """
+        Flushes the pending data to stream.
+        """
+        self._interop.Flush()
+
     def close(self, end_type: StreamEndType = StreamEndType.Closed):
         """
         Closes the stream and flushes the pending data to stream.


### PR DESCRIPTION
Added a flush method to the stream class that flushes stream's Timeseries, Events and Properties data.
This Flush is different from other as it awaits for all messages to be sent before continuing in the same way as stream.Close() awaits