### PR TITLE
Add scalar state type

### DIFF
--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -16,7 +16,7 @@ Quix Streams has state management built in to enable values to be used and persi
 
 ## State management
 
-The library is providing automatic state management which handles application lifecycle automatically, such as commits and revocation to ensure the state reflects the processed and committed messages only. The stream state managed is available on stream consumer and not the producer currently.
+The library is providing automatic state management which handles application lifecycle automatically, such as commits and revocation to ensure the state reflects the processed and committed messages only. There are two types of state available: dictionary state and scalar state. The stream state managed is available on stream consumer and not the producer currently.
 
 ### Reading and writing
 
@@ -153,6 +153,27 @@ You can delete any or all state using the state manager of a specific level. See
         var streamStateManager = streamConsumer.GetStateManager();
         streamStateManager.DeleteState("some_state");
         streamStateManager.DeleteStates(); // deletes all
+    ```
+
+### Scalar state type
+In addition to the dictionary state type, we also have the scalar state type. It functions similarly, but holds just a single value, making it simpler to use. Below is an example:
+
+=== "Python"
+    ``` python
+    def on_dataframe_received_handler(stream_consumer: qx.StreamConsumer, data: qx.TimeseriesData):
+        # Define a scalar state with a default value of 0.
+        stream_state = stream_consumer.get_scalar_state("total_rpm", lambda: 0)
+
+        # Iterate over all the timestamps in the data.
+        for row in data.timestamps:
+            # Extract the numeric value for 'EngineRPM'.
+            rpm = row.parameters["EngineRPM"].numeric_value
+
+            # Increment the state value by the extracted RPM.
+            stream_state.value += rpm
+
+            # Add the updated state value to the row as 'total_rpm'.
+            row.add_value("total_rpm", stream_state.value)
     ```
 
 ### Storage types

--- a/src/CsharpClient/QuixStreams.State.UnitTests/DictionaryStateShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/DictionaryStateShould.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace QuixStreams.State.UnitTests
 {
-    public class StateShould
+    public class DictionaryStateShould
     {
         [Fact]
         public void Constructor_UsingNonEmptyState_ShouldLoadState()
@@ -14,7 +14,7 @@ namespace QuixStreams.State.UnitTests
             // Arrange
             var storage = new InMemoryStorage();
             storage.SetAsync("existing", new StateValue("whatever"));
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
 
             // Assert
             state.Count.Should().Be(1);
@@ -26,7 +26,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
 
             // Act
             state.Add("key", new StateValue("value"));
@@ -40,7 +40,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
             state.Add("key", new StateValue("value"));
 
             // Act
@@ -55,7 +55,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
             state.Add("key1", new StateValue("value1"));
             state.Add("key2", new StateValue("value2"));
 
@@ -71,7 +71,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
             state.Add("key1", new StateValue("value1"));
             state.Add("key2", new StateValue("value2"));
 
@@ -87,7 +87,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
             state.Add("key1", new StateValue("value1"));
             state.Add("key2", new StateValue("value2"));
             state.Flush();
@@ -104,7 +104,7 @@ namespace QuixStreams.State.UnitTests
         public void State_WithNullStorage_ShouldThrowArgumentNullException()
         {
             // Act
-            Action act = () => new State(null);
+            Action act = () => new DictionaryState(null);
 
             // Assert
             act.Should().Throw<ArgumentNullException>();
@@ -115,7 +115,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
             state.Add("key", new StateValue("value"));
 
             // Act
@@ -130,7 +130,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
 
             // Act
             bool containsKey = state.ContainsKey("key");
@@ -144,7 +144,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
             state.Add("key", new StateValue("value"));
 
             // Act
@@ -160,7 +160,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
 
             // Act
             bool success = state.TryGetValue("key", out StateValue value);
@@ -175,7 +175,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
             state.Add("key", new StateValue("value"));
 
             // Act
@@ -191,7 +191,7 @@ namespace QuixStreams.State.UnitTests
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State(storage);
+            var state = new DictionaryState(storage);
             state.Add("key", new StateValue("value"));
             state.Flush();
 

--- a/src/CsharpClient/QuixStreams.State.UnitTests/ScalarStateShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/ScalarStateShould.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using FluentAssertions;
+using QuixStreams.State.Storage;
+using Xunit;
+
+namespace QuixStreams.State.UnitTests
+{
+    public class ScalarStateShould
+    {
+        
+        [Fact]
+        public void Constructor_UsingNonEmptyState_ShouldLoadState()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            storage.Set(ScalarState.StorageKey, new StateValue("whatever"));
+            var state = new ScalarState(storage);
+
+            // Assert
+            state.Value.StringValue.Should().BeEquivalentTo("whatever");
+        }
+        
+        [Fact]
+        public void SetValue_ShouldChangeValue()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new ScalarState(storage);
+
+            // Act
+            state.Value = new StateValue("value");
+
+            // Assert
+            state.Value.StringValue.Should().BeEquivalentTo("value");
+        }
+
+        [Fact]
+        public void Clear_Value_ShouldSetToNull()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new ScalarState(storage);
+            state.Value = new StateValue("value");
+
+            // Act
+            state.Clear();
+
+            // Assert
+            state.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public void Flush_Value_ShouldPersistChangesToStorage()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new ScalarState(storage);
+            state.Value = new StateValue("value");
+
+            // Act
+            state.Flush();
+
+            // Assert
+            storage.Get(ScalarState.StorageKey).StringValue.Should().BeEquivalentTo("value");
+        }
+        
+        [Fact]
+        public void Flush_ClearBeforeFlush_ShouldClearStorage()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new ScalarState(storage);
+            state.Value = new StateValue("value");
+            state.Flush();
+            state.Clear();
+
+            // Act
+            state.Flush();
+
+            // Assert
+            storage.ContainsKey(ScalarState.StorageKey).Should().BeFalse();
+        }
+
+        [Fact]
+        public void State_WithNullStorage_ShouldThrowArgumentNullException()
+        {
+            // Act
+            Action act = () => new ScalarState(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Reset_Modified_ShouldResetToSaved()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new ScalarState(storage);
+            state.Value = new StateValue("value");
+            state.Flush();
+
+            // Act
+            state.Value = new StateValue("updatedValue");
+            state.Reset();
+
+            // Assert
+            state.Value.StringValue.Should().BeEquivalentTo("value");
+        }
+    }
+}

--- a/src/CsharpClient/QuixStreams.State.UnitTests/StateTemplatedShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/StateTemplatedShould.cs
@@ -16,7 +16,7 @@ public class StateTemplatedShould
         public void Constructor_ShouldCreateState()
         {
             var storage = new InMemoryStorage();
-            var state = new State<int>(storage);
+            var state = new DictionaryState<int>(storage);
 
             state.Should().NotBeNull();
         }
@@ -24,7 +24,7 @@ public class StateTemplatedShould
         [Fact]
         public void Constructor_WithNullStateStorage_ShouldThrowArgumentNullException()
         {
-            Action nullTopicName = () => new State<int>((IStateStorage)null);
+            Action nullTopicName = () => new DictionaryState<int>((IStateStorage)null);
 
             nullTopicName.Should().Throw<ArgumentNullException>().WithMessage("*storage*");
         }
@@ -35,7 +35,7 @@ public class StateTemplatedShould
         public void StringConversion_ShouldStoreAndRetrieveCorrectly(string key, string value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<string>(storage);
+            var state = new DictionaryState<string>(storage);
 
             state[key] = value;
 
@@ -43,7 +43,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<string>(storage);
+            var state2 = new DictionaryState<string>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -53,7 +53,7 @@ public class StateTemplatedShould
         public void DoubleConversion_ShouldStoreAndRetrieveCorrectly(string key, double value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<double>(storage);
+            var state = new DictionaryState<double>(storage);
 
             state[key] = value;
 
@@ -61,7 +61,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<double>(storage);
+            var state2 = new DictionaryState<double>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -71,7 +71,7 @@ public class StateTemplatedShould
         public void DecimalConversion_ShouldStoreAndRetrieveCorrectly(string key, decimal value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<decimal>(storage);
+            var state = new DictionaryState<decimal>(storage);
 
             state[key] = value;
 
@@ -79,7 +79,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 =  new State<decimal>(storage);
+            var state2 =  new DictionaryState<decimal>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -89,7 +89,7 @@ public class StateTemplatedShould
         public void FloatConversion_ShouldStoreAndRetrieveCorrectly(string key, float value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<float>(storage);
+            var state = new DictionaryState<float>(storage);
 
             state[key] = value;
 
@@ -97,7 +97,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 =  new State<float>(storage);
+            var state2 =  new DictionaryState<float>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -108,7 +108,7 @@ public class StateTemplatedShould
         public void BoolConversion_ShouldStoreAndRetrieveCorrectly(string key, bool value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<bool>(storage);
+            var state = new DictionaryState<bool>(storage);
 
             state[key] = value;
 
@@ -116,7 +116,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<bool>(storage);
+            var state2 = new DictionaryState<bool>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -127,7 +127,7 @@ public class StateTemplatedShould
         public void CharConversion_ShouldStoreAndRetrieveCorrectly(string key, char value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<char>(storage);
+            var state = new DictionaryState<char>(storage);
 
             state[key] = value;
 
@@ -135,7 +135,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<char>(storage);
+            var state2 = new DictionaryState<char>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -145,7 +145,7 @@ public class StateTemplatedShould
         public void LongConversion_ShouldStoreAndRetrieveCorrectly(string key, long value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<long>(storage);
+            var state = new DictionaryState<long>(storage);
 
             state[key] = value;
 
@@ -153,7 +153,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<long>(storage);
+            var state2 = new DictionaryState<long>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -163,7 +163,7 @@ public class StateTemplatedShould
         public void UlongConversion_ShouldStoreAndRetrieveCorrectly(string key, ulong value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<ulong>(storage);
+            var state = new DictionaryState<ulong>(storage);
 
             state[key] = value;
 
@@ -171,7 +171,7 @@ public class StateTemplatedShould
 
             state.Flush();
             
-            var state2 = new State<ulong>(storage);
+            var state2 = new DictionaryState<ulong>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -182,7 +182,7 @@ public class StateTemplatedShould
         public void IntConversion_ShouldStoreAndRetrieveCorrectly(string key, int value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<int>(storage);
+            var state = new DictionaryState<int>(storage);
 
             state[key] = value;
 
@@ -190,7 +190,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<int>(storage);
+            var state2 = new DictionaryState<int>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -200,7 +200,7 @@ public class StateTemplatedShould
         public void UintConversion_ShouldStoreAndRetrieveCorrectly(string key, uint value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<uint>(storage);
+            var state = new DictionaryState<uint>(storage);
 
             state[key] = value;
 
@@ -208,7 +208,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<uint>(storage);
+            var state2 = new DictionaryState<uint>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -218,7 +218,7 @@ public class StateTemplatedShould
         public void ShortConversion_ShouldStoreAndRetrieveCorrectly(string key, short value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<short>(storage);
+            var state = new DictionaryState<short>(storage);
 
             state[key] = value;
 
@@ -226,7 +226,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<short>(storage);
+            var state2 = new DictionaryState<short>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -236,7 +236,7 @@ public class StateTemplatedShould
         public void UshortConversion_ShouldStoreAndRetrieveCorrectly(string key, ushort value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<ushort>(storage);
+            var state = new DictionaryState<ushort>(storage);
 
             state[key] = value;
 
@@ -244,7 +244,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<ushort>(storage);
+            var state2 = new DictionaryState<ushort>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -254,7 +254,7 @@ public class StateTemplatedShould
         public void ByteConversion_ShouldStoreAndRetrieveCorrectly(string key, byte value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<byte>(storage);
+            var state = new DictionaryState<byte>(storage);
 
             state[key] = value;
 
@@ -262,7 +262,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<byte>(storage);
+            var state2 = new DictionaryState<byte>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -272,7 +272,7 @@ public class StateTemplatedShould
         public void SbyteConversion_ShouldStoreAndRetrieveCorrectly(string key, sbyte value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<sbyte>(storage);
+            var state = new DictionaryState<sbyte>(storage);
 
             state[key] = value;
 
@@ -280,7 +280,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<sbyte>(storage);
+            var state2 = new DictionaryState<sbyte>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -290,7 +290,7 @@ public class StateTemplatedShould
         public void DatetimeConversion_ShouldStoreAndRetrieveCorrectly(string key, DateTime value)
         {
             var storage = new InMemoryStorage();
-            var state = new State<DateTime>(storage);
+            var state = new DictionaryState<DateTime>(storage);
 
             state[key] = value;
 
@@ -298,7 +298,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<DateTime>(storage);
+            var state2 = new DictionaryState<DateTime>(storage);
             
             state2[key].Should().Be(value);
         }
@@ -313,7 +313,7 @@ public class StateTemplatedShould
         {
             var storage = new InMemoryStorage();
             var key = "TestKey";
-            var state = new State<CustomClass>(storage);
+            var state = new DictionaryState<CustomClass>(storage);
 
             var customObject = new CustomClass { Id = 1, Name = "TestObject" };
             state[key] = customObject;
@@ -322,7 +322,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<CustomClass>(storage);
+            var state2 = new DictionaryState<CustomClass>(storage);
             
             state2[key].Should().BeEquivalentTo(customObject);
         }
@@ -332,7 +332,7 @@ public class StateTemplatedShould
         {
             var storage = new InMemoryStorage();
             var key = "TestKey";
-            var state = new State<List<CustomClass>>(storage);
+            var state = new DictionaryState<List<CustomClass>>(storage);
             state.Clear();
 
             var customObject = new CustomClass { Id = 1, Name = "TestObject" };
@@ -345,7 +345,7 @@ public class StateTemplatedShould
             
             state.Flush();
             
-            var state2 = new State<List<CustomClass>>(storage);
+            var state2 = new DictionaryState<List<CustomClass>>(storage);
             
             state2[key].Count.Should().Be(2);
             state2[key].All(y=> y.IsSameOrEqualTo(customObject)).Should().BeTrue();
@@ -356,7 +356,7 @@ public class StateTemplatedShould
         {
             var storage = new InMemoryStorage();
             var key = "TestKey";
-            var state = new State<int>(storage);
+            var state = new DictionaryState<int>(storage);
 
             state[key] += 2;
             state[key] -= 1;
@@ -371,7 +371,7 @@ public class StateTemplatedShould
         {
             var storage = new InMemoryStorage();
             // Arrange
-            var state = new State<string>(storage);
+            var state = new DictionaryState<string>(storage);
             state.Add("Key1", "Value1");
             state.Add("Key2", "Value2");
 
@@ -379,7 +379,7 @@ public class StateTemplatedShould
             state.Clear();
             state.Count.Should().Be(0);
             state.Flush();
-            var state2 = new State<string>(storage);
+            var state2 = new DictionaryState<string>(storage);
 
             // Assert
             state2.Count.Should().Be(0);
@@ -390,7 +390,7 @@ public class StateTemplatedShould
         {
             var storage = new InMemoryStorage();
             // Arrange
-            var state = new State<string>(storage);
+            var state = new DictionaryState<string>(storage);
             
             // Act 1
             state.Add("Key1", "Value1"); // will keep as is, before clear
@@ -425,7 +425,7 @@ public class StateTemplatedShould
             state["Key8"].Should().Be("Value8");
 
             // Act 3
-            var state2 = new State<string>(storage);
+            var state2 = new DictionaryState<string>(storage);
 
             // Assert 3
             state2.Count.Should().Be(3);
@@ -439,7 +439,7 @@ public class StateTemplatedShould
         {
             // Arrange
             var storage = new InMemoryStorage();
-            var state = new State<string>(storage);
+            var state = new DictionaryState<string>(storage);
             state.Add("key", "value");
             state.Flush();
 

--- a/src/CsharpClient/QuixStreams.State/IState.cs
+++ b/src/CsharpClient/QuixStreams.State/IState.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace QuixStreams.State
+{
+    public interface IState
+    {
+        event EventHandler OnFlushing;
+        event EventHandler OnFlushed;
+
+        void Clear();
+        void Flush();
+        void Reset();
+    }
+}

--- a/src/CsharpClient/QuixStreams.State/IState.cs
+++ b/src/CsharpClient/QuixStreams.State/IState.cs
@@ -2,13 +2,34 @@ using System;
 
 namespace QuixStreams.State
 {
+    /// <summary>
+    /// Interface for a state
+    /// </summary>
     public interface IState
     {
+        /// <summary>
+        /// Raised immediately before a flush operation is performed.
+        /// </summary>
         event EventHandler OnFlushing;
+        
+        /// <summary>
+        /// Raised immediately after a flush operation is completed.
+        /// </summary>
         event EventHandler OnFlushed;
 
+        /// <summary>
+        /// Sets the value of in-memory state to null and marks the state for clearing when flushed.
+        /// </summary>
         void Clear();
+        
+        /// <summary>
+        /// Flushes the changes made to the in-memory state to the specified storage.
+        /// </summary>
         void Flush();
+        
+        /// <summary>
+        /// Reset the state to before in-memory modifications
+        /// </summary>
         void Reset();
     }
 }

--- a/src/CsharpClient/QuixStreams.State/ScalarState.cs
+++ b/src/CsharpClient/QuixStreams.State/ScalarState.cs
@@ -33,7 +33,7 @@ namespace QuixStreams.State
         /// <summary>
         /// Represents the key used to store the state in the storage.
         /// </summary>
-        private const string StorageKey = "SCALAR";
+        public const string StorageKey = "SCALAR";
 
         /// <summary>
         /// Represents the hash of last flushed value that is persisted

--- a/src/CsharpClient/QuixStreams.State/ScalarState.cs
+++ b/src/CsharpClient/QuixStreams.State/ScalarState.cs
@@ -1,0 +1,361 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+using QuixStreams.State.Storage;
+
+namespace QuixStreams.State
+{
+    /// <summary>
+    /// Represents a state container that stores key-value pairs with the ability to flush changes to a specified storage.
+    /// </summary>
+    public class ScalarState: IState
+    {
+        /// <summary>
+        /// Represents the storage where the state changes will be persisted.
+        /// </summary>
+        private readonly IStateStorage storage;
+        
+        /// <summary>
+        /// Indicates whether the storage should be cleared before flushing the changes.
+        /// </summary>
+        private bool clearBeforeFlush;
+
+        /// <summary>
+        /// Represents the in-memory state holding the state value.
+        /// </summary>
+        private StateValue inMemoryValue = null;
+        
+        /// <summary>
+        /// Represents the key used to store the state in the storage.
+        /// </summary>
+        public const string StorageKey = "SCALAR_VALUE";
+
+        /// <summary>
+        /// Represents the in-memory state holding the key-value pairs of last persisted hash values
+        /// </summary>
+        private int lastFlushHash = default;
+        
+        /// <summary>
+        /// The logger for the class
+        /// </summary>
+        private readonly ILogger<DictionaryState> logger;
+        
+        /// <summary>
+        /// Raised immediately before a flush operation is performed.
+        /// </summary>
+        public event EventHandler OnFlushing;
+        
+        /// <summary>
+        /// Raised immediately after a flush operation is completed.
+        /// </summary>
+        public event EventHandler OnFlushed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DictionaryState"/> class using the specified storage.
+        /// </summary>
+        /// <param name="storage">An instance of <see cref="IStateStorage"/> that represents the storage to persist state changes to.</param>
+        /// <param name="loggerFactory">The logger factory to use</param>
+        /// <exception cref="ArgumentNullException">Thrown when the storage parameter is null.</exception>
+        public ScalarState(IStateStorage storage, ILoggerFactory loggerFactory = null)
+        {
+            this.logger = loggerFactory?.CreateLogger<DictionaryState>() ?? NullLogger<DictionaryState>.Instance;
+            this.storage = storage ?? throw new ArgumentNullException(nameof(storage));
+            inMemoryValue = this.storage.ContainsKey(StorageKey) ? this.storage.Get(StorageKey) : null;
+        }
+
+        /// <summary>
+        /// Removes all key-value pairs from the in-memory state and marks the state for clearing when flushed.
+        /// </summary>
+        public void Clear()
+        {
+            inMemoryValue = null;
+            clearBeforeFlush = true;
+        }
+
+        /// <summary>
+        /// Gets or sets the element with the specified key in the in-memory state.
+        /// </summary>
+        /// <returns>Returns the value</returns>
+        public StateValue Value
+        {
+            get => inMemoryValue;
+            set => inMemoryValue = value;
+        }
+        
+        /// <summary>
+        /// Flushes the changes made to the in-memory state to the specified storage.
+        /// </summary>
+        public void Flush()
+        {
+            this.logger.LogTrace("Flushing state.");
+            OnFlushing?.Invoke(this, EventArgs.Empty);
+            
+            if (this.clearBeforeFlush)
+            {
+                this.storage.Clear();
+                this.clearBeforeFlush = false;
+            }
+            
+            if (Value == null)
+            {
+                this.lastFlushHash = default;
+                storage.Remove(StorageKey);
+            }
+            else
+            {
+                var hash = inMemoryValue.GetHashCode();
+                if (lastFlushHash != hash)
+                {
+                    this.lastFlushHash = hash;
+                    this.storage.Set(StorageKey, inMemoryValue);
+                }
+            }
+
+            OnFlushed?.Invoke(this, EventArgs.Empty);
+            this.logger.LogTrace("Flushed.");
+        }
+
+        /// <summary>
+        /// Reset the state to before in-memory modifications
+        /// </summary>
+        public void Reset()
+        {
+            if (inMemoryValue.GetHashCode() == lastFlushHash)
+            {
+                this.logger.LogTrace("Resetting state not needed, hash is the same.");
+                return;
+            }
+            this.logger.LogTrace("Resetting state");
+            
+            // Retrieve values from storage
+            this.inMemoryValue = this.storage.Get(StorageKey);
+            
+            this.logger.LogTrace($"Reset state completed.");
+        }
+    }
+    
+    /// <summary>
+    /// Represents a state container that stores key-value pairs with the ability to flush changes to a specified storage.
+    /// </summary>
+    public class ScalarState<T> : IState
+    {
+        /// <summary>
+        /// The logger for the class
+        /// </summary>
+        private readonly ILogger logger;
+        
+
+        /// <summary>
+        /// Indicates whether the state should be cleared before flushing the changes.
+        /// </summary>
+        private bool clearBeforeFlush;
+        
+        /// <summary>
+        /// The underlying state storage for this State, responsible for managing the actual key-value pairs.
+        /// </summary>
+        private readonly ScalarState underlyingScalarState;
+
+        /// <summary>
+        /// A function that converts a StateValue to the desired value of type T, using appropriate conversion logic based on the type of T.
+        /// </summary>
+        private readonly Func<StateValue, T> genericConverter;
+        
+        /// <summary>
+        /// A function that converts a value of type T to a StateValue, using appropriate conversion logic based on the type of T.
+        /// </summary>
+        private readonly Func<T, StateValue> stateValueConverter;
+
+        /// <summary>
+        /// The in-memory cache to avoid conversions between State and T whenever possible
+        /// </summary>
+        private T inMemoryValue = default;
+
+        /// <summary>
+        /// Raised immediately before a flush operation is performed.
+        /// </summary>
+        public event EventHandler OnFlushing;
+        
+        /// <summary>
+        /// Raised immediately after a flush operation is completed.
+        /// </summary>
+        public event EventHandler OnFlushed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DictionaryState"/> class with the specified storage and logger factory.
+        /// </summary>
+        /// <param name="storage">The storage provider to persist state changes to. Must not be null.</param>
+        /// <param name="loggerFactory">Optional logger factory to enable logging from within the state object.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the storage parameter is null.</exception>
+        public ScalarState(IStateStorage storage, ILoggerFactory loggerFactory = null) : this(new ScalarState(storage, loggerFactory), loggerFactory)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DictionaryState"/> class with the specified storage and logger factory.
+        /// </summary>
+        /// <param name="scalarState">The state to persist state changes to. Must not be null.</param>
+        /// <param name="loggerFactory">Optional logger factory to enable logging from within the state object.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the storage parameter is null.</exception>
+        public ScalarState(ScalarState scalarState, ILoggerFactory loggerFactory = null)
+        {
+            this.underlyingScalarState = scalarState ?? throw new ArgumentNullException(nameof(scalarState));
+            this.logger = loggerFactory?.CreateLogger<DictionaryState<T>>() ?? new NullLogger<DictionaryState<T>>();
+            var type = typeof(T);
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Empty:
+                case TypeCode.DBNull:
+                    throw new ArgumentException(
+                        $"{Type.GetTypeCode(type)} is not supported by {nameof(DictionaryState<T>)}.");
+                case TypeCode.Object:
+                    var options = new JsonSerializerSettings()
+                    {
+                        Formatting = Formatting.None
+                    };
+                    genericConverter = value => JsonConvert.DeserializeObject<T>(value.StringValue);
+                    stateValueConverter = value => new StateValue(JsonConvert.SerializeObject(value, options)); // must be evaluated lazily as internal references can change whenever
+                    break;
+                case TypeCode.Boolean:
+                    genericConverter = value => (T)(object)value.BoolValue;
+                    stateValueConverter = value => new StateValue((bool)(object)value);
+                    break;
+                case TypeCode.Char:
+                    genericConverter = value => (T)(object)(char)value.LongValue;
+                    stateValueConverter = value => new StateValue((char)(object)value);
+                    break;
+                case TypeCode.SByte:
+                    genericConverter = value => (T)(object)(sbyte)value.LongValue;
+                    stateValueConverter = value => new StateValue((sbyte)(object)value);
+                    break;
+                case TypeCode.Byte:
+                    genericConverter = value => (T)(object)(byte)value.LongValue;
+                    stateValueConverter = value => new StateValue((byte)(object)value);
+                    break;
+                case TypeCode.Int16:
+                    genericConverter = value => (T)(object)(short)value.LongValue;
+                    stateValueConverter = value => new StateValue((short)(object)value);
+                    break;
+                case TypeCode.UInt16:
+                    genericConverter = value => (T)(object)(ushort)value.LongValue;
+                    stateValueConverter = value => new StateValue((ushort)(object)value);
+                    break;
+                case TypeCode.Int32:
+                    genericConverter = value => (T)(object)(int)value.LongValue;
+                    stateValueConverter = value => new StateValue((int)(object)value);
+                    break;
+                case TypeCode.UInt32:
+                    genericConverter = value => (T)(object)(uint)value.LongValue;
+                    stateValueConverter = value => new StateValue((uint)(object)value);
+                    break;
+                case TypeCode.Int64:
+                    genericConverter = value => (T)(object)value.LongValue;
+                    stateValueConverter = value => new StateValue((long)(object)value);
+                    break;
+                case TypeCode.UInt64:
+                    genericConverter = value => (T)(object)BitConverter.ToUInt64(value.BinaryValue, 0);
+                    stateValueConverter = value =>
+                        new StateValue(BitConverter.GetBytes((ulong)(object)value));
+                    break;
+                case TypeCode.Single:
+                    genericConverter = value => (T)(object)(float)value.DoubleValue;
+                    stateValueConverter = value => new StateValue((float)(object)value);
+                    break;
+                case TypeCode.Double:
+                    genericConverter = value => (T)(object)value.DoubleValue;
+                    stateValueConverter = value => new StateValue((double)(object)value);
+                    break;
+                case TypeCode.Decimal:
+                    genericConverter = value =>
+                    {
+                        var bytes = value.BinaryValue;
+                        var bits = new int[4];
+                        for (var ii = 0; ii < 4; ii++)
+                        {
+                            bits[ii] = BitConverter.ToInt32(bytes, ii * 4);
+                        }
+
+                        return (T)(object)new decimal(bits);
+                    };
+                    stateValueConverter = value =>
+                    {
+                        var bits = decimal.GetBits((decimal)(object)value);
+                        var binaryBytes = new byte[16];
+                        for (var ii = 0; ii < 4; ii++)
+                        {
+                            var intBytes = BitConverter.GetBytes(bits[ii]);
+                            Array.Copy(intBytes, 0, binaryBytes, ii * 4, 4);
+                        }
+
+                        return new StateValue(binaryBytes);
+                    };
+                    break;
+                case TypeCode.DateTime:
+                    genericConverter = value => (T)(object)DateTime.FromBinary(value.LongValue);
+                    stateValueConverter = value => new StateValue(((DateTime)(object)value).ToBinary());
+                    break;
+                case TypeCode.String:
+                    genericConverter = value => (T)(object)value.StringValue;
+                    stateValueConverter = value => new StateValue((string)(object)value);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            
+            this.inMemoryValue = underlyingScalarState.Value != null ? genericConverter(underlyingScalarState.Value) : default;
+        }
+        
+        public void Clear()
+        {
+            this.inMemoryValue = default;
+            this.clearBeforeFlush = true;
+        }
+        
+        public T Value
+        {
+            get => this.inMemoryValue;
+            set => this.inMemoryValue = value;
+        }
+        
+        /// <summary>
+        /// Flushes the changes made to the in-memory state to the specified storage.
+        /// </summary>
+        public void Flush()
+        {
+            this.logger.LogTrace("Flushing state");
+            OnFlushing?.Invoke(this, EventArgs.Empty);
+            
+            if (this.clearBeforeFlush)
+            {
+                logger.LogTrace("Clearing state before flush as clear was requested");
+                this.underlyingScalarState.Clear();
+                this.clearBeforeFlush = false;
+            }
+            
+            logger.LogTrace("Updating value from state as part of flush");
+            this.underlyingScalarState.Value = stateValueConverter(inMemoryValue);
+
+            logger.LogTrace("Flushing underlying state as part of flush");
+            this.underlyingScalarState.Flush();
+            logger.LogTrace("Flushed underlying state as part of flush");
+            OnFlushed?.Invoke(this, EventArgs.Empty);
+            this.logger.LogTrace("Flushed state.");
+        }
+        
+        /// <summary>
+        /// Reset the state to before in-memory modifications
+        /// </summary>
+        public void Reset()
+        {
+            this.logger.LogTrace("Resetting state");
+            
+            this.inMemoryValue = genericConverter(this.underlyingScalarState.Value);
+            
+            this.logger.LogTrace($"Reset state completed.");
+        }
+    }
+}

--- a/src/CsharpClient/QuixStreams.State/ScalarState.cs
+++ b/src/CsharpClient/QuixStreams.State/ScalarState.cs
@@ -11,7 +11,7 @@ using QuixStreams.State.Storage;
 namespace QuixStreams.State
 {
     /// <summary>
-    /// Represents a state container that stores key-value pairs with the ability to flush changes to a specified storage.
+    /// Represents a state container that stores scalar value with the ability to flush changes to a specified storage.
     /// </summary>
     public class ScalarState: IState
     {
@@ -33,10 +33,10 @@ namespace QuixStreams.State
         /// <summary>
         /// Represents the key used to store the state in the storage.
         /// </summary>
-        public const string StorageKey = "SCALAR_VALUE";
+        private const string StorageKey = "SCALAR";
 
         /// <summary>
-        /// Represents the in-memory state holding the key-value pairs of last persisted hash values
+        /// Represents the hash of last flushed value that is persisted
         /// </summary>
         private int lastFlushHash = default;
         
@@ -69,7 +69,7 @@ namespace QuixStreams.State
         }
 
         /// <summary>
-        /// Removes all key-value pairs from the in-memory state and marks the state for clearing when flushed.
+        /// Sets the value of in-memory state to null and marks the state for clearing when flushed.
         /// </summary>
         public void Clear()
         {
@@ -78,7 +78,7 @@ namespace QuixStreams.State
         }
 
         /// <summary>
-        /// Gets or sets the element with the specified key in the in-memory state.
+        /// Gets or sets the value to the in-memory state.
         /// </summary>
         /// <returns>Returns the value</returns>
         public StateValue Value
@@ -140,7 +140,7 @@ namespace QuixStreams.State
     }
     
     /// <summary>
-    /// Represents a state container that stores key-value pairs with the ability to flush changes to a specified storage.
+    /// Represents a state container that stores scalar value with the ability to flush changes to a specified storage.
     /// </summary>
     public class ScalarState<T> : IState
     {
@@ -156,7 +156,7 @@ namespace QuixStreams.State
         private bool clearBeforeFlush;
         
         /// <summary>
-        /// The underlying state storage for this State, responsible for managing the actual key-value pairs.
+        /// The underlying state storage for this State, responsible for managing the actual value.
         /// </summary>
         private readonly ScalarState underlyingScalarState;
 
@@ -309,12 +309,19 @@ namespace QuixStreams.State
             this.inMemoryValue = underlyingScalarState.Value != null ? genericConverter(underlyingScalarState.Value) : default;
         }
         
+        /// <summary>
+        /// Sets the value of in-memory state to null and marks the state for clearing when flushed.
+        /// </summary>
         public void Clear()
         {
             this.inMemoryValue = default;
             this.clearBeforeFlush = true;
         }
         
+        /// <summary>
+        /// Gets or sets the value to the in-memory state.
+        /// </summary>
+        /// <returns>Returns the value</returns>
         public T Value
         {
             get => this.inMemoryValue;

--- a/src/CsharpClient/QuixStreams.Streaming.UnitTests/States/StreamStateManagerShould.cs
+++ b/src/CsharpClient/QuixStreams.Streaming.UnitTests/States/StreamStateManagerShould.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -15,7 +16,7 @@ public class StreamStateManagerShould
     }
     
     [Fact]
-    public void GetStates_ShouldReturnExcepted()
+    public void GetDictionaryState_ShouldReturnExcepted()
     {
         // Arrange
         var manager = CreateStreamStateManager();
@@ -37,7 +38,7 @@ public class StreamStateManagerShould
     }
     
     [Fact]
-    public void GetState_ShouldReturnSameManagerAlways()
+    public void GetDictionaryState_ShouldReturnSameManagerAlways()
     {
         // Arrange
         var manager = CreateStreamStateManager();
@@ -49,6 +50,79 @@ public class StreamStateManagerShould
         // Assert
         testStreamState.Should().NotBeNull();
         testStreamState.Should().BeSameAs(testStreamState2);
+    }
+    
+    [Fact]
+    public void GetDictionaryState_StateNameUsedByDifferentStateType_ShouldThrow()
+    {
+        // Arrange
+        var manager = CreateStreamStateManager();
+        manager.GetDictionaryState("test");
+        
+        // Assert
+        Action scalarStateAct = () => manager.GetScalarState("test");
+        scalarStateAct.Should().Throw<ArgumentException>();
+        
+        Action dictGenericStateAct = () => manager.GetDictionaryState<int>("test");
+        dictGenericStateAct.Should().Throw<ArgumentException>();
+        
+        Action scalarGenericStateAct = () => manager.GetScalarState<int>("test");
+        scalarGenericStateAct.Should().Throw<ArgumentException>();
+    }
+    
+    [Fact]
+    public void GetDictionaryStateGeneric_StateNameUsedByDifferentStateType_ShouldThrow()
+    {
+        // Arrange
+        var manager = CreateStreamStateManager();
+        manager.GetDictionaryState<bool>("test");
+        
+        // Assert
+        Action dictStateAct = () => manager.GetDictionaryState("test");
+        dictStateAct.Should().Throw<ArgumentException>();
+
+        Action dictDiffGenericStateAct = () => manager.GetDictionaryState<int>("test");
+        dictDiffGenericStateAct.Should().Throw<ArgumentException>();
+        
+        Action scalarStateAct = () => manager.GetScalarState("test");
+        scalarStateAct.Should().Throw<ArgumentException>();
+    }
+    
+    [Fact]
+    public void GetScalarState_StateNameUsedByDifferentStateType_ShouldThrow()
+    {
+        // Arrange
+        var manager = CreateStreamStateManager();
+        manager.GetScalarState("test");
+        
+        // Assert
+        Action scalarGenericStateAct = () => manager.GetScalarState<int>("test");
+        scalarGenericStateAct.Should().Throw<ArgumentException>();
+        
+        Action dictStateAct = () => manager.GetDictionaryState("test");
+        dictStateAct.Should().Throw<ArgumentException>();
+        
+        Action dictDiffGenericStateAct = () => manager.GetDictionaryState<int>("test");
+        dictDiffGenericStateAct.Should().Throw<ArgumentException>();
+        
+    }
+    
+    [Fact]
+    public void GetScalarStateGeneric_StateNameUsedByDifferentStateType_ShouldThrow()
+    {
+        // Arrange
+        var manager = CreateStreamStateManager();
+        manager.GetScalarState<bool>("test");
+        
+        // Assert
+        Action scalarDiffGenericStateAct = () => manager.GetDictionaryState<int>("test");
+        scalarDiffGenericStateAct.Should().Throw<ArgumentException>();
+        
+        Action dictStateAct = () => manager.GetDictionaryState("test");
+        dictStateAct.Should().Throw<ArgumentException>();
+        
+        Action dictGenericStateAct = () => manager.GetDictionaryState<int>("test");
+        dictGenericStateAct.Should().Throw<ArgumentException>();
     }
     
     [Fact]

--- a/src/CsharpClient/QuixStreams.Streaming.UnitTests/States/StreamStateShould.cs
+++ b/src/CsharpClient/QuixStreams.Streaming.UnitTests/States/StreamStateShould.cs
@@ -12,7 +12,7 @@ public class StreamStateShould
     [Fact]
     public void Constructor_ShouldCreateStreamState()
     {
-        var streamState = new StreamState<int>(new InMemoryStorage(), missingStateKey => -1, NullLoggerFactory.Instance);
+        var streamState = new StreamDictionaryState<int>(new InMemoryStorage(), missingStateKey => -1, NullLoggerFactory.Instance);
 
         streamState.Should().NotBeNull();
 
@@ -24,7 +24,7 @@ public class StreamStateShould
     [Fact]
     public void Constructor_WithNullStateStorage_ShouldThrowArgumentNullException()
     {
-        Action nullTopicName = () => new StreamState<int>(null, missingStateKey => -1, NullLoggerFactory.Instance);
+        Action nullTopicName = () => new StreamDictionaryState<int>(null, missingStateKey => -1, NullLoggerFactory.Instance);
 
         nullTopicName.Should().Throw<ArgumentNullException>().WithMessage("*storage*");
     }
@@ -34,7 +34,7 @@ public class StreamStateShould
     {
         // Arrange
         var storage = new InMemoryStorage();
-        var streamState = new StreamState<string>(storage, null, NullLoggerFactory.Instance);
+        var streamState = new StreamDictionaryState<string>(storage, null, NullLoggerFactory.Instance);
 
         // Act 1
         streamState.Add("Key1", "Value1"); // will keep as is, before clear
@@ -69,7 +69,7 @@ public class StreamStateShould
         streamState["Key8"].Should().Be("Value8");
 
         // Act 3
-        var streamState2 = new StreamState<string>(storage, null, NullLoggerFactory.Instance);
+        var streamState2 = new StreamDictionaryState<string>(storage, null, NullLoggerFactory.Instance);
 
         // Assert 3
         streamState2.Count.Should().Be(3);

--- a/src/CsharpClient/QuixStreams.Streaming/IStreamConsumer.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/IStreamConsumer.cs
@@ -68,7 +68,7 @@ namespace QuixStreams.Streaming
         }
         
         /// <summary>
-        /// Gets the dictionary type stream state for the specified storage name using the provided default value factory.
+        /// Gets the scalar type stream state for the specified storage name using the provided default value factory.
         /// </summary>
         /// <typeparam name="T">The type of the stream state value.</typeparam>
         /// <param name="streamConsumer">The stream consumer to get the state for</param>

--- a/src/CsharpClient/QuixStreams.Streaming/IStreamConsumer.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/IStreamConsumer.cs
@@ -62,9 +62,22 @@ namespace QuixStreams.Streaming
         /// <param name="storageName">The name of the storage.</param>
         /// <param name="defaultValueFactory">A delegate that creates the default value for the stream state when a previously not set key is accessed.</param>
         /// <returns>The dictionary stream state for the specified storage name using the provided default value factory.</returns>
-        public static StreamState<T> GetDictionaryState<T>(this IStreamConsumer streamConsumer, string storageName, StreamStateDefaultValueDelegate<T> defaultValueFactory = null)
+        public static StreamDictionaryState<T> GetDictionaryState<T>(this IStreamConsumer streamConsumer, string storageName, StreamStateDefaultValueDelegate<T> defaultValueFactory = null)
         {
             return streamConsumer.GetStateManager().GetDictionaryState(storageName, defaultValueFactory);
+        }
+        
+        /// <summary>
+        /// Gets the dictionary type stream state for the specified storage name using the provided default value factory.
+        /// </summary>
+        /// <typeparam name="T">The type of the stream state value.</typeparam>
+        /// <param name="streamConsumer">The stream consumer to get the state for</param>
+        /// <param name="storageName">The name of the storage.</param>
+        /// <param name="defaultValueFactory">A delegate that creates the default value for the stream state when a previously not set key is accessed.</param>
+        /// <returns>The dictionary stream state for the specified storage name using the provided default value factory.</returns>
+        public static StreamScalarState<T> GetScalarState<T>(this IStreamConsumer streamConsumer, string storageName, StreamStateDefaultValueDelegate<T> defaultValueFactory = null)
+        {
+            return streamConsumer.GetStateManager().GetScalarState(storageName, defaultValueFactory);
         }
     }
     

--- a/src/CsharpClient/QuixStreams.Streaming/States/IStreamState.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/States/IStreamState.cs
@@ -3,7 +3,7 @@ using System;
 namespace QuixStreams.Streaming.States
 {
     /// <summary>
-    /// fill me
+    /// Interface for a stream state
     /// </summary>
     public interface IStreamState
     {

--- a/src/CsharpClient/QuixStreams.Streaming/States/IStreamState.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/States/IStreamState.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace QuixStreams.Streaming.States
+{
+    /// <summary>
+    /// fill me
+    /// </summary>
+    public interface IStreamState
+    {
+        /// <summary>
+        /// Raised immediately before a flush operation is performed.
+        /// </summary>
+        event EventHandler OnFlushing;
+
+        /// <summary>
+        /// Raised immediately after a flush operation is completed.
+        /// </summary>
+        event EventHandler OnFlushed;
+
+        /// <summary>
+        /// Flushes the changes made to the in-memory state to the specified storage.
+        /// </summary>
+        void Flush();
+
+        /// <summary>
+        /// Reset the state to before in-memory modifications
+        /// </summary>
+        void Reset();
+    }
+    
+    /// <summary>
+    /// Represents a method that returns the default value for a given key.
+    /// </summary>
+    /// <typeparam name="T">The type of the default value.</typeparam>
+    /// <param name="missingStateKey">The name of the key being accessed.</param>
+    /// <returns>The default value for the specified key.</returns>
+    public delegate T StreamStateDefaultValueDelegate<out T>(string missingStateKey);
+}

--- a/src/CsharpClient/QuixStreams.Streaming/States/StreamDictionaryState.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/States/StreamDictionaryState.cs
@@ -10,12 +10,12 @@ namespace QuixStreams.Streaming.States
     /// <summary>
     /// Represents a dictionary-like storage of key-value pairs with a specific topic and storage name.
     /// </summary>
-    public class StreamState : IDictionary<string, StateValue>, IDictionary
+    public class StreamDictionaryState : IStreamState, IDictionary<string, StateValue>, IDictionary
     {
         /// <summary>
         /// The underlying state storage for this StreamState, responsible for managing the actual key-value pairs.
         /// </summary>
-        private readonly State.State state;
+        private readonly State.DictionaryState dictionaryState;
 
         /// <summary>
         /// Raised immediately before a flush operation is performed.
@@ -32,9 +32,9 @@ namespace QuixStreams.Streaming.States
         /// </summary>
         /// <param name="storage">The storage the stream state is going to use as underlying storage</param>
         /// <param name="loggerFactory">The logger factory to use</param>
-        internal StreamState(IStateStorage storage, ILoggerFactory loggerFactory)
+        internal StreamDictionaryState(IStateStorage storage, ILoggerFactory loggerFactory)
         {
-            this.state = new State.State(storage, loggerFactory);
+            this.dictionaryState = new State.DictionaryState(storage, loggerFactory);
         }
 
         /// <inheritdoc/>
@@ -46,7 +46,7 @@ namespace QuixStreams.Streaming.States
         /// <inheritdoc/>
         IDictionaryEnumerator IDictionary.GetEnumerator()
         {
-            return ((IDictionary)this.state).GetEnumerator();
+            return ((IDictionary)this.dictionaryState).GetEnumerator();
         }
 
         /// <inheritdoc/>
@@ -56,12 +56,12 @@ namespace QuixStreams.Streaming.States
         }
 
         /// <inheritdoc/>
-        public bool IsFixedSize => this.state.IsFixedSize;
+        public bool IsFixedSize => this.dictionaryState.IsFixedSize;
 
         /// <inheritdoc/>
         public IEnumerator<KeyValuePair<string, StateValue>> GetEnumerator()
         {
-            return this.state.GetEnumerator();
+            return this.dictionaryState.GetEnumerator();
         }
 
         /// <inheritdoc/>
@@ -85,7 +85,7 @@ namespace QuixStreams.Streaming.States
         /// <inheritdoc cref="IDictionary.Clear" />
         public void Clear()
         {
-            this.state.Clear();
+            this.dictionaryState.Clear();
         }
 
         /// <inheritdoc/>
@@ -97,7 +97,7 @@ namespace QuixStreams.Streaming.States
         /// <inheritdoc/>
         public void CopyTo(KeyValuePair<string, StateValue>[] array, int arrayIndex)
         {
-            this.state.CopyTo(array, arrayIndex);
+            this.dictionaryState.CopyTo(array, arrayIndex);
         }
 
         /// <inheritdoc/>
@@ -109,17 +109,17 @@ namespace QuixStreams.Streaming.States
         /// <inheritdoc/>
         public void CopyTo(Array array, int index)
         {
-            this.state.CopyTo(array, index);
+            this.dictionaryState.CopyTo(array, index);
         }
 
         /// <inheritdoc cref="ICollection.Count" />
-        public int Count => this.state.Count;
+        public int Count => this.dictionaryState.Count;
 
         /// <inheritdoc />
-        public bool IsSynchronized => this.state.IsSynchronized;
+        public bool IsSynchronized => this.dictionaryState.IsSynchronized;
         
         /// <inheritdoc />
-        public object SyncRoot => this.state.SyncRoot;
+        public object SyncRoot => this.dictionaryState.SyncRoot;
 
         /// <inheritdoc cref="IDictionary.IsReadOnly" />
         public bool IsReadOnly => false;
@@ -134,45 +134,45 @@ namespace QuixStreams.Streaming.States
         /// <inheritdoc/>
         public void Add(string key, StateValue value)
         {
-            this.state.Add(key, value);
+            this.dictionaryState.Add(key, value);
         }
 
         /// <inheritdoc/>
         public bool ContainsKey(string key)
         {
-            return this.state.ContainsKey(key);
+            return this.dictionaryState.ContainsKey(key);
         }
 
         /// <inheritdoc/>
         public bool Remove(string key)
         {
-            return this.state.Remove(key);
+            return this.dictionaryState.Remove(key);
         }
 
         /// <inheritdoc/>
         public bool TryGetValue(string key, out StateValue value)
         {
-            return state.TryGetValue(key, out value);
+            return dictionaryState.TryGetValue(key, out value);
         }
 
         /// <inheritdoc/>
         public StateValue this[string key]
         {
-            get => this.state[key];
-            set => this.state[key] = value;
+            get => this.dictionaryState[key];
+            set => this.dictionaryState[key] = value;
         }
 
         /// <inheritdoc/>
-        public ICollection<string> Keys => this.state.Keys;
+        public ICollection<string> Keys => this.dictionaryState.Keys;
 
         /// <inheritdoc/>
-        ICollection IDictionary.Values => ((IDictionary)this.state).Values;
+        ICollection IDictionary.Values => ((IDictionary)this.dictionaryState).Values;
 
         /// <inheritdoc/>
-        ICollection IDictionary.Keys => ((IDictionary)this.state).Keys;
+        ICollection IDictionary.Keys => ((IDictionary)this.dictionaryState).Keys;
 
         /// <inheritdoc/>
-        public ICollection<StateValue> Values => this.state.Values;
+        public ICollection<StateValue> Values => this.dictionaryState.Values;
 
         /// <summary>
         /// Flushes the changes made to the in-memory state to the specified storage.
@@ -180,7 +180,7 @@ namespace QuixStreams.Streaming.States
         public void Flush()
         {
             OnFlushing?.Invoke(this, EventArgs.Empty);
-            this.state.Flush();
+            this.dictionaryState.Flush();
             OnFlushed?.Invoke(this, EventArgs.Empty);
         }
         
@@ -189,7 +189,7 @@ namespace QuixStreams.Streaming.States
         /// </summary>
         public void Reset()
         {
-            this.state.Reset();
+            this.dictionaryState.Reset();
         }
     }
     
@@ -197,16 +197,16 @@ namespace QuixStreams.Streaming.States
     /// Represents a dictionary-like storage of key-value pairs with a specific topic and storage name.
     /// </summary>
     /// <typeparam name="T">The type of values stored in the StreamState.</typeparam>
-    public class StreamState<T> : IDictionary<string, T>
+    public class StreamDictionaryState<T> : IStreamState, IDictionary<string, T>
     {
         /// <summary>
         /// The underlying state storage for this StreamState, responsible for managing the actual key-value pairs.
         /// </summary>
-        private readonly State.State<T> state;
+        private readonly State.DictionaryState<T> dictionaryState;
         /// <summary>
         /// Returns whether the cache keys are case-sensitive
         /// </summary>
-        private bool IsCaseSensitive => this.state.IsCaseSensitive;
+        private bool IsCaseSensitive => this.dictionaryState.IsCaseSensitive;
         
         /// <summary>
         /// A function that takes a string key and returns a default value of type T when the key is not found in the state storage.
@@ -229,16 +229,16 @@ namespace QuixStreams.Streaming.States
         /// <param name="storage">The storage the stream state is going to use as underlying storage</param>
         /// <param name="defaultValueFactory">A function that takes a string key and returns a default value of type T when the key is not found in the state</param>
         /// <param name="loggerFactory">The logger factory to use</param>
-        internal StreamState(IStateStorage storage, StreamStateDefaultValueDelegate<T> defaultValueFactory, ILoggerFactory loggerFactory)
+        internal StreamDictionaryState(IStateStorage storage, StreamStateDefaultValueDelegate<T> defaultValueFactory, ILoggerFactory loggerFactory)
         {
-            this.state = new State.State<T>(storage, loggerFactory);
+            this.dictionaryState = new State.DictionaryState<T>(storage, loggerFactory);
             this.defaultValueFactory = defaultValueFactory ?? (s => throw new KeyNotFoundException("The specified key was not found and there was no default value factory set."));
         }
 
         /// <inheritdoc/>
         public IEnumerator<KeyValuePair<string, T>> GetEnumerator()
         {
-            return this.state.GetEnumerator();
+            return this.dictionaryState.GetEnumerator();
         }
 
         /// <inheritdoc/>
@@ -256,7 +256,7 @@ namespace QuixStreams.Streaming.States
         /// <inheritdoc/>
         public void Clear()
         {
-            this.state.Clear();
+            this.dictionaryState.Clear();
         }
 
         /// <inheritdoc/>
@@ -268,7 +268,7 @@ namespace QuixStreams.Streaming.States
         /// <inheritdoc/>
         public void CopyTo(KeyValuePair<string, T>[] array, int arrayIndex)
         {
-            this.state.CopyTo(array, arrayIndex);
+            this.dictionaryState.CopyTo(array, arrayIndex);
         }
 
         /// <inheritdoc/>
@@ -278,7 +278,7 @@ namespace QuixStreams.Streaming.States
         }
 
         /// <inheritdoc/>
-        public int Count => this.state.Count;
+        public int Count => this.dictionaryState.Count;
         
         /// <inheritdoc/>
         public bool IsReadOnly => false;
@@ -286,25 +286,25 @@ namespace QuixStreams.Streaming.States
         /// <inheritdoc/>
         public void Add(string key, T value)
         {
-            this.state.Add(key, value);
+            this.dictionaryState.Add(key, value);
         }
 
         /// <inheritdoc/>
         public bool ContainsKey(string key)
         {
-            return this.state.ContainsKey(key);
+            return this.dictionaryState.ContainsKey(key);
         }
 
         /// <inheritdoc/>
         public bool Remove(string key)
         {
-            return this.state.Remove(key);
+            return this.dictionaryState.Remove(key);
         }
 
         /// <inheritdoc/>
         public bool TryGetValue(string key, out T value)
         {
-            return state.TryGetValue(key, out value);
+            return dictionaryState.TryGetValue(key, out value);
         }
 
         /// <inheritdoc/>
@@ -315,17 +315,17 @@ namespace QuixStreams.Streaming.States
                 if (!this.IsCaseSensitive) key = key.ToLower();
                 if (this.TryGetValue(key, out T val)) return val;
                 val = this.defaultValueFactory(key);
-                this.state[key] = val;
+                this.dictionaryState[key] = val;
                 return val;
             }
-            set => this.state[key] = value;
+            set => this.dictionaryState[key] = value;
         }
 
         /// <inheritdoc/>
-        public ICollection<string> Keys => this.state.Keys;
+        public ICollection<string> Keys => this.dictionaryState.Keys;
 
         /// <inheritdoc/>
-        public ICollection<T> Values => this.state.Values;
+        public ICollection<T> Values => this.dictionaryState.Values;
 
         /// <summary>
         /// Flushes the changes made to the in-memory state to the specified storage.
@@ -333,7 +333,7 @@ namespace QuixStreams.Streaming.States
         public void Flush()
         {
             OnFlushing?.Invoke(this, EventArgs.Empty);
-            this.state.Flush();
+            this.dictionaryState.Flush();
             OnFlushed?.Invoke(this, EventArgs.Empty);
         }
 
@@ -342,15 +342,7 @@ namespace QuixStreams.Streaming.States
         /// </summary>
         public void Reset()
         {
-            this.state.Reset();
+            this.dictionaryState.Reset();
         }
     }
-    
-    /// <summary>
-    /// Represents a method that returns the default value for a given key.
-    /// </summary>
-    /// <typeparam name="T">The type of the default value.</typeparam>
-    /// <param name="missingStateKey">The name of the key being accessed.</param>
-    /// <returns>The default value for the specified key.</returns>
-    public delegate T StreamStateDefaultValueDelegate<out T>(string missingStateKey);
 }

--- a/src/CsharpClient/QuixStreams.Streaming/States/StreamScalarState.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/States/StreamScalarState.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using QuixStreams.State;
@@ -8,12 +7,12 @@ using QuixStreams.State.Storage;
 namespace QuixStreams.Streaming.States
 {
     /// <summary>
-    /// Represents a dictionary-like storage of key-value pairs with a specific topic and storage name.
+    /// Represents a scalar storage of a value with a specific means to be persisted.
     /// </summary>
     public class StreamScalarState : IStreamState
     {
         /// <summary>
-        /// The underlying state storage for this StreamState, responsible for managing the actual key-value pairs.
+        /// The underlying state storage for this StreamState, responsible for managing the actual value.
         /// </summary>
         private readonly State.ScalarState scalarState;
 
@@ -36,17 +35,19 @@ namespace QuixStreams.Streaming.States
         {
             this.scalarState = new State.ScalarState(storage, loggerFactory);
         }
-
         
-        /// <inheritdoc cref="IDictionary.Clear" />
+        /// <summary>
+        /// Sets the value of in-memory state to null and marks the state for clearing when flushed.
+        /// </summary>
         public void Clear()
         {
             this.scalarState.Clear();
         }
         
         /// <summary>
-        /// fill me
+        /// Gets or sets the value to the in-memory state.
         /// </summary>
+        /// <returns>Returns the value</returns>
         public StateValue Value
         {
             get => scalarState.Value;
@@ -73,21 +74,18 @@ namespace QuixStreams.Streaming.States
     }
     
     /// <summary>
-    /// Represents a dictionary-like storage of key-value pairs with a specific topic and storage name.
+    /// Represents a scalar storage of a value with a specific means to be persisted.
     /// </summary>
     /// <typeparam name="T">The type of values stored in the StreamState.</typeparam>
     public class StreamScalarState<T> : IStreamState
     {
         /// <summary>
-        /// The underlying state storage for this StreamState, responsible for managing the actual key-value pairs.
+        /// The underlying state storage for this StreamState, responsible for managing the actual value.
         /// </summary>
         private readonly State.ScalarState<T> scalarState;
-        /// <summary>
-        /// Returns whether the cache keys are case-sensitive
-        /// </summary>
         
         /// <summary>
-        /// A function that takes a string key and returns a default value of type T when the key is not found in the state storage.
+        /// A function that returns a default value of type T when the value has not been set yet.
         /// </summary>
         private readonly StreamStateDefaultValueDelegate<T> defaultValueFactory;
 
@@ -114,8 +112,9 @@ namespace QuixStreams.Streaming.States
         }
         
         /// <summary>
-        /// fill me
+        /// Gets or sets the value to the in-memory state.
         /// </summary>
+        /// <returns>Returns the value</returns>
         public T Value
         {
             get

--- a/src/CsharpClient/QuixStreams.Streaming/States/StreamScalarState.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/States/StreamScalarState.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using QuixStreams.State;
+using QuixStreams.State.Storage;
+
+namespace QuixStreams.Streaming.States
+{
+    /// <summary>
+    /// Represents a dictionary-like storage of key-value pairs with a specific topic and storage name.
+    /// </summary>
+    public class StreamScalarState : IStreamState
+    {
+        /// <summary>
+        /// The underlying state storage for this StreamState, responsible for managing the actual key-value pairs.
+        /// </summary>
+        private readonly State.ScalarState scalarState;
+
+        /// <summary>
+        /// Raised immediately before a flush operation is performed.
+        /// </summary>
+        public event EventHandler OnFlushing;
+        
+        /// <summary>
+        /// Raised immediately after a flush operation is completed.
+        /// </summary>
+        public event EventHandler OnFlushed;
+
+        /// <summary>
+        /// Initializes a new instance of the StreamState class.
+        /// </summary>
+        /// <param name="storage">The storage the stream state is going to use as underlying storage</param>
+        /// <param name="loggerFactory">The logger factory to use</param>
+        internal StreamScalarState(IStateStorage storage, ILoggerFactory loggerFactory)
+        {
+            this.scalarState = new State.ScalarState(storage, loggerFactory);
+        }
+
+        
+        /// <inheritdoc cref="IDictionary.Clear" />
+        public void Clear()
+        {
+            this.scalarState.Clear();
+        }
+        
+        /// <summary>
+        /// fill me
+        /// </summary>
+        public StateValue Value
+        {
+            get => scalarState.Value;
+            set => scalarState.Value = value;
+        }
+
+        /// <summary>
+        /// Flushes the changes made to the in-memory state to the specified storage.
+        /// </summary>
+        public void Flush()
+        {
+            OnFlushing?.Invoke(this, EventArgs.Empty);
+            this.scalarState.Flush();
+            OnFlushed?.Invoke(this, EventArgs.Empty);
+        }
+        
+        /// <summary>
+        /// Reset the state to before in-memory modifications
+        /// </summary>
+        public void Reset()
+        {
+            this.scalarState.Reset();
+        }
+    }
+    
+    /// <summary>
+    /// Represents a dictionary-like storage of key-value pairs with a specific topic and storage name.
+    /// </summary>
+    /// <typeparam name="T">The type of values stored in the StreamState.</typeparam>
+    public class StreamScalarState<T> : IStreamState
+    {
+        /// <summary>
+        /// The underlying state storage for this StreamState, responsible for managing the actual key-value pairs.
+        /// </summary>
+        private readonly State.ScalarState<T> scalarState;
+        /// <summary>
+        /// Returns whether the cache keys are case-sensitive
+        /// </summary>
+        
+        /// <summary>
+        /// A function that takes a string key and returns a default value of type T when the key is not found in the state storage.
+        /// </summary>
+        private readonly StreamStateDefaultValueDelegate<T> defaultValueFactory;
+
+        /// <summary>
+        /// Raised immediately before a flush operation is performed.
+        /// </summary>
+        public event EventHandler OnFlushing;
+        
+        /// <summary>
+        /// Raised immediately after a flush operation is completed.
+        /// </summary>
+        public event EventHandler OnFlushed;
+
+        /// <summary>
+        /// Initializes a new instance of the StreamState class.
+        /// </summary>
+        /// <param name="storage">The storage the stream state is going to use as underlying storage</param>
+        /// <param name="defaultValueFactory">A function that returns a default value of type T when the value has not been set yet</param>
+        /// <param name="loggerFactory">The logger factory to use</param>
+        internal StreamScalarState(IStateStorage storage, StreamStateDefaultValueDelegate<T> defaultValueFactory, ILoggerFactory loggerFactory)
+        {
+            this.scalarState = new State.ScalarState<T>(storage, loggerFactory);
+            this.defaultValueFactory = defaultValueFactory ?? (s => throw new KeyNotFoundException("The specified key was not found and there was no default value factory set."));
+        }
+        
+        /// <summary>
+        /// fill me
+        /// </summary>
+        public T Value
+        {
+            get
+            {
+                if (this.scalarState.Value != null) return this.scalarState.Value;
+                var val = this.defaultValueFactory(string.Empty);
+                this.scalarState.Value = val;
+                return val;
+            }
+            set => this.scalarState.Value = value;
+        }
+        
+        /// <summary>
+        /// Flushes the changes made to the in-memory state to the specified storage.
+        /// </summary>
+        public void Flush()
+        {
+            OnFlushing?.Invoke(this, EventArgs.Empty);
+            this.scalarState.Flush();
+            OnFlushed?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Reset the state to before in-memory modifications
+        /// </summary>
+        public void Reset()
+        {
+            this.scalarState.Reset();
+        }
+    }
+}

--- a/src/CsharpClient/QuixStreams.Streaming/StreamConsumer.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/StreamConsumer.cs
@@ -66,11 +66,15 @@ namespace QuixStreams.Streaming
 
         /// <inheritdoc />
         public event EventHandler<StreamClosedEventArgs> OnStreamClosed;
-
-        /// <inheritdoc />
-        public StreamState<T> GetState<T>(string stateName, StreamStateDefaultValueDelegate<T> defaultValueFactory)
+        
+        public StreamDictionaryState<T> GetDictionaryState<T>(string stateName, StreamStateDefaultValueDelegate<T> defaultValueFactory)
         {
             return this.GetStateManager().GetDictionaryState(stateName, defaultValueFactory);
+        }
+        
+        public StreamScalarState<T> GetScalarState<T>(string stateName, StreamStateDefaultValueDelegate<T> defaultValueFactory)
+        {
+            return this.GetStateManager().GetScalarState(stateName, defaultValueFactory);
         }
 
         /// <inheritdoc />

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.4"
+package_version = "0.5.5.dev1"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/src/quixstreams/states/dictstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/dictstreamstate.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 from ..helpers.nativedecorator import nativedecorator
 from ..native.Python.InteropHelpers.InteropUtils import InteropUtils
 from ..native.Python.InteropHelpers.ExternalTypes.System.Array import Array as ai
-from ..native.Python.QuixStreamsStreaming.States.StreamState import StreamState as ssi
+from ..native.Python.QuixStreamsStreaming.States.StreamDictionaryState import StreamDictionaryState as sdsi
 
 from ..models.netdict import NetDict
 from ..state.statevalue import StateValue
@@ -16,30 +16,30 @@ StreamStateType = TypeVar('StreamStateType')
 
 
 @nativedecorator
-class StreamState(Generic[StreamStateType]):
+class DictStreamState(Generic[StreamStateType]):
     """
-    Represents a dictionary-like storage of key-value pairs with a specific topic and storage name.
+    Represents a state container that stores key-value pairs with the ability to flush changes to a specified storage.
     """
 
     def __init__(self, net_pointer: ctypes.c_void_p, state_type: StreamStateType, default_value_factory: Callable[[str], StreamStateType]):
         """
-        Initializes a new instance of StreamState.
+        Initializes a new instance of DictStreamState.
 
-        NOTE: Do not initialize this class manually, use StreamStateManager.get_state
+        NOTE: Do not initialize this class manually, use StreamStateManager.get_dict_state
 
         Args:
-            net_pointer: The .net object representing a StreamState.
+            net_pointer: The .net object representing a DictStreamState.
             state_type: The type of the state
             default_value_factory: The default value factory to create value when the key is not yet present in the state
         """
 
         if net_pointer is None:
-            raise Exception("StreamState is none")
+            raise Exception("DictStreamState is none")
 
         if state_type is None:
             raise Exception('state_type must be specified')
 
-        self._interop = ssi(net_pointer)
+        self._interop = sdsi(net_pointer)
         self._default_value_factory = default_value_factory
         self._type = state_type
 

--- a/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
@@ -12,7 +12,7 @@ from typing import Generic, Callable
 @nativedecorator
 class ScalarStreamState(Generic[StreamStateType]):
     """
-    Represents a state container that stores key-value pairs with the ability to flush changes to a specified storage.
+    Represents a state container that stores a scalar value with the ability to flush changes to a specified storage.
     """
 
     def __init__(self, net_pointer: ctypes.c_void_p, state_type: StreamStateType, default_value_factory: Callable[[], StreamStateType]):

--- a/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
@@ -52,7 +52,7 @@ class ScalarStreamState(Generic[StreamStateType]):
         self._on_flushing_internal = None
         if not self._immutable:
             def on_flushing_internal():
-                self._interop.set_Value(self.convert_val_from_python(self._in_memory_value))
+                self._underlying_value = self._in_memory_value
 
             self._on_flushing_internal = on_flushing_internal
             self.on_flushing = None  # this will subscribe to the event and invoke the internal

--- a/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
@@ -1,0 +1,233 @@
+import ctypes
+import traceback
+from .dictstreamstate import StreamStateType
+from ..helpers.nativedecorator import nativedecorator
+from ..native.Python.InteropHelpers.InteropUtils import InteropUtils
+from ..native.Python.QuixStreamsStreaming.States.StreamScalarState import StreamScalarState as sssi
+from ..state.statevalue import StateValue
+
+from typing import Generic, Callable
+
+
+@nativedecorator
+class ScalarStreamState(Generic[StreamStateType]):
+    """
+    Represents a state container that stores key-value pairs with the ability to flush changes to a specified storage.
+    """
+
+    def __init__(self, net_pointer: ctypes.c_void_p, state_type: StreamStateType, default_value_factory: Callable[[], StreamStateType]):
+        """
+        Initializes a new instance of ScalarStreamState.
+
+        NOTE: Do not initialize this class manually, use StreamStateManager.get_scalar_state
+
+        Args:
+            net_pointer: The .net object representing a ScalarStreamState.
+            state_type: The type of the state
+            default_value_factory: A function that returns a default value of type T when the value has not been set yet
+        """
+
+        if net_pointer is None:
+            raise Exception("ScalarStreamState is none")
+
+        if state_type is None:
+            raise Exception('state_type must be specified')
+
+        self._interop = sssi(net_pointer)
+        self._default_value_factory = default_value_factory
+        self._type = state_type
+
+        self._in_memory_value = None
+
+        # Define events and their reference holders
+        self._on_flushed = None
+        self._on_flushed_ref = None  # Keeping reference to avoid garbage collection
+
+        self._on_flushing = None
+        self._on_flushing_ref = None  # Keeping reference to avoid garbage collection
+
+        # Check if type is immutable, because it needs special handling. Content could change without ScalarStreamState being
+        # notified
+        self._immutable = self._type in (int, float, bool, complex, str, bytes, bytearray, range)
+        self._on_flushing_internal = None
+        if not self._immutable:
+            def on_flushing_internal():
+                self._interop.set_Value(self.convert_val_from_python(self._in_memory_value))
+
+            self._on_flushing_internal = on_flushing_internal
+            self.on_flushing = None  # this will subscribe to the event and invoke the internal
+
+    def _finalizerfunc(self):
+        self._on_flushed_dispose()
+        self._on_flushing_dispose()
+
+    @property
+    def type(self) -> type:
+        """
+        Gets the type of the ScalarStreamState
+
+        Returns:
+            StreamStateType: type of the state
+        """
+        return self._type
+
+    # Region on_flushed
+    @property
+    def on_flushed(self) -> Callable[[], None]:
+        """
+        Gets the handler for when flush operation is completed.
+
+        Returns:
+            Callable[[], None]: The event handler for after flush.
+        """
+        return self._on_flushed
+
+    @on_flushed.setter
+    def on_flushed(self, value: Callable[[], None]) -> None:
+        """
+        Sets the handler for when flush operation is completed.
+
+        Args:
+            value: The parameterless callback to invoke
+        """
+
+        self._on_flushed = value
+        if self._on_flushed_ref is not None:
+            self._interop.remove_OnFlushed(self._on_flushed_ref)
+            self._on_flushed_ref = None
+
+        if self.on_flushed is None:
+            return
+
+        if self._on_flushed_ref is None:
+            self._on_flushed_ref = self._interop.add_OnFlushed(self._on_flushed_wrapper)
+
+    def _on_flushed_wrapper(self, sender_hptr, args_hptr):
+        try:
+            self._on_flushed(self._stream_consumer)
+        except:
+            traceback.print_exc()
+        finally:
+            InteropUtils.free_hptr(sender_hptr)
+            InteropUtils.free_hptr(args_hptr)
+
+    def _on_flushed_dispose(self):
+        if self._on_flushed_ref is not None:
+            self._interop.remove_OnFlushed(self._on_flushed_ref)
+            self._on_flushed_ref = None
+
+    # End region on_flushed
+
+    # Region on_flushing
+    @property
+    def on_flushing(self) -> Callable[[], None]:
+        """
+        Gets the handler for when flush operation begins.
+
+        Returns:
+            Callable[[], None]: The event handler for after flush.
+        """
+        return self._on_flushing
+
+    @on_flushing.setter
+    def on_flushing(self, value: Callable[[], None]) -> None:
+        """
+        Sets the handler for when flush operation begins.
+
+        Args:
+            value: The parameterless callback to invoke
+        """
+
+        self._on_flushing = value
+        if self._on_flushing_ref is not None:
+            self._interop.remove_OnFlushing(self._on_flushing_ref)
+            self._on_flushing_ref = None
+
+        if self.on_flushing is None and self._on_flushing_internal is None:
+            return
+
+        if self._on_flushing_ref is None:
+            self._on_flushing_ref = self._interop.add_OnFlushing(self._on_flushing_wrapper)
+
+    def _on_flushing_wrapper(self, sender_hptr, args_hptr):
+        try:
+            if self._on_flushing is not None:
+                self._on_flushing()
+            if self._on_flushing_internal is not None:
+                self._on_flushing_internal()
+        except:
+            traceback.print_exc()
+        finally:
+            InteropUtils.free_hptr(sender_hptr)
+            InteropUtils.free_hptr(args_hptr)
+
+    def _on_flushing_dispose(self):
+        if self._on_flushing_ref is not None:
+            self._interop.remove_OnFlushing(self._on_flushing_ref)
+            self._on_flushing_ref = None
+
+    # End region on_flushing
+
+    def flush(self):
+        """
+        Flushes the changes made to the in-memory state to the specified storage.
+        """
+        self._interop.Flush()
+
+    def reset(self):
+        """
+        Reset the state to before in-memory modifications
+        """
+        self._interop.Reset()
+
+    @property
+    def _underlying_value(self) -> StreamStateType:
+        net_value = (self._interop.get_Value())
+        if net_value is None:
+            return None
+        python_value = StateValue(net_value).value
+        return python_value
+
+    @_underlying_value.setter
+    def _underlying_value(self, python_value: StreamStateType):
+        if python_value is None:
+            return None
+        net_value = StateValue(python_value).get_net_pointer()
+        self._interop.set_Value(net_value)
+
+
+    @property
+    def value(self):
+        """
+        Gets the value of the state.
+
+        Returns:
+            StreamStateType: The value of the state.
+        """
+
+        if self._in_memory_value is not None:
+            return self._in_memory_value
+        else:
+            if self._underlying_value is not None:
+                _value = self._underlying_value
+            else:
+                if self._default_value_factory is None:
+                    raise
+
+                value = self._default_value_factory()
+                return value
+
+            self._in_memory_value = _value
+            return _value
+
+    @value.setter
+    def value(self, val: StreamStateType):
+        """
+        Sets the value of the state.
+
+        Args:
+            val: The value of the state.
+        """
+        self._in_memory_value = val
+        self._underlying_value = val
+

--- a/src/PythonClient/src/quixstreams/states/streamstatemanager.py
+++ b/src/PythonClient/src/quixstreams/states/streamstatemanager.py
@@ -99,7 +99,7 @@ class StreamStateManager(object):
             this will return a state where type is 'Any', with an integer 1 (zero) as default when
             value has not been set yet. The lambda function will be invoked with 'get_state_type_check' key to determine type
 
-            >>> stream_consumer.get_scalar_state('some_state', lambda missing_key: return {}, float)
+            >>> stream_consumer.get_scalar_state('some_state', lambda missing_key: return 0, float)
             this will return a state where type is a specific type, with default value
 
             >>> stream_consumer.get_scalar_state('some_state', state_type=float)

--- a/src/PythonClient/src/quixstreams/streamconsumer.py
+++ b/src/PythonClient/src/quixstreams/streamconsumer.py
@@ -267,7 +267,7 @@ class StreamConsumer(object):
             state_type: The type of the state
 
         Returns:
-            DictStreamState: The stream state
+            ScalarStreamState: The stream state
 
          Example:
             >>> stream_consumer.get_scalar_state('some_state')

--- a/src/PythonClient/src/quixstreams/streamconsumer.py
+++ b/src/PythonClient/src/quixstreams/streamconsumer.py
@@ -277,7 +277,7 @@ class StreamConsumer(object):
             this will return a state where type is 'Any', with an integer 1 (zero) as default when
             value has not been set yet. The lambda function will be invoked with 'get_state_type_check' key to determine type
 
-            >>> stream_consumer.get_scalar_state('some_state', lambda missing_key: return {}, float)
+            >>> stream_consumer.get_scalar_state('some_state', lambda missing_key: return 0, float)
             this will return a state where type is a specific type, with default value
 
             >>> stream_consumer.get_scalar_state('some_state', state_type=float)

--- a/src/PythonClient/src/quixstreams/streamconsumer.py
+++ b/src/PythonClient/src/quixstreams/streamconsumer.py
@@ -13,7 +13,8 @@ from .native.Python.InteropHelpers.InteropUtils import InteropUtils
 from .native.Python.QuixStreamsStreaming.IStreamConsumer import IStreamConsumer as sci
 from .native.Python.QuixStreamsStreaming.PackageReceivedEventArgs import PackageReceivedEventArgs
 from .native.Python.QuixStreamsStreaming.StreamClosedEventArgs import StreamClosedEventArgs
-from .states.streamstate import StreamState
+from .states.dictstreamstate import DictStreamState
+from .states.scalarstreamstate import ScalarStreamState
 from .states.streamstatemanager import StreamStateManager
 
 from typing import TypeVar
@@ -227,7 +228,7 @@ class StreamConsumer(object):
             self._streamTimeseriesConsumer = StreamTimeseriesConsumer(self, self._interop.get_Timeseries())
         return self._streamTimeseriesConsumer
 
-    def get_dict_state(self, state_name: str, default_value_factory: Callable[[str], StreamStateType] = None, state_type: StreamStateType = None) -> StreamState[StreamStateType]:
+    def get_dict_state(self, state_name: str, default_value_factory: Callable[[str], StreamStateType] = None, state_type: StreamStateType = None) -> DictStreamState[StreamStateType]:
         """
         Creates a new application state of dictionary type with automatically managed lifecycle for the stream
 
@@ -237,7 +238,7 @@ class StreamConsumer(object):
             state_type: The type of the state
 
         Returns:
-            StreamState: The stream state
+            DictStreamState: The stream state
 
          Example:
             >>> stream_consumer.get_dict_state('some_state')
@@ -255,6 +256,35 @@ class StreamConsumer(object):
         """
 
         return self.get_state_manager().get_dict_state(state_name, default_value_factory, state_type)
+
+    def get_scalar_state(self, state_name: str, default_value_factory: Callable[[], StreamStateType] = None, state_type: StreamStateType = None) -> ScalarStreamState[StreamStateType]:
+        """
+        Creates a new application state of scalar type with automatically managed lifecycle for the stream
+
+        Args:
+            state_name: The name of the state
+            default_value_factory: The default value factory to create value when it has not been set yet
+            state_type: The type of the state
+
+        Returns:
+            DictStreamState: The stream state
+
+         Example:
+            >>> stream_consumer.get_scalar_state('some_state')
+            This will return a state where type is 'Any'
+
+            >>> stream_consumer.get_scalar_state('some_state', lambda missing_key: return 1)
+            this will return a state where type is 'Any', with an integer 1 (zero) as default when
+            value has not been set yet. The lambda function will be invoked with 'get_state_type_check' key to determine type
+
+            >>> stream_consumer.get_scalar_state('some_state', lambda missing_key: return {}, float)
+            this will return a state where type is a specific type, with default value
+
+            >>> stream_consumer.get_scalar_state('some_state', state_type=float)
+            this will return a state where type is a float with a default value of that type
+        """
+
+        return self.get_state_manager().get_scalar_state(state_name, default_value_factory, state_type)
 
     def get_state_manager(self) -> StreamStateManager:
         """

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -6,9 +6,9 @@ import shutil
 import fileinput
 from typing import List
 
-version = "0.5.4.0"
-informal_version = "0.5.4.0"
-nuget_version = "0.5.4.0"
+version = "0.5.5.0"
+informal_version = "0.5.5.0-dev1"
+nuget_version = "0.5.5.0-dev1"
 
 
 def updatecsproj(projfilepath):


### PR DESCRIPTION
``` python 
def on_dataframe_received_handler(stream_consumer: qx.StreamConsumer, data: qx.TimeseriesData):

    stream_state = stream_consumer.get_scalar_state("total_rpm", lambda x: 0) # default value for state name.

    for row in data.timestamps:

        rpm = row.parameters["EngineRPM"].numeric_value

        stream_state.value += rpm

        row.add_value("total_rpm", stream_state.value)
```