### PR TITLE
Fix segmentation faults in tests

### DIFF
--- a/src/CsharpClient/QuixStreams.Telemetry.UnitTests/Models/Telemetry/CodecRegistryShould.cs
+++ b/src/CsharpClient/QuixStreams.Telemetry.UnitTests/Models/Telemetry/CodecRegistryShould.cs
@@ -33,7 +33,7 @@ namespace QuixStreams.Telemetry.UnitTests.Models.Telemetry
         }
         
         [Fact]
-        public void Register_ImprovedJsonTimeseriesData_ShouldRegisterAsExpected()
+        public void Register_CompactJsonForBetterPerformance_ShouldRegisterAsExpected()
         {
             // Act
             CodecRegistry.Register(CodecType.CompactJsonForBetterPerformance);
@@ -41,10 +41,10 @@ namespace QuixStreams.Telemetry.UnitTests.Models.Telemetry
             // Assert
             var codecs = Transport.Registry.CodecRegistry.RetrieveCodecs(new ModelKey("TimeseriesData"));
             codecs.Count().Should().Be(3);
-            codecs.Should().Contain(x => x is DefaultJsonCodec<TimeseriesDataRaw>); // for reading
-            codecs.Should().Contain(x => x is TimeseriesDataJsonCodec);
+            codecs.Should().Contain(x => x is TimeseriesDataReadableCodec); // for reading
+            codecs.Should().Contain(x => x is TimeseriesDataJsonCodec); // for reading
             codecs.Should().Contain(x => x is TimeseriesDataProtobufCodec); // for reading
-            codecs.First().GetType().Should().Be(typeof(TimeseriesDataJsonCodec)); // for writing
+            codecs.First().GetType().Should().Be(typeof(TimeseriesDataReadableCodec)); // for writing
         }
         
         [Fact]
@@ -56,10 +56,10 @@ namespace QuixStreams.Telemetry.UnitTests.Models.Telemetry
             // Assert
             var codecs = Transport.Registry.CodecRegistry.RetrieveCodecs(new ModelKey("TimeseriesData"));
             codecs.Count().Should().Be(3);
-            codecs.Should().Contain(x => x is DefaultJsonCodec<TimeseriesDataRaw>); 
+            codecs.Should().Contain(x => x is TimeseriesDataReadableCodec); // for reading
             codecs.Should().Contain(x => x is TimeseriesDataJsonCodec); // for reading
             codecs.Should().Contain(x => x is TimeseriesDataProtobufCodec); // for reading
-            codecs.First().GetType().Should().Be(typeof(DefaultJsonCodec<TimeseriesDataRaw>)); // for writing
+            codecs.First().GetType().Should().Be(typeof(TimeseriesDataJsonCodec)); // for writing
         }
         
         [Fact]

--- a/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/Parameters/Codecs/TimeseriesDataCustomJsonCodec.cs
+++ b/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/Parameters/Codecs/TimeseriesDataCustomJsonCodec.cs
@@ -127,11 +127,11 @@ namespace QuixStreams.Telemetry.Models.Telemetry.Parameters.Codecs
                 return new TimeseriesDataRaw
                 {
                     Epoch = epoch,
-                    Timestamps = timestamps.ToArray(),
-                    NumericValues = numericValues,
-                    StringValues = stringValues,
-                    BinaryValues = binaryValues,
-                    TagValues = tagValues
+                    Timestamps = timestamps?.ToArray() ?? Array.Empty<long>(),
+                    NumericValues = numericValues ?? new Dictionary<string, double?[]>(),
+                    StringValues = stringValues ?? new Dictionary<string, string[]>(),
+                    BinaryValues = binaryValues ?? new Dictionary<string, byte[][]>(),
+                    TagValues = tagValues ?? new Dictionary<string, string[]>()
                 };
             }
 

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/ExternalTypes/System/List.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/ExternalTypes/System/List.cs
@@ -120,7 +120,6 @@ public class ListInterop
             var target = InteropUtils.FromHPtr<IList>(dictionaryHPtr);
             var listType = target.GetType().GetGenericArguments()[0];
             var value = InteropUtils.PtrToObject(valuePtr, listType);
