### PR TITLE
Adds GetOrAddTimestamp methods and overwrite overloads for AddValue.

### DIFF
--- a/src/CsharpClient/QuixStreams.Streaming/Models/StreamProducer/TimeseriesDataBuilder.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/StreamProducer/TimeseriesDataBuilder.cs
@@ -3,7 +3,7 @@
 namespace QuixStreams.Streaming.Models.StreamProducer
 {
     /// <summary>
-    /// Builder for managing <see cref="TimeseriesDataTimestamp"/> instances on <see cref="TimeseriesBufferProducer"/> 
+    /// Builder for managing <see cref="TimeseriesDataTimestamp"/> instances on <see cref="TimeseriesBufferProducer"/>
     /// </summary>
     public class TimeseriesDataBuilder
     {
@@ -40,6 +40,19 @@ namespace QuixStreams.Streaming.Models.StreamProducer
         /// Adds new parameter value at the time the builder is created for
         /// </summary>
         /// <param name="parameterId">Parameter Id</param>
+        /// <param name="value">Numeric value</param>
+        /// <param name="overwrite">Indicates whether to overwrite the value for the parameter if it already exists.</param>
+        public TimeseriesDataBuilder AddValue(string parameterId, double value, bool overwrite)
+        {
+            this.timestamp.AddValue(parameterId, value, overwrite);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds new parameter value at the time the builder is created for
+        /// </summary>
+        /// <param name="parameterId">Parameter Id</param>
         /// <param name="value">String value</param>
         public TimeseriesDataBuilder AddValue(string parameterId, string value)
         {
@@ -47,7 +60,20 @@ namespace QuixStreams.Streaming.Models.StreamProducer
 
             return this;
         }
-        
+
+        /// <summary>
+        /// Adds new parameter value at the time the builder is created for
+        /// </summary>
+        /// <param name="parameterId">Parameter Id</param>
+        /// <param name="value">String value</param>
+        /// <param name="overwrite">Indicates whether to overwrite the value for the parameter if it already exists.</param>
+        public TimeseriesDataBuilder AddValue(string parameterId, string value, bool overwrite)
+        {
+            this.timestamp.AddValue(parameterId, value, overwrite);
+
+            return this;
+        }
+
         /// <summary>
         /// Adds new parameter value at the time the builder is created for
         /// </summary>
@@ -59,7 +85,19 @@ namespace QuixStreams.Streaming.Models.StreamProducer
 
             return this;
         }
-        
+
+        /// <summary>
+        /// Adds new parameter value at the time the builder is created for
+        /// </summary>
+        /// <param name="parameterId">Parameter Id</param>
+        /// <param name="value">Binary value</param>
+        /// <param name="overwrite">Indicates whether to overwrite the value for the parameter if it already exists.</param>
+        public TimeseriesDataBuilder AddValue(string parameterId, byte[] value, bool overwrite)
+        {
+            this.timestamp.AddValue(parameterId, value, overwrite);
+
+            return this;
+        }
 
         /// <summary>
         /// Adds a tag to the values.
@@ -72,7 +110,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
 
             return this;
         }
-        
+
         /// <summary>
         /// Adds tags to the values.
         /// </summary>

--- a/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesData.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesData.cs
@@ -20,13 +20,15 @@ namespace QuixStreams.Streaming.Models
 
         private int nextIndexRawData = 0;
         private bool removedTimestamps = false;
+        private Dictionary<int, long> timestampToIndexMap = new Dictionary<int, long>();
+        private Dictionary<long, TimeseriesDataTimestamp> existingTimestamps = new Dictionary<long, TimeseriesDataTimestamp>();
 
         internal bool[] epochsIncluded;
 
         /// <summary>
         /// Create a new empty Timeseries Data instance to allow create new timestamps and parameters values from scratch
         /// </summary>
-        /// <param name="capacity">The number of timestamps that the new Timeseries Data initially store. 
+        /// <param name="capacity">The number of timestamps that the new Timeseries Data initially store.
         /// Using this parameter when you know the number of Timestamps you need to store will increase the performance of the writing.</param>
         public TimeseriesData(int capacity = 10)
         {
@@ -372,11 +374,11 @@ namespace QuixStreams.Streaming.Models
                     dupeList.Add(index);
                 }
             }
