### PR TITLE
Expand coverage of idle connection reap message check for consumer

### DIFF
--- a/src/CsharpClient/QuixStreams.Transport.Kafka/KafkaConsumer.cs
+++ b/src/CsharpClient/QuixStreams.Transport.Kafka/KafkaConsumer.cs
@@ -596,7 +596,7 @@ namespace QuixStreams.Transport.Kafka
                 return;
             }
             
-            if (exception.Message.Contains("Receive failed: Connection timed out (after "))
+            if (exception.Message.Contains("Receive failed") && exception.Message.Contains("Connection timed out (after "))
             {
                 var match = Constants.ExceptionMsRegex.Match(exception.Message);
                 if (match.Success)


### PR DESCRIPTION
Sometimes the message is not exactly what it was checking for, so updated check to look for the key fragments separately.