-            ;
             target.Add(value);
         }
         catch (Exception ex)

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
@@ -382,6 +382,7 @@ public class InteropUtils
     [UnmanagedCallersOnly(EntryPoint = "interoputils_pin_hptr_target")]
     public static IntPtr PinHPtrTarget(IntPtr ptr)
     {
+        LogDebug("Invoked interoputils_pin_hptr_target with HPtr: {0}", ptr);
         if (ptr == IntPtr.Zero)
         {
             if (DebugMode) Console.WriteLine($"Allocated null Ptr");
@@ -397,6 +398,7 @@ public class InteropUtils
     [UnmanagedCallersOnly(EntryPoint = "interoputils_get_pin_address")]
     public static IntPtr GetPinAddress(IntPtr pinnedPtr)
     {
+        LogDebug("Invoked interoputils_get_pin_address with Pinned Ptr: {0}", pinnedPtr);
         if (pinnedPtr == IntPtr.Zero) return IntPtr.Zero;
         var handler = GCHandle.FromIntPtr(pinnedPtr);
         return handler.AddrOfPinnedObject();
@@ -439,6 +441,7 @@ public class InteropUtils
     [UnmanagedCallersOnly(EntryPoint = "interoputils_free_hptr")]
     public static void FreeHPtr(IntPtr ptr)
     {
+        LogDebug("Invoked interoputils_free_hptr with HPtr: {0}", ptr);
         if (ptr == IntPtr.Zero) return; // exception maybe ? (however that might be a problem due to unmanaged nature)
         var handler = GCHandle.FromIntPtr(ptr);
         LogDebug("Freed Ptr: {0}", ptr);

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/MethodWriter.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/MethodWriter.cs
@@ -626,13 +626,14 @@ public class MethodWriter : BaseWriter
                     var type = arguments[index];
                     if (index != arguments.Length - 1 || !hasReturn)
                     {
+                        writer.Write($"InteropUtils.LogDebug($\"Parameter {index} is getting converted now.\");");
                         if (index != 0) invocationSb.Append(", ");
                         var name = $"arg{index}";
                         var result = WriteTypeConversion(writer, preFunctionWriter, type, true, name);
-                        //if (unmanagedType == typeof(IntPtr)) writer.Write($"Console.WriteLine(\"{this.methodWrittenDetails.EntryPoint} invoking with value ptr: \" + {result});"); // helpful for debug
-                        //else writer.Write($"Console.WriteLine(\"{this.methodWrittenDetails.EntryPoint} invoking with value: \" + {result});"); // helpful for debug
                         appendEmptyLineAfterConversions |= name != result;
                         invocationSb.Append(result);
+                        writer.Write($"InteropUtils.LogDebug($\"Parameter {index} for {this.methodWrittenDetails.EntryPoint} has value: {{{result}}}\");");
+
                     }
                 
                     if (index == arguments.Length - 1)

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/ExternalTypes/System/List.py
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/ExternalTypes/System/List.py
@@ -25,7 +25,7 @@ class List:
 
     # ctypes function return type//parameter fix
     interop_func = InteropUtils.get_function("list_get_value")
-    interop_func.argtypes = [c_void_p]
+    interop_func.argtypes = [c_void_p, c_int]
     interop_func.restype = c_void_p
     @staticmethod
     def GetValue(list_hptr: c_void_p, index: c_int) -> c_void_p:

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -1415,7 +1415,6 @@ class TestTimeseriesData(BaseIntegrationTest):
         assert_timeseries_data_equal(written_data, read_data)
         assert_timeseries_data_equal(read_data, written_data)
 
-    @pytest.mark.skip("TODO: Fix segmentation fault")
     def test_parameters_read_with_parameter_filter(self,
                                                    test_name,
                                                    topic_consumer_earliest,
@@ -1553,7 +1552,6 @@ class TestTimeseriesData(BaseIntegrationTest):
     def test_parameters_read_with_filter(self, topic_consumer_earliest, topic_producer):
         pass
 
-    @pytest.mark.skip('TODO: Fix segmentation fault')
     def test_parameters_read_with_filter_from_buffer_config(self,
                                                             test_name,
                                                             topic_consumer_earliest,
@@ -1707,7 +1705,6 @@ class TestStreamState(BaseIntegrationTest):
             'somevalue']
         assert {'key': 'value'} == object_state_somevalue
 
-    @pytest.mark.skip("TODO: Fix segmentation fault")
     def test_stream_state_used_from_data_handler(self,
                                                  test_name,
                                                  topic_producer,

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -1607,7 +1607,6 @@ class TestTimeseriesData(BaseIntegrationTest):
         assert special_func_invocation_count == 3
 
 
-@pytest.mark.skip("TODO: Fix segmentation fault")
 class TestRawData(BaseIntegrationTest):
     def test_raw_read_write(self, test_name, raw_topic_consumer, raw_topic_producer):
         # Arrange

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -1792,7 +1792,7 @@ class TestStreamState(BaseIntegrationTest):
             rolling_sum += i + 1
             assert rolling_sum == actual_values_sum[i]
 
-    @pytest.mark.skip('TODO: Fix segmentation fault')
+    @pytest.mark.skip('TODO: fix test hanging sometimes')
     def test_stream_state_committed_from_background_thread(self,
                                                            test_name,
                                                            topic_producer,

--- a/src/PythonClient/tests/quixstreams/unittests/models/test_netlist.py
+++ b/src/PythonClient/tests/quixstreams/unittests/models/test_netlist.py
@@ -5,7 +5,6 @@ import pytest
 from src.quixstreams.models.netlist import NetList
 
 
-@pytest.mark.skip('TODO: Fix the tests')
 class NetListTests(unittest.TestCase):
 
     def test_constructor_for_string(self):
@@ -19,7 +18,7 @@ class NetListTests(unittest.TestCase):
 
         net_list[0] = "test 3"
 
-        self.assertEqual(net_list[0], "test 3")
+        self.assertEqual("test 3", net_list[0])
 
     def test_delitem_single(self):
         net_list = NetList.constructor_for_string()
@@ -34,8 +33,8 @@ class NetListTests(unittest.TestCase):
 
         self.assertEqual(net_list.count(), 2)
 
-        self.assertEqual(net_list[0], "test")
-        self.assertEqual(net_list[1], "test 3")
+        self.assertEqual("test", net_list[0])
+        self.assertEqual("test 3", net_list[1])
 
     # def test_delitem_slice(self): # TODO
     #     net_list = NetList.constructor_for_string()
@@ -45,21 +44,25 @@ class NetListTests(unittest.TestCase):
     #     net_list.append("test 3")
     #     net_list.append("test 4")
     #
-    #     self.assertEqual(net_list.count(), 4)
+    #     self.assertEqual(4, net_list.count())
     #
     #     del net_list[1:2]
     #
-    #     self.assertEqual(net_list.count(), 2)
+    #     self.assertEqual(2, net_list.count())
     #
-    #     self.assertEqual(net_list[0], "test")
-    #     self.assertEqual(net_list[1], "test 4")
+    #     self.assertEqual("test", net_list[0])
+    #     self.assertEqual("test 4", net_list[1])
 
     def test_append(self):
         net_list = NetList.constructor_for_string()
 
         net_list.append("test")
+        net_list.append("test2")
+        net_list.append("test3")
 
-        self.assertEqual(net_list[0], "test")
+        self.assertEqual("test", net_list[0])
+        self.assertEqual("test2", net_list[1])
+        self.assertEqual("test3", net_list[2])
 
     def test_remove(self):
         net_list = NetList.constructor_for_string()
@@ -73,8 +76,8 @@ class NetListTests(unittest.TestCase):
         net_list.remove("test 2")
 
         self.assertEqual(net_list.count(), 2)
-        self.assertEqual(net_list[0], "test")
-        self.assertEqual(net_list[1], "test 3")
+        self.assertEqual("test", net_list[0])
+        self.assertEqual("test 3", net_list[1])
 
     def test_clear(self):
         net_list = NetList.constructor_for_string()
@@ -82,21 +85,20 @@ class NetListTests(unittest.TestCase):
         net_list.append("test 2")
         net_list.append("test 3")
 
-        self.assertEqual(net_list.count(), 3)
+        self.assertEqual(3, net_list.count())
 
         net_list.clear()
 
-        self.assertEqual(net_list.count(), 0)
+        self.assertEqual(0, net_list.count())
 
 
-@pytest.mark.skip('TODO: Fix the tests')
 class NetReadOnlyListTests(unittest.TestCase):
 
     def test_getitem(self):
         net_list = NetList.constructor_for_string()
         net_list.append("test")
 
-        self.assertEqual(net_list[0], "test")
+        self.assertEqual("test", net_list[0])
 
     def test_contains(self):
         net_list = NetList.constructor_for_string()
@@ -109,13 +111,13 @@ class NetReadOnlyListTests(unittest.TestCase):
         net_list = NetList.constructor_for_string()
         net_list.append("test")
 
-        self.assertEqual(net_list.count(), 1)
+        self.assertEqual(1, net_list.count())
 
         net_list.append("test 2")
         net_list.append("test 3")
         net_list.append("test 4")
 
-        self.assertEqual(net_list.count(), 4)
+        self.assertEqual(4, net_list.count())
 
     def test_iter(self):
         net_list = NetList.constructor_for_string()
@@ -127,9 +129,9 @@ class NetReadOnlyListTests(unittest.TestCase):
         for i, v in enumerate(net_list):
             python_list[i] = v
 
-        self.assertEqual(python_list[0], "test")
-        self.assertEqual(python_list[1], "test 2")
-        self.assertEqual(python_list[2], "test 3")
+        self.assertEqual("test", python_list[0])
+        self.assertEqual("test 2", python_list[1])
+        self.assertEqual("test 3", python_list[2])
 
     def test_iter2(self):
         net_list = NetList.constructor_for_string()
@@ -141,6 +143,6 @@ class NetReadOnlyListTests(unittest.TestCase):
         for v in net_list:
             pythonlist.append(v)
 
-        self.assertEqual(pythonlist[0], "test")
-        self.assertEqual(pythonlist[1], "test 2")
-        self.assertEqual(pythonlist[2], "test 3")
+        self.assertEqual("test", pythonlist[0])
+        self.assertEqual("test 2", pythonlist[1])
+        self.assertEqual("test 3", pythonlist[2])


### PR DESCRIPTION
- Fix segmentation faults in python (and therefore tests) related to the new json serializer
- Reenabled all tests marked as segfault issue, local testing resulted in no more segfault
- Fix net_list incorrect function arguments, now the tests pass
- Fix several C# tests