-            
+
             if (dupes.Count == 0) return;
 
-            var uniqueTimestamps = new Dictionary<(long, long), int>();            
-            
+            var uniqueTimestamps = new Dictionary<(long, long), int>();
+
             foreach (var timestamp in dupes)
             {
                 foreach (var index in timestamp.Value)
@@ -491,6 +493,34 @@ namespace QuixStreams.Streaming.Models
         public TimeseriesDataTimestamp AddTimestampNanoseconds(long timeNanoseconds) => this.AddTimestampNanoseconds(timeNanoseconds, false);
 
         /// <summary>
+        /// Either starts adding a new set, or enables extending an existing set of parameter values at the given timestamp.
+        /// </summary>
+        /// <param name="dateTime">The datetime to use for adding new parameter values</param>
+        /// <returns>Timeseries data to add parameter values at the provided time</returns>
+        public TimeseriesDataTimestamp GetOrAddTimestamp(DateTime dateTime) => this.GetOrAddTimestampNanoseconds(dateTime.ToUnixNanoseconds(), true);
+
+        /// <summary>
+        /// Either starts adding a new set, or enables extending an existing set of parameter values at the given timestamp.
+        /// </summary>
+        /// <param name="timeSpan">The time since the <see name="epochOffset"/> to add the parameter values at</param>
+        /// <returns>Timeseries data to add parameter values at the provided time</returns>
+        public TimeseriesDataTimestamp GetOrAddTimestamp(TimeSpan timeSpan) => this.GetOrAddTimestampNanoseconds(timeSpan.ToNanoseconds(), false);
+
+        /// <summary>
+        /// Either starts adding a new set, or enables extending an existing set of parameter values at the given timestamp.
+        /// </summary>
+        /// <param name="timeMilliseconds">The time in milliseconds since the <see name="epochOffset"/> to add the parameter values at</param>
+        /// <returns>Timeseries data to add parameter values at the provided time</returns>
+        public TimeseriesDataTimestamp GetOrAddTimestampMilliseconds(long timeMilliseconds) => this.GetOrAddTimestampNanoseconds(timeMilliseconds * (long)1e6, false);
+
+        /// <summary>
+        /// Either starts adding a new set, or enables extending an existing set of parameter values at the given timestamp.
+        /// </summary>
+        /// <param name="timeNanoseconds">The time in nanoseconds since the  <see name="epochOffset"/> to add the parameter values at</param>
+        /// <returns>Timeseries data to add parameter values at the provided time</returns>
+        public TimeseriesDataTimestamp GetOrAddTimestampNanoseconds(long timeNanoseconds) => this.GetOrAddTimestampNanoseconds(timeNanoseconds, false);
+
+        /// <summary>
         /// Starts adding a new set of parameter values at the given timestamp.
         /// </summary>
         /// <param name="timeNanoseconds">The time in nanoseconds since the  <see name="epoch"/> to add the parameter values at</param>
@@ -498,7 +528,7 @@ namespace QuixStreams.Streaming.Models
         /// <returns>Timeseries data to add parameter values at the provided time</returns>
         internal TimeseriesDataTimestamp AddTimestampNanoseconds(long timeNanoseconds, bool epochIncluded)
         {
-            var sizeNeeded = this.timestampsList.Count() + 1;
+            var sizeNeeded = this.timestampsList.Count + 1;
             this.CheckRawDataSize(sizeNeeded);
 
             this.timestampsList.Add(this.nextIndexRawData);
@@ -507,14 +537,35 @@ namespace QuixStreams.Streaming.Models
             this.epochsIncluded[this.nextIndexRawData] = epochIncluded;
 
             var newTimestamp = new TimeseriesDataTimestamp(this, this.nextIndexRawData);
+            this.existingTimestamps[timeNanoseconds] = newTimestamp;
+            this.timestampToIndexMap[this.nextIndexRawData] = timeNanoseconds;
             this.nextIndexRawData++;
 
             return newTimestamp;
         }
 
+        /// <summary>
+        /// Either starts adding a new set, or enables extending an existing set of parameter values at the given timestamp.
+        /// </summary>
+        /// <param name="timeNanoseconds">The time in nanoseconds since the  <see name="epoch"/> to add the parameter values at</param>
+        /// <param name="epochIncluded">Epoch offset is included in the timestamp</param>
+        /// <returns>Timeseries data to add parameter values at the provided time</returns>
+        internal TimeseriesDataTimestamp GetOrAddTimestampNanoseconds(long timeNanoseconds, bool epochIncluded)
+        {
+            if (!existingTimestamps.TryGetValue(timeNanoseconds, out var timestamp))
+            {
+                // AddTimestampNanoseconds updates existingTimestamps.
+                timestamp = AddTimestampNanoseconds(timeNanoseconds, epochIncluded);
+            }
+            return timestamp;
+        }
+
         internal void RemoveTimestamp(int index)
         {
             this.timestampsList.RemoveAt(index);
+            var timestamp = this.timestampToIndexMap[index];
+            this.timestampToIndexMap.Remove(index);
+            this.existingTimestamps.Remove(timestamp);
             this.removedTimestamps = true;
         }
 

--- a/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesDataTimestamp.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesDataTimestamp.cs
@@ -37,7 +37,7 @@ namespace QuixStreams.Streaming.Models
         {
             get
             {
-                return !this.TimeseriesData.epochsIncluded[this.timestampRawIndex] 
+                return !this.TimeseriesData.epochsIncluded[this.timestampRawIndex]
                     ? this.TimeseriesData.rawData.Timestamps[this.timestampRawIndex] + this.TimeseriesData.rawData.Epoch
                     : this.TimeseriesData.rawData.Timestamps[this.timestampRawIndex];
             }
@@ -82,6 +82,19 @@ namespace QuixStreams.Streaming.Models
         /// <returns>This instance</returns>
         public TimeseriesDataTimestamp AddValue(string parameterId, double value)
         {
+            return AddValue(parameterId, value, overwrite: true);
+        }
+
+        /// <summary>
+        /// Adds a new numeric value.
+        /// </summary>
+        /// <param name="parameterId">Parameter Id</param>
+        /// <param name="value">Numeric value</param>
+        /// <param name="overwrite">Indicates whether to overwrite the value for the parameter if it already exists.</param>
+        /// <returns>This instance</returns>
+        public TimeseriesDataTimestamp AddValue(string parameterId, double value, bool overwrite)
+        {
+            var valueExists = false;
             if (!this.TimeseriesData.rawData.NumericValues.TryGetValue(parameterId, out var values))
             {
                 values = new double?[this.TimeseriesData.rawData.Timestamps.Length];
@@ -89,8 +102,15 @@ namespace QuixStreams.Streaming.Models
 
                 this.TimeseriesData.parameterList[parameterId] = new Parameter(parameterId, values);
             }
+            else
+            {
+                valueExists = values[this.timestampRawIndex] != null;
+            }
 
-            values[this.timestampRawIndex] = value;
+            if (overwrite || !valueExists)
+            {
+                values[this.timestampRawIndex] = value;
+            }
 
             return this;
         }
@@ -103,6 +123,19 @@ namespace QuixStreams.Streaming.Models
         /// <returns>This instance</returns>
         public TimeseriesDataTimestamp AddValue(string parameterId, string value)
         {
+            return AddValue(parameterId, value, overwrite: true);
+        }
+
+        /// <summary>
+        /// Adds a new string value.
+        /// </summary>
+        /// <param name="parameterId">Parameter Id</param>
+        /// <param name="value">String value</param>
+        /// <param name="overwrite">Indicates whether to overwrite the value for the parameter if it already exists.</param>
+        /// <returns>This instance</returns>
+        public TimeseriesDataTimestamp AddValue(string parameterId, string value, bool overwrite)
+        {
+            var valueExists = false;
             if (!this.TimeseriesData.rawData.StringValues.TryGetValue(parameterId, out var values))
             {
                 values = new string[this.TimeseriesData.rawData.Timestamps.Length];
@@ -110,8 +143,15 @@ namespace QuixStreams.Streaming.Models
 
                 this.TimeseriesData.parameterList[parameterId] = new Parameter(parameterId, values);
             }
+            else
+            {
+                valueExists = values[this.timestampRawIndex] != null;
+            }
 
-            values[this.timestampRawIndex] = value;
+            if (overwrite || !valueExists)
+            {
+                values[this.timestampRawIndex] = value;
+            }
 
             return this;
         }
@@ -120,10 +160,23 @@ namespace QuixStreams.Streaming.Models
         /// Adds a new binary value.
         /// </summary>
         /// <param name="parameterId">Parameter Id</param>
-        /// <param name="value">String value</param>
+        /// <param name="value">Byte array value</param>
         /// <returns>This instance</returns>
         public TimeseriesDataTimestamp AddValue(string parameterId, byte[] value)
         {
+            return AddValue(parameterId, value, overwrite: true);
+        }
+
+        /// <summary>
+        /// Adds a new binary value.
+        /// </summary>
+        /// <param name="parameterId">Parameter Id</param>
+        /// <param name="value">Byte array value</param>
+        /// <param name="overwrite">Indicates whether to overwrite the value for the parameter if it already exists.</param>
+        /// <returns>This instance</returns>
+        public TimeseriesDataTimestamp AddValue(string parameterId, byte[] value, bool overwrite)
+        {
+            var valueExists = false;
             if (!this.TimeseriesData.rawData.BinaryValues.TryGetValue(parameterId, out var values))
             {
                 values = new byte[this.TimeseriesData.rawData.Timestamps.Length][];
@@ -131,8 +184,15 @@ namespace QuixStreams.Streaming.Models
 
                 this.TimeseriesData.parameterList[parameterId] = new Parameter(parameterId, values);
             }
+            else
+            {
+                valueExists = values[this.timestampRawIndex] != null;
+            }
 
-            values[this.timestampRawIndex] = value;
+            if (overwrite || !valueExists)
+            {
+                values[this.timestampRawIndex] = value;
+            }
 
             return this;
         }
@@ -152,6 +212,26 @@ namespace QuixStreams.Streaming.Models
             if (valueType == ParameterValueType.Numeric) this.AddValue(parameterId, value.NumericValue ?? 0);
             else if (valueType == ParameterValueType.String) this.AddValue(parameterId, value.StringValue);
             else if (valueType == ParameterValueType.Binary) this.AddValue(parameterId, value.BinaryValue);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a new value.
+        /// </summary>
+        /// <param name="parameterId">Parameter Id</param>
+        /// <param name="value">The value</param>
+        /// <param name="overwrite">Indicates whether to overwrite the value for the parameter if it already exists.</param>
+        /// <returns>This instance</returns>
+        public TimeseriesDataTimestamp AddValue(string parameterId, ParameterValue value, bool overwrite)
+        {
+            if (value.Value == null) return this;
+
+            var valueType = value.Type;
+
+            if (valueType == ParameterValueType.Numeric) this.AddValue(parameterId, value.NumericValue ?? 0, overwrite);
+            else if (valueType == ParameterValueType.String) this.AddValue(parameterId, value.StringValue, overwrite);
+            else if (valueType == ParameterValueType.Binary) this.AddValue(parameterId, value.BinaryValue, overwrite);
 
             return this;
         }
@@ -194,7 +274,7 @@ namespace QuixStreams.Streaming.Models
 
             return this;
         }
-        
+
         /// <summary>
         /// Copies the tags from the specified dictionary.
         /// Conflicting tags will be overwritten
@@ -223,7 +303,7 @@ namespace QuixStreams.Streaming.Models
 
             return this;
         }
-        
+
         internal TimeseriesDataRaw ConvertToTimeseriesDataRaw()
         {
             return new TimeseriesData(new List<TimeseriesDataTimestamp>{this}).rawData;


### PR DESCRIPTION
Proposal for solution to issue #143 - _Add ability to optionally overwrite values for existing timestamps when adding to the buffer_, enabling the following C# API:

```CSharp
for (var i = 0; i < samples.Timestamps.Length; i++)
{
    var sampleTimestamp = samples.Timestamps[i];
    var value = samples.Values[i];
    var status = samples.Status[i];

    var timestamp = producer.Timeseries.Buffer.GetOrAddTimestampNanoseconds(sampleTimestamp);
    timestamp.AddValue(parameterId, value, overwrite: status); // Only overwrite *existing* samples if status is true
}
```