### PR TITLE
Handle nulls better in State store

### DIFF
--- a/src/CsharpClient/QuixStreams.State.UnitTests/DictionaryStateShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/DictionaryStateShould.cs
@@ -203,5 +203,41 @@ namespace QuixStreams.State.UnitTests
             StateValue value = state["key"];
             value.StringValue.Should().BeEquivalentTo("value");
         }
+        
+        [Fact]
+        public void Update_WithNullValue_ShouldNotBeInStorage()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState(storage);
+            state.Add("key", new StateValue(new byte[] {1,2,3}));
+            state.Flush();
+            storage.ContainsKey("key").Should().BeTrue();
+
+            // Act
+            state["key"] = new StateValue((byte[])null);
+            state.Flush();
+
+            // Assert
+            storage.ContainsKey("key").Should().BeFalse();
+        }
+        
+        [Fact]
+        public void Update_WithNull_ShouldNotBeInStorage()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState(storage);
+            state.Add("key", new StateValue(new byte[] {1,2,3}));
+            state.Flush();
+            storage.ContainsKey("key").Should().BeTrue();
+
+            // Act
+            state["key"] = null;
+            state.Flush();
+
+            // Assert
+            storage.ContainsKey("key").Should().BeFalse();
+        }
     }
 }

--- a/src/CsharpClient/QuixStreams.State.UnitTests/ScalarStateShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/ScalarStateShould.cs
@@ -107,5 +107,59 @@ namespace QuixStreams.State.UnitTests
             // Assert
             state.Value.StringValue.Should().BeEquivalentTo("value");
         }
+        
+        [Fact]
+        public void Update_WithNullByteValue_ShouldBeRemovedFromState()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new ScalarState(storage);
+            state.Value = new StateValue(new byte[] {1,2,3});
+            state.Flush();
+            storage.ContainsKey(ScalarState.StorageKey).Should().BeTrue();
+
+            // Act
+            state.Value = new StateValue((byte[])null);
+            state.Flush();
+
+            // Assert
+            storage.ContainsKey(ScalarState.StorageKey).Should().BeFalse();
+        }
+        
+        [Fact]
+        public void Update_WithNullObjectValue_ShouldBeRemovedFromState()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new ScalarState(storage);
+            state.Value = new StateValue(new byte[] {1,2,3}, StateValue.StateType.Object);
+            state.Flush();
+            storage.ContainsKey(ScalarState.StorageKey).Should().BeTrue();
+
+            // Act
+            state.Value = new StateValue(null, StateValue.StateType.Object);
+            state.Flush();
+
+            // Assert
+            storage.ContainsKey(ScalarState.StorageKey).Should().BeFalse();
+        }
+        
+        [Fact]
+        public void Update_WithNullStringValue_ShouldBeRemovedFromState()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new ScalarState(storage);
+            state.Value = new StateValue("something");
+            state.Flush();
+            storage.ContainsKey(ScalarState.StorageKey).Should().BeTrue();
+
+            // Act
+            state.Value = new StateValue((string)null);
+            state.Flush();
+
+            // Assert
+            storage.ContainsKey(ScalarState.StorageKey).Should().BeFalse();
+        }
     }
 }

--- a/src/CsharpClient/QuixStreams.State.UnitTests/StateTemplatedShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/StateTemplatedShould.cs
@@ -451,6 +451,26 @@ public class StateTemplatedShould
             var value = state["key"];
             value.Should().BeEquivalentTo("value");
         }
+        
+        [Fact]
+        public void Add_WithNullValue_ShouldRemoveFromState()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<object>(storage);
+            state.Add("key", "value");
+            state.Flush();
+            storage.ContainsKey("key").Should().BeTrue();
+
+            // Act
+            state["key"] = null;
+            state.Flush();
+
+            // Assert
+            var value = state["key"];
+            value.Should().BeNull();
+            storage.ContainsKey("key").Should().BeFalse();
+        }
 
         public class CustomClass : IEquatable<CustomClass>
         {

--- a/src/CsharpClient/QuixStreams.State.UnitTests/StateValueShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/StateValueShould.cs
@@ -20,6 +20,7 @@ namespace QuixStreams.State.UnitTests
             value.Type.Should().BeEquivalentTo(StateValue.StateType.Bool);
             value.BoolValue.Should().Be(true);
         }
