### PR TITLE
Fix how native objects are cleaned

### DIFF
--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.3"
+package_version = "0.5.4.dev8"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/src/quixstreams/helpers/nativedecorator.py
+++ b/src/PythonClient/src/quixstreams/helpers/nativedecorator.py
@@ -11,15 +11,23 @@ def nativedecorator(cls):
     orig_enter = getattr(cls, "__enter__", _dummy)
     orig_exit = getattr(cls, "__exit__", _dummy)
     orig_dispose = getattr(cls, "dispose", _dummy)
+    orig_del = getattr(cls, "__del__", _dummy)
 
     def new_init(self, *args, **kwargs):
+        self._nativedecorator_finalized = False
         orig_init(self, *args, **kwargs)
-        self._nativedecorator_finalizer = weakref.finalize(self, new_finalizerfunc, self)
 
     def new_finalizerfunc(self):
+        if self._nativedecorator_finalized:
+            return
+
+        self._nativedecorator_finalized = True
         orig_finalizer(self)
         getattr(self, "_interop").dispose_ptr__()
-        self._nativedecorator_finalizer.detach()
+
+    def new_del(self):
+        new_finalizerfunc(self)
+        orig_del(self)
 
     def new_enter(self):
         orig_enter(self)
@@ -29,14 +37,15 @@ def nativedecorator(cls):
         new_dispose(self)
 
     def new_dispose(self, *args, **kwargs):
-        if not self._nativedecorator_finalizer.alive:
+        if self._nativedecorator_finalized:
             return
+
         orig_dispose(self, *args, **kwargs)
-        self._nativedecorator_finalizer()
 
     cls.__init__ = new_init
     cls._finalizerfunc = new_finalizerfunc
     cls.__enter__ = new_enter
     cls.__exit__ = new_exit
+    cls.__del__ = new_del
     cls.dispose = new_dispose
     return cls

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -6,9 +6,9 @@ import shutil
 import fileinput
 from typing import List
 
-version = "0.5.3.0"
-informal_version = "0.5.3.0"
-nuget_version = "0.5.3.0"
+version = "0.5.4.0"
+informal_version = "0.5.4.0-dev8"
+nuget_version = "0.5.4.0-dev8"
 
 
 def updatecsproj(projfilepath):


### PR DESCRIPTION
Fix the way we're cleaning up native objects. The initial implementation was causing a circular reference the GC couldn't deal with.