### PR TITLE
Update migration guide, handle empty/null tag values

### DIFF
--- a/docs/versionmigration.md
+++ b/docs/versionmigration.md
@@ -466,9 +466,9 @@ def on_event_data_handler(stream: StreamConsumer, data: EventData):
 … the rest of your code
 ```
 
-### NumPy types no longer handled transparently
+### Pre 0.5.3 some types are not handled transparently
 
-Certain code may generate run-time errors such as:
+As of 0.5.3 we've taken care of most cases we're aware of, such as using NumPy numerical values instead of built-in python types. If you're using a version before this, you will encounter runtime errors for some cases, such as:
 
 ```
 Invalid type <class 'numpy.float64'> passed as parameter value

--- a/src/CsharpClient/QuixStreams.Streaming/Models/EventData.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/EventData.cs
@@ -127,7 +127,8 @@ namespace QuixStreams.Streaming.Models
         public EventData AddTag(string tagId, string tagValue)
         {
             if (string.IsNullOrWhiteSpace(tagId)) throw new ArgumentNullException(nameof(tagId), "Tag id can't be null or empty");
-            if (string.IsNullOrWhiteSpace(tagValue)) throw new ArgumentNullException(nameof(tagValue), $"Tag ({tagId}) value can't be null or empty");
+            if (tagValue == null) return this.RemoveTag(tagId);
+            
             this.Tags[tagId] = tagValue;
 
             return this;

--- a/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesDataTimestamp.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesDataTimestamp.cs
@@ -181,7 +181,7 @@ namespace QuixStreams.Streaming.Models
         public TimeseriesDataTimestamp AddTag(string tagId, string tagValue)
         {
             if (string.IsNullOrWhiteSpace(tagId)) throw new ArgumentNullException(nameof(tagId), "Tag id can't be null or empty");
-            if (string.IsNullOrWhiteSpace(tagValue)) throw new ArgumentNullException(nameof(tagValue), $"Tag ({tagId}) value can't be null or empty");
+            if (tagValue == null) return this.RemoveTag(tagId);
 
             if (!this.TimeseriesData.rawData.TagValues.TryGetValue(tagId, out var values))
             {


### PR DESCRIPTION
- Update migration guide to reflect 0.5.3 changes and allow
- Null tag values will remove the tag, empty or whitespace will be sent.