### PR TITLE
Fix python state segfaults

### DIFF
--- a/src/CsharpClient/QuixStreams.State.UnitTests/BaseCrudShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/BaseCrudShould.cs
@@ -9,8 +9,6 @@ namespace QuixStreams.State.UnitTests
 {
     public abstract class BaseCRUDShould
     {
-        
-        
         protected abstract BaseFileStorage GetStorage();
 
         protected async Task testLong(BaseFileStorage storage, string key, long inp)

--- a/src/CsharpClient/QuixStreams.State.UnitTests/StateTemplatedShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/StateTemplatedShould.cs
@@ -9,496 +9,493 @@ using Xunit;
 namespace QuixStreams.State.UnitTests;
 
 public class StateTemplatedShould
-{ 
-    public class StateShould
+{
+    [Fact]
+    public void Constructor_ShouldCreateState()
     {
-        [Fact]
-        public void Constructor_ShouldCreateState()
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<int>(storage);
+
+        state.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Constructor_WithNullStateStorage_ShouldThrowArgumentNullException()
+    {
+        Action nullTopicName = () => new DictionaryState<int>((IStateStorage)null);
+
+        nullTopicName.Should().Throw<ArgumentNullException>().WithMessage("*storage*");
+    }
+
+
+    [Theory]
+    [InlineData("TestKey", "TestValue")]
+    public void StringConversion_ShouldStoreAndRetrieveCorrectly(string key, string value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<string>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<string>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", 3.14)]
+    public void DoubleConversion_ShouldStoreAndRetrieveCorrectly(string key, double value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<double>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<double>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", 3.146546597897)]
+    public void DecimalConversion_ShouldStoreAndRetrieveCorrectly(string key, decimal value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<decimal>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<decimal>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", 42.0f)]
+    public void FloatConversion_ShouldStoreAndRetrieveCorrectly(string key, float value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<float>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<float>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", true)]
+    [InlineData("TestKey", false)]
+    public void BoolConversion_ShouldStoreAndRetrieveCorrectly(string key, bool value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<bool>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<bool>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+
+    [Theory]
+    [InlineData("TestKey", 'A')]
+    public void CharConversion_ShouldStoreAndRetrieveCorrectly(string key, char value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<char>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<char>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", 1234567890123456789L)]
+    public void LongConversion_ShouldStoreAndRetrieveCorrectly(string key, long value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<long>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<long>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", 1234567890123456789UL)]
+    public void UlongConversion_ShouldStoreAndRetrieveCorrectly(string key, ulong value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<ulong>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<ulong>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+
+    [Theory]
+    [InlineData("TestKey", 42)]
+    public void IntConversion_ShouldStoreAndRetrieveCorrectly(string key, int value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<int>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<int>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", 42u)]
+    public void UintConversion_ShouldStoreAndRetrieveCorrectly(string key, uint value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<uint>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<uint>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", (short)42)]
+    public void ShortConversion_ShouldStoreAndRetrieveCorrectly(string key, short value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<short>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<short>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", (ushort)42u)]
+    public void UshortConversion_ShouldStoreAndRetrieveCorrectly(string key, ushort value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<ushort>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<ushort>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", (byte)42)]
+    public void ByteConversion_ShouldStoreAndRetrieveCorrectly(string key, byte value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<byte>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<byte>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData("TestKey", (sbyte)42u)]
+    public void SbyteConversion_ShouldStoreAndRetrieveCorrectly(string key, sbyte value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<sbyte>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<sbyte>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetDateTimeValues))]
+    public void DatetimeConversion_ShouldStoreAndRetrieveCorrectly(string key, DateTime value)
+    {
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<DateTime>(storage);
+
+        state[key] = value;
+
+        state[key].Should().Be(value);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<DateTime>(storage);
+
+        state2[key].Should().Be(value);
+    }
+
+    public static IEnumerable<object[]> GetDateTimeValues()
+    {
+        yield return new object[] { "someKey", DateTime.UtcNow };
+    }
+
+    [Fact]
+    public void CustomClassConversion_ShouldStoreAndRetrieveCorrectly()
+    {
+        var storage = new InMemoryStorage();
+        var key = "TestKey";
+        var state = new DictionaryState<CustomClass>(storage);
+
+        var customObject = new CustomClass { Id = 1, Name = "TestObject" };
+        state[key] = customObject;
+
+        state[key].Should().BeEquivalentTo(customObject);
+
+        state.Flush();
+
+        var state2 = new DictionaryState<CustomClass>(storage);
+
+        state2[key].Should().BeEquivalentTo(customObject);
+    }
+
+    [Fact]
+    public void ListCustomClassConversion_ShouldStoreAndRetrieveCorrectly()
+    {
+        var storage = new InMemoryStorage();
+        var key = "TestKey";
+        var state = new DictionaryState<List<CustomClass>>(storage);
+        state.Clear();
+
+        var customObject = new CustomClass { Id = 1, Name = "TestObject" };
+        state[key] = new List<CustomClass>();
+        state[key].Add(customObject);
+        state[key].Add(customObject);
+
+        state[key].Count.Should().Be(2);
+        state[key].All(y => y == customObject).Should().BeTrue();
+
+        state.Flush();
+
+        var state2 = new DictionaryState<List<CustomClass>>(storage);
+
+        state2[key].Count.Should().Be(2);
+        state2[key].All(y => y.IsSameOrEqualTo(customObject)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void OperationWithElement_ShouldStoreAndRetrieveCorrectly()
+    {
+        var storage = new InMemoryStorage();
+        var key = "TestKey";
+        var state = new DictionaryState<int>(storage);
+
+        state[key] += 2;
+        state[key] -= 1;
+        state[key] *= 8;
+
+        state[key].Should().Be(8);
+    }
+
+
+    [Fact]
+    public void Clear_ShouldRemoveAllValues()
+    {
+        var storage = new InMemoryStorage();
+        // Arrange
+        var state = new DictionaryState<string>(storage);
+        state.Add("Key1", "Value1");
+        state.Add("Key2", "Value2");
+
+        // Act
+        state.Clear();
+        state.Count.Should().Be(0);
+        state.Flush();
+        var state2 = new DictionaryState<string>(storage);
+
+        // Assert
+        state2.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void ComplexModifications_ShouldHaveExpectedValues()
+    {
+        var storage = new InMemoryStorage();
+        // Arrange
+        var state = new DictionaryState<string>(storage);
+
+        // Act 1
+        state.Add("Key1", "Value1"); // will keep as is, before clear
+        state.Add("Key2", "Value2"); // will remove, before clear
+        state.Add("Key3", "Value3"); // will override, before clear
+        state["Key4"] = "Value4"; // leave as is
+        state.Remove("Key2");
+        state["Key3"] = "Value3b";
+        state.Clear();
+        state.Add("Key5", "Value5"); // will keep as is
+        state.Add("Key6", "Value6"); // will remove
+        state.Add("Key7", "Value7"); // will override
+        state["Key8"] = "Value8"; // leave as is
+        state.Remove("Key5");
+        state["Key6"] = "Value6b";
+
+        // Assert 1
+        state.Count.Should().Be(3);
+        state["Key6"].Should().Be("Value6b");
+        state["Key7"].Should().Be("Value7");
+        state["Key8"].Should().Be("Value8");
+
+        // Act 2
+        state.Flush();
+        state["Key8"] = "Value8";
+        state.Flush();
+
+        // Assert 2
+        state.Count.Should().Be(3);
+        state["Key6"].Should().Be("Value6b");
+        state["Key7"].Should().Be("Value7");
+        state["Key8"].Should().Be("Value8");
+
+        // Act 3
+        var state2 = new DictionaryState<string>(storage);
+
+        // Assert 3
+        state2.Count.Should().Be(3);
+        state2["Key6"].Should().Be("Value6b");
+        state2["Key7"].Should().Be("Value7");
+        state2["Key8"].Should().Be("Value8");
+    }
+
+    [Fact]
+    public void Reset_Modified_ShouldResetToSaved()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<string>(storage);
+        state.Add("key", "value");
+        state.Flush();
+
+        // Act
+        state["key"] = "updatedValue";
+        state.Reset();
+
+        // Assert
+        var value = state["key"];
+        value.Should().BeEquivalentTo("value");
+    }
+
+    [Fact]
+    public void Add_WithNullValue_ShouldRemoveFromState()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var state = new DictionaryState<object>(storage);
+        state.Add("key", "value");
+        state.Flush();
+        storage.ContainsKey("key").Should().BeTrue();
+
+        // Act
+        state["key"] = null;
+        state.Flush();
+
+        // Assert
+        var value = state["key"];
+        value.Should().BeNull();
+        storage.ContainsKey("key").Should().BeFalse();
+    }
+
+    public class CustomClass : IEquatable<CustomClass>
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public bool Equals(CustomClass other)
         {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<int>(storage);
-
-            state.Should().NotBeNull();
-        }
-
-        [Fact]
-        public void Constructor_WithNullStateStorage_ShouldThrowArgumentNullException()
-        {
-            Action nullTopicName = () => new DictionaryState<int>((IStateStorage)null);
-
-            nullTopicName.Should().Throw<ArgumentNullException>().WithMessage("*storage*");
-        }
-        
-        
-        [Theory]
-        [InlineData("TestKey", "TestValue")]
-        public void StringConversion_ShouldStoreAndRetrieveCorrectly(string key, string value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<string>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<string>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-
-        [Theory]
-        [InlineData("TestKey", 3.14)]
-        public void DoubleConversion_ShouldStoreAndRetrieveCorrectly(string key, double value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<double>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<double>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        [Theory]
-        [InlineData("TestKey", 3.146546597897)]
-        public void DecimalConversion_ShouldStoreAndRetrieveCorrectly(string key, decimal value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<decimal>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 =  new DictionaryState<decimal>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        [Theory]
-        [InlineData("TestKey", 42.0f)]
-        public void FloatConversion_ShouldStoreAndRetrieveCorrectly(string key, float value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<float>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 =  new DictionaryState<float>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-
-        [Theory]
-        [InlineData("TestKey", true)]
-        [InlineData("TestKey", false)]
-        public void BoolConversion_ShouldStoreAndRetrieveCorrectly(string key, bool value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<bool>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<bool>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-
-
-        [Theory]
-        [InlineData("TestKey", 'A')]
-        public void CharConversion_ShouldStoreAndRetrieveCorrectly(string key, char value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<char>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<char>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-
-        [Theory]
-        [InlineData("TestKey", 1234567890123456789L)]
-        public void LongConversion_ShouldStoreAndRetrieveCorrectly(string key, long value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<long>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<long>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        [Theory]
-        [InlineData("TestKey", 1234567890123456789UL)]
-        public void UlongConversion_ShouldStoreAndRetrieveCorrectly(string key, ulong value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<ulong>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-
-            state.Flush();
-            
-            var state2 = new DictionaryState<ulong>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        
-        [Theory]
-        [InlineData("TestKey", 42)]
-        public void IntConversion_ShouldStoreAndRetrieveCorrectly(string key, int value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<int>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<int>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        [Theory]
-        [InlineData("TestKey", 42u)]
-        public void UintConversion_ShouldStoreAndRetrieveCorrectly(string key, uint value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<uint>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<uint>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        [Theory]
-        [InlineData("TestKey", (short)42)]
-        public void ShortConversion_ShouldStoreAndRetrieveCorrectly(string key, short value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<short>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<short>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        [Theory]
-        [InlineData("TestKey", (ushort)42u)]
-        public void UshortConversion_ShouldStoreAndRetrieveCorrectly(string key, ushort value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<ushort>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<ushort>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        [Theory]
-        [InlineData("TestKey", (byte)42)]
-        public void ByteConversion_ShouldStoreAndRetrieveCorrectly(string key, byte value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<byte>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<byte>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        [Theory]
-        [InlineData("TestKey", (sbyte)42u)]
-        public void SbyteConversion_ShouldStoreAndRetrieveCorrectly(string key, sbyte value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<sbyte>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<sbyte>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        [Theory]
-        [MemberData(nameof(GetDateTimeValues))]
-        public void DatetimeConversion_ShouldStoreAndRetrieveCorrectly(string key, DateTime value)
-        {
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<DateTime>(storage);
-
-            state[key] = value;
-
-            state[key].Should().Be(value);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<DateTime>(storage);
-            
-            state2[key].Should().Be(value);
-        }
-        
-        public static IEnumerable<object[]> GetDateTimeValues()
-        {
-            yield return new object[] { "someKey", DateTime.UtcNow};
-        }
-        
-        [Fact]
-        public void CustomClassConversion_ShouldStoreAndRetrieveCorrectly()
-        {
-            var storage = new InMemoryStorage();
-            var key = "TestKey";
-            var state = new DictionaryState<CustomClass>(storage);
-
-            var customObject = new CustomClass { Id = 1, Name = "TestObject" };
-            state[key] = customObject;
-
-            state[key].Should().BeEquivalentTo(customObject);
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<CustomClass>(storage);
-            
-            state2[key].Should().BeEquivalentTo(customObject);
-        }
-        
-        [Fact]
-        public void ListCustomClassConversion_ShouldStoreAndRetrieveCorrectly()
-        {
-            var storage = new InMemoryStorage();
-            var key = "TestKey";
-            var state = new DictionaryState<List<CustomClass>>(storage);
-            state.Clear();
-
-            var customObject = new CustomClass { Id = 1, Name = "TestObject" };
-            state[key] = new List<CustomClass>();
-            state[key].Add(customObject);
-            state[key].Add(customObject);
-
-            state[key].Count.Should().Be(2);
-            state[key].All(y=> y == customObject).Should().BeTrue();
-            
-            state.Flush();
-            
-            var state2 = new DictionaryState<List<CustomClass>>(storage);
-            
-            state2[key].Count.Should().Be(2);
-            state2[key].All(y=> y.IsSameOrEqualTo(customObject)).Should().BeTrue();
-        }
-        
-        [Fact]
-        public void OperationWithElement_ShouldStoreAndRetrieveCorrectly()
-        {
-            var storage = new InMemoryStorage();
-            var key = "TestKey";
-            var state = new DictionaryState<int>(storage);
-
-            state[key] += 2;
-            state[key] -= 1;
-            state[key] *= 8;
-
-            state[key].Should().Be(8);
-        }
-        
-        
-        [Fact]
-        public void Clear_ShouldRemoveAllValues()
-        {
-            var storage = new InMemoryStorage();
-            // Arrange
-            var state = new DictionaryState<string>(storage);
-            state.Add("Key1", "Value1");
-            state.Add("Key2", "Value2");
-
-            // Act
-            state.Clear();
-            state.Count.Should().Be(0);
-            state.Flush();
-            var state2 = new DictionaryState<string>(storage);
-
-            // Assert
-            state2.Count.Should().Be(0);
-        }
-        
-        [Fact]
-        public void ComplexModifications_ShouldHaveExpectedValues()
-        {
-            var storage = new InMemoryStorage();
-            // Arrange
-            var state = new DictionaryState<string>(storage);
-            
-            // Act 1
-            state.Add("Key1", "Value1"); // will keep as is, before clear
-            state.Add("Key2", "Value2"); // will remove, before clear
-            state.Add("Key3", "Value3"); // will override, before clear
-            state["Key4"] = "Value4"; // leave as is
-            state.Remove("Key2");
-            state["Key3"] = "Value3b";
-            state.Clear();
-            state.Add("Key5", "Value5"); // will keep as is
-            state.Add("Key6", "Value6"); // will remove
-            state.Add("Key7", "Value7"); // will override
-            state["Key8"] = "Value8"; // leave as is
-            state.Remove("Key5");
-            state["Key6"] = "Value6b";
-            
-            // Assert 1
-            state.Count.Should().Be(3);
-            state["Key6"].Should().Be("Value6b");
-            state["Key7"].Should().Be("Value7");
-            state["Key8"].Should().Be("Value8");
-            
-            // Act 2
-            state.Flush();
-            state["Key8"] = "Value8";
-            state.Flush();
-            
-            // Assert 2
-            state.Count.Should().Be(3);
-            state["Key6"].Should().Be("Value6b");
-            state["Key7"].Should().Be("Value7");
-            state["Key8"].Should().Be("Value8");
-
-            // Act 3
-            var state2 = new DictionaryState<string>(storage);
-
-            // Assert 3
-            state2.Count.Should().Be(3);
-            state2["Key6"].Should().Be("Value6b");
-            state2["Key7"].Should().Be("Value7");
-            state2["Key8"].Should().Be("Value8");
-        }
-        
-        [Fact]
-        public void Reset_Modified_ShouldResetToSaved()
-        {
-            // Arrange
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<string>(storage);
-            state.Add("key", "value");
-            state.Flush();
-
-            // Act
-            state["key"] = "updatedValue";
-            state.Reset();
-
-            // Assert
-            var value = state["key"];
-            value.Should().BeEquivalentTo("value");
-        }
-        
-        [Fact]
-        public void Add_WithNullValue_ShouldRemoveFromState()
-        {
-            // Arrange
-            var storage = new InMemoryStorage();
-            var state = new DictionaryState<object>(storage);
-            state.Add("key", "value");
-            state.Flush();
-            storage.ContainsKey("key").Should().BeTrue();
-
-            // Act
-            state["key"] = null;
-            state.Flush();
-
-            // Assert
-            var value = state["key"];
-            value.Should().BeNull();
-            storage.ContainsKey("key").Should().BeFalse();
-        }
-
-        public class CustomClass : IEquatable<CustomClass>
-        {
-            public int Id { get; set; }
-            public string Name { get; set; }
-
-            public bool Equals(CustomClass other)
+            if (other == null)
             {
-                if (other == null)
-                {
-                    return false;
-                }
-
-                return this.Id == other.Id && this.Name == other.Name;
+                return false;
             }
 
-            public override bool Equals(object obj)
-            {
-                return this.Equals(obj as CustomClass);
-            }
+            return this.Id == other.Id && this.Name == other.Name;
+        }
 
-            public override int GetHashCode()
-            {
-                int hash = 17;
-                hash = hash * 31 + this.Id.GetHashCode();
-                hash = hash * 31 + (this.Name == null ? 0 : this.Name.GetHashCode());
-                return hash;
-            }
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as CustomClass);
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 17;
+            hash = hash * 31 + this.Id.GetHashCode();
+            hash = hash * 31 + (this.Name == null ? 0 : this.Name.GetHashCode());
+            return hash;
         }
     }
 }

--- a/src/CsharpClient/QuixStreams.Streaming/TopicProducer.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/TopicProducer.cs
@@ -17,6 +17,7 @@ namespace QuixStreams.Streaming
         private readonly ConcurrentDictionary<string, Lazy<IStreamProducer>> streams = new ConcurrentDictionary<string, Lazy<IStreamProducer>>();
         private readonly IKafkaProducer kafkaProducer;
         private readonly ILogger<TopicProducer> logger = Logging.CreateLogger<TopicProducer>();
+        private bool disposed = false;
 
         /// <inheritdoc />
         public event EventHandler OnDisposed;
@@ -119,6 +120,8 @@ namespace QuixStreams.Streaming
         /// </summary>
         public void Dispose()
         {
+            if (disposed) return;
+            disposed = true;
             this.Flush();
             this.kafkaProducer?.Dispose();
             this.OnDisposed?.Invoke(this, EventArgs.Empty);

--- a/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/Parameters/Codecs/TimeseriesDataCustomJsonCodec.cs
+++ b/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/Parameters/Codecs/TimeseriesDataCustomJsonCodec.cs
@@ -114,7 +114,7 @@ namespace QuixStreams.Telemetry.Models.Telemetry.Parameters.Codecs
                                 stringValues = ParseDict(reader, ref size, o => (string)o);
                                 break;
                             case "BinaryValues":
-                                binaryValues = ParseDict(reader, ref size, o => Convert.FromBase64String((string)o));
+                                binaryValues = ParseDict(reader, ref size, o => o == null ? null : Convert.FromBase64String((string)o));
                                 break;
                             case "TagValues":
                                 tagValues = ParseDict(reader, ref size, o => (string)o);

--- a/src/InteropGenerator/Quix.InteropGenerator.LogChecker/Evaluator.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator.LogChecker/Evaluator.cs
@@ -20,7 +20,15 @@ public class Evaluator
             {
                 case LogParser.PtrAllocationLineParser ptrAllocation:
                     allocationCount++;
-                    remainingAllocations.Add(ptrAllocation.Ptr, ptrAllocation);
+                    try
+                    {
+                        remainingAllocations.Add(ptrAllocation.Ptr, ptrAllocation);
+                    }
+                    catch
+                    {
+                        oddStuff.Add((parser, $"Allocated pointer {ptrAllocation.Ptr} multiple times without being deallocated first"));
+                    }
+
                     allocations[ptrAllocation.Ptr] = ptrAllocation;
                     break;
                 case LogParser.PtrFreedLineParser ptrFreed:

--- a/src/InteropGenerator/Quix.InteropGenerator.LogChecker/LogParser.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator.LogChecker/LogParser.cs
@@ -32,7 +32,7 @@ public class LogParser
             if (splitIndex > -1)
             {
                 var timePart = line.Substring(0, splitIndex + 1);
-                var linePart = line.Substring(splitIndex + timeSplitText.Length);
+                var linePart = line.Substring(splitIndex + timeSplitText.Length).TrimStart();
                 line = linePart;
             }
             foreach (var parserPair in parsers)

--- a/src/InteropGenerator/Quix.InteropGenerator.LogChecker/LogParser.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator.LogChecker/LogParser.cs
@@ -21,10 +21,19 @@ public class LogParser
         while (!sr.EndOfStream)
         {
             var line = await sr.ReadLineAsync();
-            if (line.Contains('\0'))
+            if (line!.Contains('\0'))
             {
                 line = line.Replace("\0", "");
                 Console.WriteLine($"Line {lineNumber} has '\\0' char in it, expect problems");
+            }
+            
+            const string timeSplitText = "]  ";
+            var splitIndex = line.IndexOf(timeSplitText);
+            if (splitIndex > -1)
+            {
+                var timePart = line.Substring(0, splitIndex + 1);
+                var linePart = line.Substring(splitIndex + timeSplitText.Length);
+                line = linePart;
             }
             foreach (var parserPair in parsers)
             {

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/ExceptionHandlerWriter.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/ExceptionHandlerWriter.cs
@@ -8,12 +8,14 @@ internal class ExceptionHandlerWriter<T> : IDisposable where T: IIndentWriter, I
     private readonly T contentWriter;
     private readonly bool hasReturnValue;
     private readonly Action<T> onExceptionCallback;
+    private readonly Action<T> onFinallyCallback;
 
-    public ExceptionHandlerWriter(T contentWriter, bool hasReturnValue, Action<T> onExceptionCallback = null)
+    public ExceptionHandlerWriter(T contentWriter, bool hasReturnValue, Action<T> onExceptionCallback = null, Action<T> onFinallyCallback = null)
     {
         this.contentWriter = contentWriter;
         this.hasReturnValue = hasReturnValue;
         this.onExceptionCallback = onExceptionCallback;
+        this.onFinallyCallback = onFinallyCallback;
 
         contentWriter.Write("try");
         contentWriter.Write("{");
@@ -33,6 +35,13 @@ internal class ExceptionHandlerWriter<T> : IDisposable where T: IIndentWriter, I
         }
         contentWriter.Write("InteropUtils.RaiseException(ex);");
         if (hasReturnValue) contentWriter.Write("return default;");
+        contentWriter.DecrementIndent();
+        contentWriter.Write("}");
+        if (onFinallyCallback == null) return;
+        contentWriter.Write("finally");
+        contentWriter.Write("{");
+        contentWriter.IncrementIndent();
+        onFinallyCallback(contentWriter);
         contentWriter.DecrementIndent();
         contentWriter.Write("}");
     }

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/ExceptionHandlerWriter.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/ExceptionHandlerWriter.cs
@@ -6,14 +6,14 @@ namespace Quix.InteropGenerator.Writers.CsharpInteropWriter;
 internal class ExceptionHandlerWriter<T> : IDisposable where T: IIndentWriter, IContentWriter
 {
     private readonly T contentWriter;
-    private readonly bool hasReturnValue;
+    private readonly Func<Type> getReturnType;
     private readonly Action<T> onExceptionCallback;
     private readonly Action<T> onFinallyCallback;
 
-    public ExceptionHandlerWriter(T contentWriter, bool hasReturnValue, Action<T> onExceptionCallback = null, Action<T> onFinallyCallback = null)
+    public ExceptionHandlerWriter(T contentWriter, Func<Type> getReturnType, Action<T> onExceptionCallback = null, Action<T> onFinallyCallback = null)
     {
         this.contentWriter = contentWriter;
-        this.hasReturnValue = hasReturnValue;
+        this.getReturnType = getReturnType;
         this.onExceptionCallback = onExceptionCallback;
         this.onFinallyCallback = onFinallyCallback;
 
@@ -34,7 +34,7 @@ internal class ExceptionHandlerWriter<T> : IDisposable where T: IIndentWriter, I
             onExceptionCallback(contentWriter);
         }
         contentWriter.Write("InteropUtils.RaiseException(ex);");
-        if (hasReturnValue) contentWriter.Write("return default;");
+        if (getReturnType() != typeof(void)) contentWriter.Write("return default;");
         contentWriter.DecrementIndent();
         contentWriter.Write("}");
         if (onFinallyCallback == null) return;

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/ExternalTypes/System/Dictionary.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/ExternalTypes/System/Dictionary.cs
@@ -90,7 +90,6 @@ public class DictionaryInterop
 
     private static IntPtr DictionaryToUptr(IDictionary dictionary)
     {
-        InteropUtils.LogDebug("Dictionary");
         var count = dictionary.Count;
         if (count == 0)
         {

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 
 // leave it as InteropHelpers.Interop.
 namespace InteropHelpers.Interop;
@@ -34,7 +35,8 @@ public class InteropUtils
         // in order to not have potential for incorrect log write
         lock (debugLogsLock)
         {
-            debuglogs.Value.Write("[" + DateTime.Now.ToString("YYYY-MM-dd HH:mm:ss.fff") + "]  ");
+            int threadId = Thread.CurrentThread.ManagedThreadId;
+            debuglogs.Value.Write($"[{DateTime.Now:yy-MM-dd HH:mm:ss.fff}][{threadId}]  ");
             if (debugLogIndent > 0) debuglogs.Value.Write(new string(' ', debugLogIndent));
             debuglogs.Value.WriteLine(string.Format(format, @params));
 

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
@@ -34,7 +34,7 @@ public class InteropUtils
         // in order to not have potential for incorrect log write
         lock (debugLogsLock)
         {
-            debuglogs.Value.Write("[" + DateTime.Now.ToString("YY-MM-dd HH:mm:ss.fff") + "]  ");
+            debuglogs.Value.Write("[" + DateTime.Now.ToString("YYYY-MM-dd HH:mm:ss.fff") + "]  ");
             if (debugLogIndent > 0) debuglogs.Value.Write(new string(' ', debugLogIndent));
             debuglogs.Value.WriteLine(string.Format(format, @params));
 

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/InteropHelpers/InteropUtils.cs
@@ -34,6 +34,7 @@ public class InteropUtils
         // in order to not have potential for incorrect log write
         lock (debugLogsLock)
         {
+            debuglogs.Value.Write("[" + DateTime.Now.ToString("YY-MM-dd HH:mm:ss.fff") + "]  ");
             if (debugLogIndent > 0) debuglogs.Value.Write(new string(' ', debugLogIndent));
             debuglogs.Value.WriteLine(string.Format(format, @params));
 
@@ -390,7 +391,7 @@ public class InteropUtils
     [UnmanagedCallersOnly(EntryPoint = "interoputils_log_debug_indentdecr")]
     public static void LogDebugIndentDecrInterop()
     {
-        LogDebugIndentIncr();
+        LogDebugIndentDecr();
     }
     
     

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/MethodWriter.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/MethodWriter.cs
@@ -90,6 +90,9 @@ public class MethodWriter : BaseWriter
                 }
                 else delayedWriter.Write($"InteropUtils.LogDebug($\"Arg {argName.Key} ({argName.Value}) has value: {{{argName.Key}}}\");");   
             }
+        }, (w) =>
+        {
+            writer.Write($"InteropUtils.LogDebug($\"Invoked entrypoint {this.methodWrittenDetails.EntryPoint}\");");    
         });
 
         var paramNames = new Dictionary<string, string>();
@@ -643,6 +646,7 @@ public class MethodWriter : BaseWriter
                         invocationSb.Append(");");
                         if (hasReturn) invocationSb.Insert(0, "var result = ");
                         writer.Write(invocationSb.ToString());
+                        writer.Write($"InteropUtils.LogDebug($\"Invoked handler {{(IntPtr){sourceName}}} for {this.methodWrittenDetails.EntryPoint}\");");
                         if (hasReturn)
                         {
                             var result = WriteTypeConversion(writer, preFunctionWriter, type, false, "result");

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/MethodWriter.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/MethodWriter.cs
@@ -79,6 +79,7 @@ public class MethodWriter : BaseWriter
     {
         using var iw = new IndentWriter<DelayedWriter>(writer);
         writer.Write($"InteropUtils.LogDebug($\"Invoking entrypoint {this.methodWrittenDetails.EntryPoint}\");");
+        writer.Write($"InteropUtils.LogDebugIndentIncr();");
         using var ehw = new ExceptionHandlerWriter<DelayedWriter>(writer, this.methodWrittenDetails.ReturnType != typeof(void), delayedWriter =>
         {
             delayedWriter.Write($"InteropUtils.LogDebug(\"Exception in {this.methodWrittenDetails.EntryPoint}\");");
@@ -92,6 +93,7 @@ public class MethodWriter : BaseWriter
             }
         }, (w) =>
         {
+            writer.Write($"InteropUtils.LogDebugIndentDecr();");
             writer.Write($"InteropUtils.LogDebug($\"Invoked entrypoint {this.methodWrittenDetails.EntryPoint}\");");    
         });
 

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/InteropUtils.py
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/InteropUtils.py
@@ -36,6 +36,12 @@ class InteropUtils(object):
 
         interoputils_log_debug = getattr(lib, "interoputils_log_debug")
         interoputils_log_debug.argtypes = [c_void_p]
+        
+        interoputils_log_debug_indentincr = getattr(lib, "interoputils_log_debug_indentincr")
+        interoputils_log_debug.argtypes = []
+        
+        interoputils_log_debug_indentdecr = getattr(lib, "interoputils_log_debug_indentdecr")
+        interoputils_log_debug.argtypes = []
 
         interoputils_alloc_uptr = getattr(lib, "interoputils_alloc_uptr")
         interoputils_alloc_uptr.argtypes = [ctypes.c_int32]
@@ -170,6 +176,28 @@ class InteropUtils(object):
         message_ptr = InteropUtils.utf8_to_ptr(message)
 
         InteropUtils.invoke("interoputils_log_debug", message_ptr)
+        
+    @staticmethod
+    def log_debug_indent_increment():
+        """
+        Increments the indent for log messages
+        """
+
+        if not InteropUtils.DebugEnabled:
+            return
+
+        InteropUtils.invoke("interoputils_log_debug_indentincr")
+           
+    @staticmethod
+    def log_debug_indent_decrement():
+        """
+        Decrements the indent for log messages
+        """
+
+        if not InteropUtils.DebugEnabled:
+            return
+
+        InteropUtils.invoke("interoputils_log_debug_indentdecr")
 
     @staticmethod
     def enable_debug():

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/InteropUtils.py
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/InteropUtils.py
@@ -1,10 +1,13 @@
 import ctypes
+import inspect
 import threading
 from ctypes import c_void_p
 import os
 import sysconfig
 from typing import Callable
 
+import traceback
+import sys
 
 class InteropException(Exception):
 
@@ -16,6 +19,7 @@ class InteropException(Exception):
 
 
 class InteropUtils(object):
+
     DebugEnabled = False
 
     lib = None
@@ -24,6 +28,7 @@ class InteropUtils(object):
     __last_exception = None
     __interop_exception_handler_ref = None
     __exception_handler = None
+    __logged_ptrs = []
 
     @staticmethod
     def set_lib(lib, with_debug_enabled=False):
@@ -36,10 +41,10 @@ class InteropUtils(object):
 
         interoputils_log_debug = getattr(lib, "interoputils_log_debug")
         interoputils_log_debug.argtypes = [c_void_p]
-        
+
         interoputils_log_debug_indentincr = getattr(lib, "interoputils_log_debug_indentincr")
         interoputils_log_debug.argtypes = []
-        
+
         interoputils_log_debug_indentdecr = getattr(lib, "interoputils_log_debug_indentdecr")
         interoputils_log_debug.argtypes = []
 
@@ -144,7 +149,7 @@ class InteropUtils(object):
     def __set_exception_callback(callback: Callable[[InteropException], None]):
         """
         Sets the exception handler for the library
-        
+
         callback: Callable[[InteropException], None]
             The callback which takes InteropException and returns nothing
         """
@@ -165,7 +170,7 @@ class InteropUtils(object):
     def log_debug(message: str):
         """
         Logs debug message if debugging is enabled
-        
+
         message: str
             The message to log
         """
@@ -176,7 +181,7 @@ class InteropUtils(object):
         message_ptr = InteropUtils.utf8_to_ptr(message)
 
         InteropUtils.invoke("interoputils_log_debug", message_ptr)
-        
+
     @staticmethod
     def log_debug_indent_increment():
         """
@@ -187,7 +192,7 @@ class InteropUtils(object):
             return
 
         InteropUtils.invoke("interoputils_log_debug_indentincr")
-           
+
     @staticmethod
     def log_debug_indent_decrement():
         """
@@ -268,8 +273,26 @@ class InteropUtils(object):
         hptr: c_void_p
             Pointer to .Net GC Handle
         """
+        if InteropUtils.DebugEnabled and hptr in InteropUtils.__logged_ptrs:
+            stack_trace = inspect.stack()
+
+            # Format the stack trace into a readable string
+            InteropUtils.log_debug(f"Freeing HPTR {hptr}")
+            msg = ""
+            for frame_info in stack_trace:
+                msg = msg + f"File: {frame_info.filename}, Line: {frame_info.lineno}, Function: {frame_info.function}\n"
+
+            InteropUtils.log_debug(msg)
 
         return InteropUtils.invoke("interoputils_free_hptr", hptr)
+
+    @staticmethod
+    def add_logged(ptr: c_void_p):
+        """
+        Adds the specified pointer to the logged pointer list, so it is easier to trace where it is used
+        """
+        if ptr not in InteropUtils.__logged_ptrs:
+            InteropUtils.__logged_ptrs.append(ptr)
 
     @staticmethod
     def free_uptr(uptr: c_void_p) -> None:

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.5.dev4"
+package_version = "0.5.5.dev5"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/src/quixstreams/helpers/nativedecorator.py
+++ b/src/PythonClient/src/quixstreams/helpers/nativedecorator.py
@@ -21,15 +21,18 @@ def nativedecorator(cls):
         if self._nativedecorator_finalized:
             return
 
-        InteropUtils.log_debug(f"Finalizing {cls.__name__}")
+        ptr = getattr(self, "_interop").get_interop_ptr__()
+
+        InteropUtils.log_debug(f"Finalizing {cls.__name__} ({ptr.value})")
         InteropUtils.log_debug_indent_increment()
 
         self._nativedecorator_finalized = True
         orig_finalizer(self)
+
         getattr(self, "_interop").dispose_ptr__()
 
         InteropUtils.log_debug_indent_decrement()
-        InteropUtils.log_debug(f"Finalized {cls.__name__}")
+        InteropUtils.log_debug(f"Finalized {cls.__name__} ({ptr.value})")
 
 
     def new_del(self):
@@ -46,7 +49,9 @@ def nativedecorator(cls):
 
     def new_dispose(self, *args, **kwargs):
 
-        InteropUtils.log_debug(f"Disposing {cls.__name__}")
+        ptr = getattr(self, "_interop").get_interop_ptr__()
+
+        InteropUtils.log_debug(f"Disposing {cls.__name__} ({ptr.value})")
         InteropUtils.log_debug_indent_increment()
 
         if self._nativedecorator_finalized:
@@ -56,7 +61,7 @@ def nativedecorator(cls):
         new_finalizerfunc(self)
 
         InteropUtils.log_debug_indent_decrement()
-        InteropUtils.log_debug(f"Disposed {cls.__name__}")
+        InteropUtils.log_debug(f"Disposed {cls.__name__} ({ptr.value})")
 
     cls.__init__ = new_init
     cls._finalizerfunc = new_finalizerfunc

--- a/src/PythonClient/src/quixstreams/helpers/nativedecorator.py
+++ b/src/PythonClient/src/quixstreams/helpers/nativedecorator.py
@@ -1,3 +1,6 @@
+from ..native.Python.InteropHelpers.InteropUtils import InteropUtils
+
+
 def _dummy(*args, **kwargs):
     pass
 
@@ -18,9 +21,16 @@ def nativedecorator(cls):
         if self._nativedecorator_finalized:
             return
 
+        InteropUtils.log_debug(f"Finalizing {cls.__name__}")
+        InteropUtils.log_debug_indent_increment()
+
         self._nativedecorator_finalized = True
         orig_finalizer(self)
         getattr(self, "_interop").dispose_ptr__()
+
+        InteropUtils.log_debug_indent_decrement()
+        InteropUtils.log_debug(f"Finalized {cls.__name__}")
+
 
     def new_del(self):
         new_finalizerfunc(self)
@@ -35,10 +45,18 @@ def nativedecorator(cls):
         return result
 
     def new_dispose(self, *args, **kwargs):
+
+        InteropUtils.log_debug(f"Disposing {cls.__name__}")
+        InteropUtils.log_debug_indent_increment()
+
         if self._nativedecorator_finalized:
             return
 
         orig_dispose(self, *args, **kwargs)
+        new_finalizerfunc(self)
+
+        InteropUtils.log_debug_indent_decrement()
+        InteropUtils.log_debug(f"Disposed {cls.__name__}")
 
     cls.__init__ = new_init
     cls._finalizerfunc = new_finalizerfunc

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/streameventsconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/streameventsconsumer.py
@@ -35,10 +35,10 @@ class StreamEventsConsumer(object):
 
         # define events and their ref holder
         self._on_data_received = None
-        self._on_data_received_refs = None  # keeping reference to avoid GC
+        self._on_data_received_refs = None  # keeping references to avoid GC
 
         self._on_definitions_changed = None
-        self._on_definitions_changed_refs = None  # keeping reference to avoid GC
+        self._on_definitions_changed_refs = None  # keeping references to avoid GC
 
     def _finalizerfunc(self):
         self._on_data_received_dispose()

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/streameventsconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/streameventsconsumer.py
@@ -35,10 +35,10 @@ class StreamEventsConsumer(object):
 
         # define events and their ref holder
         self._on_data_received = None
-        self._on_data_received_ref = None  # keeping reference to avoid GC
+        self._on_data_received_refs = None  # keeping reference to avoid GC
 
         self._on_definitions_changed = None
-        self._on_definitions_changed_ref = None  # keeping reference to avoid GC
+        self._on_definitions_changed_refs = None  # keeping reference to avoid GC
 
     def _finalizerfunc(self):
         self._on_data_received_dispose()
@@ -65,8 +65,8 @@ class StreamEventsConsumer(object):
             value: The first parameter is the stream the event is received for. The second is the event.
         """
         self._on_data_received = value
-        if self._on_data_received_ref is None:
-            self._on_data_received_ref = self._interop.add_OnDataReceived(self._on_data_received_wrapper)
+        if self._on_data_received_refs is None:
+            self._on_data_received_refs = self._interop.add_OnDataReceived(self._on_data_received_wrapper)
 
     def _on_data_received_wrapper(self, stream_hptr, args_hptr):
         # To avoid unnecessary overhead and complication, we're using the stream instance we already have
@@ -79,9 +79,9 @@ class StreamEventsConsumer(object):
             traceback.print_exc()
 
     def _on_data_received_dispose(self):
-        if self._on_data_received_ref is not None:
-            self._interop.remove_OnDataReceived(self._on_data_received_ref)
-            self._on_data_received_ref = None
+        if self._on_data_received_refs is not None:
+            self._interop.remove_OnDataReceived(self._on_data_received_refs[0])
+            self._on_data_received_refs = None
 
     # endregion on_data_received
 
@@ -106,8 +106,8 @@ class StreamEventsConsumer(object):
             value: The first parameter is the stream the event definitions changed for.
         """
         self._on_definitions_changed = value
-        if self._on_definitions_changed_ref is None:
-            self._on_definitions_changed_ref = self._interop.add_OnDefinitionsChanged(
+        if self._on_definitions_changed_refs is None:
+            self._on_definitions_changed_refs = self._interop.add_OnDefinitionsChanged(
                 self._on_definitions_changed_wrapper)
 
     def _on_definitions_changed_wrapper(self, stream_hptr, args_hptr):
@@ -120,9 +120,9 @@ class StreamEventsConsumer(object):
             traceback.print_exc()
 
     def _on_definitions_changed_dispose(self):
-        if self._on_definitions_changed_ref is not None:
-            self._interop.remove_OnDefinitionsChanged(self._on_definitions_changed_ref)
-            self._on_definitions_changed_ref = None
+        if self._on_definitions_changed_refs is not None:
+            self._interop.remove_OnDefinitionsChanged(self._on_definitions_changed_refs[0])
+            self._on_definitions_changed_refs = None
 
     # endregion on_definitions_changed
 

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/streampropertiesconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/streampropertiesconsumer.py
@@ -36,7 +36,7 @@ class StreamPropertiesConsumer(object):
 
         # Define events and their reference holders
         self._on_changed = None
-        self._on_changed_refs = None  # Keeping reference to avoid garbage collection
+        self._on_changed_refs = None  # Keeping references to avoid garbage collection
 
         self._metadata = None
         self._parents = None

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/streampropertiesconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/streampropertiesconsumer.py
@@ -36,7 +36,7 @@ class StreamPropertiesConsumer(object):
 
         # Define events and their reference holders
         self._on_changed = None
-        self._on_changed_ref = None  # Keeping reference to avoid garbage collection
+        self._on_changed_refs = None  # Keeping reference to avoid garbage collection
 
         self._metadata = None
         self._parents = None
@@ -69,8 +69,8 @@ class StreamPropertiesConsumer(object):
             value: The first parameter is the stream it is invoked for.
         """
         self._on_changed = value
-        if self._on_changed_ref is None:
-            self._on_changed_ref = self._interop.add_OnChanged(self._on_changed_wrapper)
+        if self._on_changed_refs is None:
+            self._on_changed_refs = self._interop.add_OnChanged(self._on_changed_wrapper)
 
     def _on_changed_wrapper(self, sender_hptr, args_hptr):
         # To avoid unnecessary overhead and complication, we're using the instances we already have
@@ -82,9 +82,9 @@ class StreamPropertiesConsumer(object):
             traceback.print_exc()
 
     def _on_changed_dispose(self):
-        if self._on_changed_ref is not None:
-            self._interop.remove_OnChanged(self._on_changed_ref)
-            self._on_changed_ref = None
+        if self._on_changed_refs is not None:
+            self._interop.remove_OnChanged(self._on_changed_refs[0])
+            self._on_changed_refs = None
 
     # End region on_changed
 

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/streamtimeseriesconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/streamtimeseriesconsumer.py
@@ -44,16 +44,16 @@ class StreamTimeseriesConsumer(object):
 
         # Define events and their reference holders.
         self._on_data_received = None
-        self._on_data_received_ref = None  # Keeping reference to avoid GC.
+        self._on_data_received_refs = None  # Keeping reference to avoid GC.
 
         self._on_raw_received = None
-        self._on_raw_received_ref = None  # Keeping reference to avoid GC.
+        self._on_raw_received_refs = None  # Keeping reference to avoid GC.
 
         self._on_dataframe_received = None
-        self._on_dataframe_received_ref = None  # Keeping reference to avoid GC.
+        self._on_dataframe_received_refs = None  # Keeping reference to avoid GC.
 
         self._on_definitions_changed = None
-        self._on_definitions_changed_ref = None  # Keeping reference to avoid GC.
+        self._on_definitions_changed_refs = None  # Keeping reference to avoid GC.
 
     def _finalizerfunc(self):
         [buffer.dispose() for buffer in self._buffers]
@@ -84,8 +84,8 @@ class StreamTimeseriesConsumer(object):
                 The first parameter is the stream that receives the data, and the second is the data in TimeseriesData format.
         """
         self._on_data_received = value
-        if self._on_data_received_ref is None:
-            self._on_data_received_ref = self._interop.add_OnDataReceived(self._on_data_received_wrapper)
+        if self._on_data_received_refs is None:
+            self._on_data_received_refs = self._interop.add_OnDataReceived(self._on_data_received_wrapper)
 
     def _on_data_received_wrapper(self, stream_hptr, args_hptr):
         # To avoid unnecessary overhead and complication, we're using the stream instance we already have.
@@ -97,9 +97,9 @@ class StreamTimeseriesConsumer(object):
             traceback.print_exc()
 
     def _on_data_received_dispose(self):
-        if self._on_data_received_ref is not None:
-            self._interop.remove_OnDataReceived(self._on_data_received_ref)
-            self._on_data_received_ref = None
+        if self._on_data_received_refs is not None:
+            self._interop.remove_OnDataReceived(self._on_data_received_refs[0])
+            self._on_data_received_refs = None
 
     # endregion on_data_received
 
@@ -125,8 +125,8 @@ class StreamTimeseriesConsumer(object):
                 The first parameter is the stream that receives the data, and the second is the data in TimeseriesDataRaw format.
         """
         self._on_raw_received = value
-        if self._on_raw_received_ref is None:
-            self._on_raw_received_ref = self._interop.add_OnRawReceived(self._on_raw_received_wrapper)
+        if self._on_raw_received_refs is None:
+            self._on_raw_received_refs = self._interop.add_OnRawReceived(self._on_raw_received_wrapper)
 
     def _on_raw_received_wrapper(self, stream_hptr, args_hptr):
         # To avoid unnecessary overhead and complication, we're using the stream instance we already have.
@@ -138,9 +138,9 @@ class StreamTimeseriesConsumer(object):
             traceback.print_exc()
 
     def _on_raw_received_dispose(self):
-        if self._on_raw_received_ref is not None:
-            self._interop.remove_OnRawReceived(self._on_raw_received_ref)
-            self._on_raw_received_ref = None
+        if self._on_raw_received_refs is not None:
+            self._interop.remove_OnRawReceived(self._on_raw_received_refs[0])
+            self._on_raw_received_refs = None
 
     # endregion on_raw_receive
 
@@ -166,8 +166,8 @@ class StreamTimeseriesConsumer(object):
                 The first parameter is the stream that receives the data, and the second is the data in pandas DataFrame format.
         """
         self._on_dataframe_received = value
-        if self._on_dataframe_received_ref is None:
-            self._on_dataframe_received_ref = self._interop.add_OnRawReceived(self._on_dataframe_received_wrapper)
+        if self._on_dataframe_received_refs is None:
+            self._on_dataframe_received_refs = self._interop.add_OnRawReceived(self._on_dataframe_received_wrapper)
 
     def _on_dataframe_received_wrapper(self, stream_hptr, args_hptr):
         # To avoid unnecessary overhead and complication, we're using the stream instance we already have
@@ -182,9 +182,9 @@ class StreamTimeseriesConsumer(object):
             traceback.print_exc()
 
     def _on_dataframe_received_dispose(self):
-        if self._on_dataframe_received_ref is not None:
-            self._interop.remove_OnRawReceived(self._on_dataframe_received_ref)
-            self._on_dataframe_received_ref = None
+        if self._on_dataframe_received_refs is not None:
+            self._interop.remove_OnRawReceived(self._on_dataframe_received_refs[0])
+            self._on_dataframe_received_refs = None
 
     # endregion on_dataframe_receive
 
@@ -211,8 +211,8 @@ class StreamTimeseriesConsumer(object):
                 The first parameter is the stream for which the parameter definitions changed.
         """
         self._on_definitions_changed = value
-        if self._on_definitions_changed_ref is None:
-            self._on_definitions_changed_ref = self._interop.add_OnDefinitionsChanged(
+        if self._on_definitions_changed_refs is None:
+            self._on_definitions_changed_refs = self._interop.add_OnDefinitionsChanged(
                 self._on_definitions_changed_wrapper)
 
     def _on_definitions_changed_wrapper(self, stream_hptr, args_hptr):
@@ -225,9 +225,9 @@ class StreamTimeseriesConsumer(object):
             traceback.print_exc()
 
     def _on_definitions_changed_dispose(self):
-        if self._on_definitions_changed_ref is not None:
-            self._interop.remove_OnDefinitionsChanged(self._on_definitions_changed_ref)
-            self._on_definitions_changed_ref = None
+        if self._on_definitions_changed_refs is not None:
+            self._interop.remove_OnDefinitionsChanged(self._on_definitions_changed_refs[0])
+            self._on_definitions_changed_refs = None
 
     # endregion on_definitions_changed
 

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/streamtimeseriesconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/streamtimeseriesconsumer.py
@@ -44,16 +44,16 @@ class StreamTimeseriesConsumer(object):
 
         # Define events and their reference holders.
         self._on_data_received = None
-        self._on_data_received_refs = None  # Keeping reference to avoid GC.
+        self._on_data_received_refs = None  # Keeping references to avoid GC.
 
         self._on_raw_received = None
-        self._on_raw_received_refs = None  # Keeping reference to avoid GC.
+        self._on_raw_received_refs = None  # Keeping references to avoid GC.
 
         self._on_dataframe_received = None
-        self._on_dataframe_received_refs = None  # Keeping reference to avoid GC.
+        self._on_dataframe_received_refs = None  # Keeping references to avoid GC.
 
         self._on_definitions_changed = None
-        self._on_definitions_changed_refs = None  # Keeping reference to avoid GC.
+        self._on_definitions_changed_refs = None  # Keeping references to avoid GC.
 
     def _finalizerfunc(self):
         [buffer.dispose() for buffer in self._buffers]

--- a/src/PythonClient/src/quixstreams/models/timeseriesbuffer.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesbuffer.py
@@ -57,13 +57,13 @@ class TimeseriesBuffer(object):
 
         # define events and their ref holder
         self._on_data_released = None
-        self._on_data_released_refs = None  # keeping reference to avoid GC
+        self._on_data_released_refs = None  # keeping references to avoid GC
 
         self._on_raw_released = None
-        self._on_raw_released_refs = None  # keeping reference to avoid GC
+        self._on_raw_released_refs = None  # keeping references to avoid GC
 
         self._on_dataframe_released = None
-        self._on_dataframe_released_refs = None  # keeping reference to avoid GC
+        self._on_dataframe_released_refs = None  # keeping references to avoid GC
 
     def _finalizerfunc(self):
         self._on_data_released_dispose()

--- a/src/PythonClient/src/quixstreams/models/timeseriesbuffer.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesbuffer.py
@@ -57,13 +57,13 @@ class TimeseriesBuffer(object):
 
         # define events and their ref holder
         self._on_data_released = None
-        self._on_data_released_ref = None  # keeping reference to avoid GC
+        self._on_data_released_refs = None  # keeping reference to avoid GC
 
         self._on_raw_released = None
-        self._on_raw_released_ref = None  # keeping reference to avoid GC
+        self._on_raw_released_refs = None  # keeping reference to avoid GC
 
         self._on_dataframe_released = None
-        self._on_dataframe_released_ref = None  # keeping reference to avoid GC
+        self._on_dataframe_released_refs = None  # keeping reference to avoid GC
 
     def _finalizerfunc(self):
         self._on_data_released_dispose()
@@ -92,8 +92,8 @@ class TimeseriesBuffer(object):
             value: The event handler. The first parameter is the stream the data is received for, second is the data in TimeseriesData format.
         """
         self._on_data_released = value
-        if self._on_data_released_ref is None:
-            self._on_data_released_ref = self._interop_pb.add_OnDataReleased(self._on_data_released_wrapper)
+        if self._on_data_released_refs is None:
+            self._on_data_released_refs = self._interop_pb.add_OnDataReleased(self._on_data_released_wrapper)
 
     def _on_data_released_wrapper(self, stream_hptr, args_hptr):
         # To avoid unnecessary overhead and complication, we're using the stream instance we already have
@@ -106,9 +106,9 @@ class TimeseriesBuffer(object):
             traceback.print_exc()
 
     def _on_data_released_dispose(self):
-        if self._on_data_released_ref is not None:
-            self._interop_pb.remove_OnDataReleased(self._on_data_released_ref)
-            self._on_data_released_ref = None
+        if self._on_data_released_refs is not None:
+            self._interop_pb.remove_OnDataReleased(self._on_data_released_refs[0])
+            self._on_data_released_refs = None
 
     # endregion on_data_released
 
@@ -133,8 +133,8 @@ class TimeseriesBuffer(object):
             value: The event handler. The first parameter is the stream the data is received for, second is the data in TimeseriesDataRaw format.
         """
         self._on_raw_released = value
-        if self._on_raw_released_ref is None:
-            self._on_raw_released_ref = self._interop_pb.add_OnRawReleased(self._on_raw_released_wrapper)
+        if self._on_raw_released_refs is None:
+            self._on_raw_released_refs = self._interop_pb.add_OnRawReleased(self._on_raw_released_wrapper)
 
     def _on_raw_released_wrapper(self, stream_hptr, args_hptr):
         # To avoid unnecessary overhead and complication, we're using the stream instance we already have
@@ -146,9 +146,9 @@ class TimeseriesBuffer(object):
             traceback.print_exc()
 
     def _on_raw_released_dispose(self):
-        if self._on_raw_released_ref is not None:
-            self._interop_pb.remove_OnRawReleased(self._on_raw_released_ref)
-            self._on_raw_released_ref = None
+        if self._on_raw_released_refs is not None:
+            self._interop_pb.remove_OnRawReleased(self._on_raw_released_refs[0])
+            self._on_raw_released_refs = None
 
     # endregion on_raw_released
 
@@ -173,8 +173,8 @@ class TimeseriesBuffer(object):
             value: The event handler. The first parameter is the stream the data is received for, second is the data in pandas.DataFrame format.
         """
         self._on_dataframe_released = value
-        if self._on_dataframe_released_ref is None:
-            self._on_dataframe_released_ref = self._interop_pb.add_OnRawReleased(self._on_dataframe_released_wrapper)
+        if self._on_dataframe_released_refs is None:
+            self._on_dataframe_released_refs = self._interop_pb.add_OnRawReleased(self._on_dataframe_released_wrapper)
 
     def _on_dataframe_released_wrapper(self, stream_hptr, args_hptr):
         # To avoid unnecessary overhead and complication, we're using the stream instance we already have
@@ -189,9 +189,9 @@ class TimeseriesBuffer(object):
             traceback.print_exc()
 
     def _on_dataframe_released_dispose(self):
-        if self._on_dataframe_released_ref is not None:
-            self._interop_pb.remove_OnRawReleased(self._on_dataframe_released_ref)
-            self._on_dataframe_released_ref = None
+        if self._on_dataframe_released_refs is not None:
+            self._interop_pb.remove_OnRawReleased(self._on_dataframe_released_refs[0])
+            self._on_dataframe_released_refs = None
 
     # endregion on_dataframe_released
 

--- a/src/PythonClient/src/quixstreams/models/timeseriesdata.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesdata.py
@@ -39,9 +39,9 @@ class TimeseriesData(object):
         self._init_timestamps()  # else the first time addition could result in double counting it in local cache
 
     def _finalizerfunc(self):
-        if self._timestamps is not None:
-            [pdstamp.dispose() for pdstamp in self._timestamps]
-            self._timestamps = None
+        # do not dispose individual timestamps,
+        # let GC deal with it, otherwise might remove still used instances
+        self._timestamps = None
 
 
     # TODO

--- a/src/PythonClient/src/quixstreams/raw/rawtopicconsumer.py
+++ b/src/PythonClient/src/quixstreams/raw/rawtopicconsumer.py
@@ -32,10 +32,10 @@ class RawTopicConsumer(object):
 
         # define events and their ref holder
         self._on_message_received = None
-        self._on_message_received_refs = None  # keeping reference to avoid GC
+        self._on_message_received_refs = None  # keeping references to avoid GC
 
         self._on_error_occurred = None
-        self._on_error_occurred_refs = None  # keeping reference to avoid GC
+        self._on_error_occurred_refs = None  # keeping references to avoid GC
 
     def _finalizerfunc(self):
         self._on_message_received_dispose()

--- a/src/PythonClient/src/quixstreams/raw/rawtopicconsumer.py
+++ b/src/PythonClient/src/quixstreams/raw/rawtopicconsumer.py
@@ -32,10 +32,10 @@ class RawTopicConsumer(object):
 
         # define events and their ref holder
         self._on_message_received = None
-        self._on_message_received_ref = None  # keeping reference to avoid GC
+        self._on_message_received_refs = None  # keeping reference to avoid GC
 
         self._on_error_occurred = None
-        self._on_error_occurred_ref = None  # keeping reference to avoid GC
+        self._on_error_occurred_refs = None  # keeping reference to avoid GC
 
     def _finalizerfunc(self):
         self._on_message_received_dispose()
@@ -63,8 +63,8 @@ class RawTopicConsumer(object):
                 The first parameter is the RawTopicConsumer instance for which the message is received, and the second is the RawMessage.
         """
         self._on_message_received = value
-        if self._on_message_received_ref is None:
-            self._on_message_received_ref = self._interop.add_OnMessageReceived(self._on_message_received_wrapper)
+        if self._on_message_received_refs is None:
+            self._on_message_received_refs = self._interop.add_OnMessageReceived(self._on_message_received_wrapper)
 
     def _on_message_received_wrapper(self, topic_hptr, message_hptr):
         # To avoid unnecessary overhead and complication, we're using the topic instance we already have
@@ -75,9 +75,9 @@ class RawTopicConsumer(object):
             traceback.print_exc()
 
     def _on_message_received_dispose(self):
-        if self._on_message_received_ref is not None:
-            self._interop.remove_OnMessageReceived(self._on_message_received_ref)
-            self._on_message_received_ref = None
+        if self._on_message_received_refs is not None:
+            self._interop.remove_OnMessageReceived(self._on_message_received_refs[0])
+            self._on_message_received_refs = None
 
     # endregion on_message_received
 
@@ -103,8 +103,8 @@ class RawTopicConsumer(object):
                 The first parameter is the RawTopicConsumer instance for which the error is received, and the second is the exception.
         """
         self._on_error_occurred = value
-        if self._on_error_occurred_ref is None:
-            self._on_error_occurred_ref = self._interop.add_OnErrorOccurred(self._on_error_occurred_wrapper)
+        if self._on_error_occurred_refs is None:
+            self._on_error_occurred_refs = self._interop.add_OnErrorOccurred(self._on_error_occurred_wrapper)
 
     def _on_error_occurred_wrapper(self, topic_hptr, error_hptr):
         # To avoid unnecessary overhead and complication, we're using the topic instance we already have
@@ -117,9 +117,9 @@ class RawTopicConsumer(object):
             traceback.print_exc()
 
     def _on_error_occurred_dispose(self):
-        if self._on_error_occurred_ref is not None:
-            self._interop.remove_OnErrorOccurred(self._on_error_occurred_ref)
-            self._on_error_occurred_ref = None
+        if self._on_error_occurred_refs is not None:
+            self._interop.remove_OnErrorOccurred(self._on_error_occurred_refs[0])
+            self._on_error_occurred_refs = None
 
     # endregion on_error_occurred
 

--- a/src/PythonClient/src/quixstreams/states/dictstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/dictstreamstate.py
@@ -71,10 +71,10 @@ class DictStreamState(Generic[StreamStateType]):
 
         # Define events and their reference holders
         self._on_flushed = None
-        self._on_flushed_ref = None  # Keeping reference to avoid garbage collection
+        self._on_flushed_refs = None  # Keeping reference to avoid garbage collection
 
         self._on_flushing = None
-        self._on_flushing_ref = None  # Keeping reference to avoid garbage collection
+        self._on_flushing_refs = None  # Keeping reference to avoid garbage collection
 
         # Check if type is immutable, because it needs special handling. Content could change without StreamState being
         # notified
@@ -86,7 +86,7 @@ class DictStreamState(Generic[StreamStateType]):
                     self._underlying[key] = val
 
             self._on_flushing_internal = on_flushing_internal
-            self.on_flushing = None  # this will subscribe to the even and invoke the internal
+            self.on_flushing = None  # this will subscribe to the event and invoke the internal
 
     def _finalizerfunc(self):
         self._on_flushed_dispose()
@@ -123,19 +123,16 @@ class DictStreamState(Generic[StreamStateType]):
         """
 
         self._on_flushed = value
-        if self._on_flushed_ref is not None:
-            self._interop.remove_OnFlushed(self._on_flushed_ref)
-            self._on_flushed_ref = None
+        self._on_flushed_dispose()
 
-        if self.on_flushed is None:
+        if self._on_flushed is None:
             return
 
-        if self._on_flushed_ref is None:
-            self._on_flushed_ref = self._interop.add_OnFlushed(self._on_flushed_wrapper)
+        self._on_flushed_refs = self._interop.add_OnFlushed(self._on_flushed_wrapper)
 
     def _on_flushed_wrapper(self, sender_hptr, args_hptr):
         try:
-            self._on_flushed(self._stream_consumer)
+            self._on_flushed()
         except:
             traceback.print_exc()
         finally:
@@ -143,9 +140,9 @@ class DictStreamState(Generic[StreamStateType]):
             InteropUtils.free_hptr(args_hptr)
 
     def _on_flushed_dispose(self):
-        if self._on_flushed_ref is not None:
-            self._interop.remove_OnFlushed(self._on_flushed_ref)
-            self._on_flushed_ref = None
+        if self._on_flushed_refs is not None:
+            self._interop.remove_OnFlushed(self._on_flushed_refs[0])
+            self._on_flushed_refs = None
 
     # End region on_flushed
 
@@ -170,15 +167,12 @@ class DictStreamState(Generic[StreamStateType]):
         """
 
         self._on_flushing = value
-        if self._on_flushing_ref is not None:
-            self._interop.remove_OnFlushing(self._on_flushing_ref)
-            self._on_flushing_ref = None
+        self._on_flushing_dispose()
 
-        if self.on_flushing is None and self._on_flushing_internal is None:
+        if self._on_flushing is None and self._on_flushing_internal is None:
             return
 
-        if self._on_flushing_ref is None:
-            self._on_flushing_ref = self._interop.add_OnFlushing(self._on_flushing_wrapper)
+        self._on_flushing_refs = self._interop.add_OnFlushing(self._on_flushing_wrapper)
 
     def _on_flushing_wrapper(self, sender_hptr, args_hptr):
         try:
@@ -192,10 +186,11 @@ class DictStreamState(Generic[StreamStateType]):
             InteropUtils.free_hptr(sender_hptr)
             InteropUtils.free_hptr(args_hptr)
 
+
     def _on_flushing_dispose(self):
-        if self._on_flushing_ref is not None:
-            self._interop.remove_OnFlushing(self._on_flushing_ref)
-            self._on_flushing_ref = None
+        if self._on_flushing_refs is not None:
+            self._interop.remove_OnFlushing(self._on_flushing_refs[0])
+            self._on_flushing_refs = None
 
     # End region on_flushing
 

--- a/src/PythonClient/src/quixstreams/states/dictstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/dictstreamstate.py
@@ -71,10 +71,10 @@ class DictStreamState(Generic[StreamStateType]):
 
         # Define events and their reference holders
         self._on_flushed = None
-        self._on_flushed_refs = None  # Keeping reference to avoid garbage collection
+        self._on_flushed_refs = None  # Keeping references to avoid garbage collection
 
         self._on_flushing = None
-        self._on_flushing_refs = None  # Keeping reference to avoid garbage collection
+        self._on_flushing_refs = None  # Keeping references to avoid garbage collection
 
         # Check if type is immutable, because it needs special handling. Content could change without StreamState being
         # notified

--- a/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
@@ -41,10 +41,10 @@ class ScalarStreamState(Generic[StreamStateType]):
 
         # Define events and their reference holders
         self._on_flushed = None
-        self._on_flushed_ref = None  # Keeping reference to avoid garbage collection
+        self._on_flushed_refs = None  # Keeping reference to avoid garbage collection
 
         self._on_flushing = None
-        self._on_flushing_ref = None  # Keeping reference to avoid garbage collection
+        self._on_flushing_refs = None  # Keeping reference to avoid garbage collection
 
         # Check if type is immutable, because it needs special handling. Content could change without ScalarStreamState being
         # notified
@@ -92,15 +92,15 @@ class ScalarStreamState(Generic[StreamStateType]):
         """
 
         self._on_flushed = value
-        if self._on_flushed_ref is not None:
-            self._interop.remove_OnFlushed(self._on_flushed_ref)
-            self._on_flushed_ref = None
+        if self._on_flushed_refs is not None:
+            self._interop.remove_OnFlushed(self._on_flushed_refs[0])
+            self._on_flushed_refs = None
 
         if self.on_flushed is None:
             return
 
-        if self._on_flushed_ref is None:
-            self._on_flushed_ref = self._interop.add_OnFlushed(self._on_flushed_wrapper)
+        if self._on_flushed_refs is None:
+            self._on_flushed_refs = self._interop.add_OnFlushed(self._on_flushed_wrapper)
 
     def _on_flushed_wrapper(self, sender_hptr, args_hptr):
         try:
@@ -112,9 +112,9 @@ class ScalarStreamState(Generic[StreamStateType]):
             InteropUtils.free_hptr(args_hptr)
 
     def _on_flushed_dispose(self):
-        if self._on_flushed_ref is not None:
-            self._interop.remove_OnFlushed(self._on_flushed_ref)
-            self._on_flushed_ref = None
+        if self._on_flushed_refs is not None:
+            self._interop.remove_OnFlushed(self._on_flushed_refs[0])
+            self._on_flushed_refs = None
 
     # End region on_flushed
 
@@ -139,15 +139,15 @@ class ScalarStreamState(Generic[StreamStateType]):
         """
 
         self._on_flushing = value
-        if self._on_flushing_ref is not None:
-            self._interop.remove_OnFlushing(self._on_flushing_ref)
-            self._on_flushing_ref = None
+        if self._on_flushing_refs is not None:
+            self._interop.remove_OnFlushing(self._on_flushing_refs[0])
+            self._on_flushing_refs = None
 
         if self.on_flushing is None and self._on_flushing_internal is None:
             return
 
-        if self._on_flushing_ref is None:
-            self._on_flushing_ref = self._interop.add_OnFlushing(self._on_flushing_wrapper)
+        if self._on_flushing_refs is None:
+            self._on_flushing_refs = self._interop.add_OnFlushing(self._on_flushing_wrapper)
 
     def _on_flushing_wrapper(self, sender_hptr, args_hptr):
         try:
@@ -162,9 +162,9 @@ class ScalarStreamState(Generic[StreamStateType]):
             InteropUtils.free_hptr(args_hptr)
 
     def _on_flushing_dispose(self):
-        if self._on_flushing_ref is not None:
-            self._interop.remove_OnFlushing(self._on_flushing_ref)
-            self._on_flushing_ref = None
+        if self._on_flushing_refs is not None:
+            self._interop.remove_OnFlushing(self._on_flushing_refs[0])
+            self._on_flushing_refs = None
 
     # End region on_flushing
 

--- a/src/PythonClient/src/quixstreams/states/streamstatemanager.py
+++ b/src/PythonClient/src/quixstreams/states/streamstatemanager.py
@@ -1,9 +1,9 @@
 import ctypes
 import logging
-import weakref
 
 from .scalarstreamstate import ScalarStreamState
 from ..helpers.nativedecorator import nativedecorator
+from ..native.Python.InteropHelpers.InteropUtils import InteropUtils
 from ..native.Python.QuixStreamsStreaming.States.StreamStateManager import StreamStateManager as ssmi
 from ..native.Python.InteropHelpers.ExternalTypes.System.Enumerable import Enumerable as ei
 
@@ -34,8 +34,13 @@ class StreamStateManager(object):
         if net_pointer is None:
             raise Exception("StreamStateManager is none")
 
-        self._cache = weakref.WeakValueDictionary()
+        self._cache = {}
         self._interop = ssmi(net_pointer)
+
+    def _finalizerfunc(self):
+        for (k, v) in self._cache.items():
+            v.dispose()
+
 
     def get_dict_state(self, state_name: str, default_value_factory: Callable[[str], StreamStateType] = None, state_type: StreamStateType = None) -> DictStreamState[StreamStateType]:
         """

--- a/src/PythonClient/src/quixstreams/states/topicstatemanager.py
+++ b/src/PythonClient/src/quixstreams/states/topicstatemanager.py
@@ -1,8 +1,8 @@
 import ctypes
-import weakref
 from typing import List
 
 from ..helpers.nativedecorator import nativedecorator
+from ..native.Python.InteropHelpers.InteropUtils import InteropUtils
 from ..native.Python.QuixStreamsStreaming.States.TopicStateManager import TopicStateManager as tsmi
 
 from ..native.Python.InteropHelpers.ExternalTypes.System.Enumerable import Enumerable as ei
@@ -28,8 +28,12 @@ class TopicStateManager(object):
         if net_pointer is None:
             raise Exception("TopicStateManager is none")
 
-        self._stream_state_cache = weakref.WeakValueDictionary()
+        self._stream_state_cache = {}
         self._interop = tsmi(net_pointer)
+
+    def _finalizerfunc(self):
+        for (k, v) in self._stream_state_cache.items():
+            v.dispose()
 
     def get_stream_states(self) -> List[str]:
         """

--- a/src/PythonClient/src/quixstreams/streamproducer.py
+++ b/src/PythonClient/src/quixstreams/streamproducer.py
@@ -42,7 +42,7 @@ class StreamProducer(object):
 
         # define events and their ref holder
         self._on_write_exception = None
-        self._on_write_exception_ref = None  # keeping reference to avoid GC
+        self._on_write_exception_refs = None  # keeping reference to avoid GC
 
         self._stream_id = self._interop.get_StreamId()
 
@@ -88,8 +88,8 @@ class StreamProducer(object):
                 The first parameter is the stream is received for, second is the exception.
         """
         self._on_write_exception = value
-        if self._on_write_exception_ref is None:
-            self._on_write_exception_ref = self._interop.add_OnWriteException(self._on_write_exception_wrapper)
+        if self._on_write_exception_refs is None:
+            self._on_write_exception_refs = self._interop.add_OnWriteException(self._on_write_exception_wrapper)
 
     def _on_write_exception_wrapper(self, stream_hptr, exception_hptr):
         # To avoid unnecessary overhead and complication, we're using the topic instance we already have
@@ -102,9 +102,9 @@ class StreamProducer(object):
             traceback.print_exc()
 
     def _on_write_exception_dispose(self):
-        if self._on_write_exception_ref is not None:
-            self._interop.remove_OnWriteException(self._on_write_exception_ref)
-            self._on_write_exception_ref = None
+        if self._on_write_exception_refs is not None:
+            self._interop.remove_OnWriteException(self._on_write_exception_refs[0])
+            self._on_write_exception_refs = None
 
     # endregion on_write_exception
 

--- a/src/PythonClient/src/quixstreams/topicproducer.py
+++ b/src/PythonClient/src/quixstreams/topicproducer.py
@@ -28,7 +28,7 @@ class TopicProducer(object):
 
         # define events and their ref holder
         self._on_disposed = None
-        self._on_disposed_ref = None  # keeping reference to avoid GC
+        self._on_disposed_refs = None  # keeping reference to avoid GC
 
     def _finalizerfunc(self):
         self._on_disposed_dispose()
@@ -67,9 +67,8 @@ class TopicProducer(object):
                 The first parameter is the TopicProducer instance that got disposed.
         """
         self._on_disposed = value
-        if self._on_disposed_ref is None:
-            self._on_disposed_ref = self._interop.add_OnDisposed(
-                self._on_disposed_wrapper)
+        if self._on_disposed_refs is None:
+            self._on_disposed_refs = self._interop.add_OnDisposed(self._on_disposed_wrapper)
 
     def _on_disposed_wrapper(self, stream_hptr, arg_hptr):
         # To avoid unnecessary overhead and complication, we're using the stream instance we already have
@@ -81,9 +80,9 @@ class TopicProducer(object):
             traceback.print_exc()
 
     def _on_disposed_dispose(self):
-        if self._on_disposed_ref is not None:
-            self._interop.remove_OnDisposed(self._on_disposed_ref)
-            self._on_disposed_ref = None
+        if self._on_disposed_refs is not None:
+            self._interop.remove_OnDisposed(self._on_disposed_refs[0])
+            self._on_disposed_refs = None
 
     # endregion on_disposed
 
@@ -146,5 +145,4 @@ class TopicProducer(object):
 
             callback = on_create_callback
 
-        return StreamProducer(self,
-                              self._interop.GetOrCreateStream(stream_id, callback)[0])
+        return StreamProducer(self, self._interop.GetOrCreateStream(stream_id, callback)[0])

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -823,7 +823,6 @@ class TestTimeseriesData(BaseIntegrationTest):
         assert isinstance(binary_value, bytes)
         assert binary_value == bytes(bytearray("binary_param", "UTF-8"))
 
-    @pytest.mark.skip('TODO: Fix timeouts')
     def test_parameters_write_via_buffer_and_read(self,
                                                   test_name,
                                                   topic_consumer_earliest,
@@ -1007,7 +1006,6 @@ class TestTimeseriesData(BaseIntegrationTest):
         # and is done by checking both ways
         assert_timeseries_data_equal(read_data, written_data)
 
-    @pytest.mark.skip('TODO: Fix timeouts')
     def test_timeseries_data_raw_publish_via_buffer_and_consume(self,
                                                                 test_name,
                                                                 topic_consumer_earliest,
@@ -1122,7 +1120,6 @@ class TestTimeseriesData(BaseIntegrationTest):
         assert_timestamps_equal(consumed_timeseries_data.timestamps[0],
                                 published_timestamp)
 
-    @pytest.mark.skip('TODO: Fix timeouts')
     def test_timeseries_data_timestamp_publish_via_buffer_and_consume(self,
                                                                       test_name,
                                                                       topic_producer,

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.5.0"
-informal_version = "0.5.5.0-dev4"
-nuget_version = "0.5.5.0-dev4"
+informal_version = "0.5.5.0-dev5"
+nuget_version = "0.5.5.0-dev5"
 
 
 def updatecsproj(projfilepath):


### PR DESCRIPTION
Python BugFix:
- Unsubscribing from an interop wrapped event now works. Previously removal was not unsubscribing with correct handler, leaving the initial subscription active
- Nativedecorator properly invokes finalize
- State cache items no longer get finalized ahead of their time
- StreamClose should properly clean up after itself

C# Bugfix:
- Null binary won't cause issue when using custom json serializer

Misc:
- Improved NativeDecorator logs 
- Improve InteropGenerator debug logs & parser for it 
- Improve InteropGenerator Log parser
- Refactor C# InteropGenerator MethodWriter to be easier to follow