+        
         [Fact]
         public void TestString()
         {
@@ -27,6 +28,17 @@ namespace QuixStreams.State.UnitTests
             value.Type.Should().BeEquivalentTo(StateValue.StateType.String);
             value.StringValue.Should().Be("TestStr312");
         }
+        
+        [Fact]
+        public void TestString_WithNull_ShouldReturnNull()
+        {
+            var value = new StateValue((string)null);
+            value.Type.Should().BeEquivalentTo(StateValue.StateType.String);
+            value.StringValue.Should().BeNull();
+            value.IsNull().Should().BeTrue();
+        }
+
+        
         [Fact]
         public void TestDouble()
         {
@@ -42,6 +54,28 @@ namespace QuixStreams.State.UnitTests
             var value = new StateValue(bytes);
             value.Type.Should().BeEquivalentTo(StateValue.StateType.Binary);
             value.BinaryValue.Should().BeEquivalentTo(bytes, options => options.WithStrictOrdering());
+        }
+        
+        [Fact]
+        public void TestBinary_WithNull_ShouldReturnNull()
+        {
+            var bytes = (byte[])null;
+
+            var value = new StateValue(bytes);
+            value.Type.Should().BeEquivalentTo(StateValue.StateType.Binary);
+            value.BinaryValue.Should().BeNull();
+            value.IsNull().Should().BeTrue();
+        }
+        
+        [Fact]
+        public void TestObject_WithValue_ShouldReturnValue()
+        {
+            var bytes = (byte[])null;
+
+            var value = new StateValue(bytes, StateValue.StateType.Object);
+            value.Type.Should().BeEquivalentTo(StateValue.StateType.Object);
+            value.BinaryValue.Should().BeNull();
+            value.IsNull().Should().BeTrue();
         }
 
 

--- a/src/CsharpClient/QuixStreams.State/ScalarState.cs
+++ b/src/CsharpClient/QuixStreams.State/ScalarState.cs
@@ -101,7 +101,7 @@ namespace QuixStreams.State
                 this.clearBeforeFlush = false;
             }
             
-            if (Value == null)
+            if (Value == null || Value.IsNull())
             {
                 this.lastFlushHash = default;
                 storage.Remove(StorageKey);

--- a/src/CsharpClient/QuixStreams.State/Serializers/ByteValueSerializer.cs
+++ b/src/CsharpClient/QuixStreams.State/Serializers/ByteValueSerializer.cs
@@ -46,16 +46,31 @@ namespace QuixStreams.State.Serializers
                             {
                                 byte[] data = value.BinaryValue;
                                 writer.Write(TypeBinary);
-                                writer.Write(data.Length);
-                                writer.Write(data);
+
+                                if (data != null)
+                                {
+                                    writer.Write(data.Length);
+                                    writer.Write(data);
+                                }
+                                else
+                                {
+                                    writer.Write(-1);
+                                }
                             }
                             break;
                         case StateValue.StateType.Object:
                         {
-                            byte[] data = value.BinaryValue;
+                            byte[] data = value.BinaryValue ?? Array.Empty<byte>();
                             writer.Write(TypeObject);
-                            writer.Write(data.Length);
-                            writer.Write(data);
+                            if (data != null)
+                            {
+                                writer.Write(data.Length);
+                                writer.Write(data);
+                            }
+                            else
+                            {
+                                writer.Write(-1);
+                            }
                         }
                             break;                        
                         case StateValue.StateType.Bool:
@@ -81,7 +96,7 @@ namespace QuixStreams.State.Serializers
                             break;
                         case StateValue.StateType.String:
                             {
-                                string data = value.StringValue;
+                                string data = value.StringValue ?? ""; // null would throw arg exc
                                 writer.Write(TypeString);
                                 writer.Write(data);
                             }
@@ -143,13 +158,15 @@ namespace QuixStreams.State.Serializers
                         case TypeBinary:
                             {
                                 int dataLength = reader.ReadInt32();
+                                if (dataLength == -1) return new StateValue((byte[])null);
                                 return new StateValue(reader.ReadBytes(dataLength));
                             }
                         case TypeObject:
-                        {
-                            int dataLength = reader.ReadInt32();
-                            return new StateValue(reader.ReadBytes(dataLength), StateValue.StateType.Object);
-                        }                        
+                            {
+                                int dataLength = reader.ReadInt32();
+                                if (dataLength == -1) return new StateValue((byte[])null);
+                                return new StateValue(reader.ReadBytes(dataLength), StateValue.StateType.Object);
+                            }                        
                         case TypeBool:
                             {
                                 return new StateValue(reader.ReadBoolean());

--- a/src/CsharpClient/QuixStreams.State/StateValue.cs
+++ b/src/CsharpClient/QuixStreams.State/StateValue.cs
@@ -189,12 +189,35 @@ namespace QuixStreams.State
             }
         }
 
-        public override int GetHashCode()
+        /// <summary>
+        /// Returns whether the State value is null or not if the allows
+        /// </summary>
+        /// <returns>True if null, false otherwise</returns>
+        public bool IsNull()
         {
-            switch (Type)
+            switch (this.Type)
             {
                 case StateType.Binary:
-                    return this.BinaryValue.GetHashCode();
+                    return this.BinaryValue == null;
+                case StateType.Long:
+                case StateType.Bool:
+                case StateType.Double:
+                    return false;
+                case StateType.String:
+                    return this.StringValue == null;
+                case StateType.Object:
+                    return this.BinaryValue == null;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            switch (this.Type)
+            {
+                case StateType.Binary:
+                    return this.BinaryValue?.GetHashCode() ?? 0;
                 case StateType.Long:
                     return this.LongValue.GetHashCode();
                 case StateType.Bool:
@@ -202,9 +225,9 @@ namespace QuixStreams.State
                 case StateType.Double:
                     return this.DoubleValue.GetHashCode();
                 case StateType.String:
-                    return this.StringValue.GetHashCode();
+                    return this.StringValue?.GetHashCode() ?? 0;
                 case StateType.Object:
-                    return this.BinaryValue.GetHashCode();
+                    return this.BinaryValue?.GetHashCode() ?? 0;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/CsharpClient/QuixStreams.Streaming/QuixApi/WorkspaceBrokerTypeJsonConverter.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/QuixApi/WorkspaceBrokerTypeJsonConverter.cs
@@ -4,7 +4,7 @@ using QuixStreams.Streaming.QuixApi.Portal;
 
 namespace QuixStreams.Streaming.QuixApi
 {
-    public class WorkspaceBrokerTypeJsonConverter : JsonConverter
+    internal class WorkspaceBrokerTypeJsonConverter : JsonConverter
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/Helpers/AssemblyHelpers.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/Helpers/AssemblyHelpers.cs
@@ -74,7 +74,17 @@ public class AssemblyHelpers
     /// <returns></returns>
     public static List<Type> GetPublicAssemblyTypes(Assembly assembly)
     {
-        return assembly.GetTypes().Where(y => (y.IsPublic || y.IsNestedPublic) && Utils.IsInteropSupported(y)).ToList();
+        return assembly.GetTypes().Where(y => (y.IsPublic || IsPublicNestedType(y)) && Utils.IsInteropSupported(y)).ToList();
+    }
+
+    private static bool IsPublicNestedType(Type type)
+    {
+        if (type == null) return false;
+        if (!type.IsNested) return false;
+        if (!type.IsNestedPublic) return false;
+        if (type.DeclaringType == null) return false;
+        if (!type.DeclaringType.IsPublic && !IsPublicNestedType(type.DeclaringType)) return false;
+        return true;
     }
 
     /// <summary>

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.5.dev3"
+package_version = "0.5.5.dev4"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.5.0"
-informal_version = "0.5.5.0-dev3"
-nuget_version = "0.5.5.0-dev3"
+informal_version = "0.5.5.0-dev4"
+nuget_version = "0.5.5.0-dev4"
 
 
 def updatecsproj(projfilepath):


### PR DESCRIPTION
State store will handle nulls and null state values better from now on.

Instead of saving as null and possibly running into null refs at places, it will be removed from the underlying storage. Added extra null checks for safety.

(unrelated) Also fixed accessibility of a class used for internal deserialization as it broke interop generation.