### PR TITLE
Revert to empty parameter when missing rather than exception

### DIFF
--- a/src/CsharpClient/QuixStreams.Streaming/Models/ParameterValue.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/ParameterValue.cs
@@ -10,19 +10,19 @@ namespace QuixStreams.Streaming.Models
     public readonly struct ParameterValue
     {
         private readonly long timestampRawIndex;
-        private readonly Parameter parameter;
+        private readonly TimeseriesDataParameter timeseriesDataParameter;
 
-        internal ParameterValue(long timestampRawIndex, Parameter parameter)
+        internal ParameterValue(long timestampRawIndex, TimeseriesDataParameter timeseriesDataParameter)
         {
             this.timestampRawIndex = timestampRawIndex;
-            this.parameter = parameter;
-            this.Type = this.parameter.ValueType;
+            this.timeseriesDataParameter = timeseriesDataParameter;
+            this.Type = this.timeseriesDataParameter.ValueType;
         }
 
         /// <summary>
         /// Gets the Parameter Id of the parameter
         /// </summary>
-        public readonly string ParameterId => this.parameter.ParameterId;
+        public readonly string ParameterId => this.timeseriesDataParameter.ParameterId;
 
         /// <summary>
         /// Gets the type of value, which is numeric, string or binary if set, else empty
@@ -36,16 +36,16 @@ namespace QuixStreams.Streaming.Models
         {
             get
             {
-                return this.parameter.NumericValues?[this.timestampRawIndex];
+                return this.timeseriesDataParameter.NumericValues?[this.timestampRawIndex];
             }
             set
             {
-                if (this.parameter.NumericValues == null)
+                if (this.timeseriesDataParameter.NumericValues == null)
                 {
                     throw new InvalidOperationException($"The parameter '{this.ParameterId}' is not of Numeric type.");
                 }
 
-                this.parameter.NumericValues[this.timestampRawIndex] = value;
+                this.timeseriesDataParameter.NumericValues[this.timestampRawIndex] = value;
             }
         }
 
@@ -56,16 +56,16 @@ namespace QuixStreams.Streaming.Models
         {
             get
             {
-                return this.parameter.StringValues?[this.timestampRawIndex];
+                return this.timeseriesDataParameter.StringValues?[this.timestampRawIndex];
             }
             set
             {
-                if (this.parameter.StringValues == null)
+                if (this.timeseriesDataParameter.StringValues == null)
                 {
                     throw new InvalidOperationException($"The parameter '{this.ParameterId}' is not of String type.");
                 }
 
-                this.parameter.StringValues[this.timestampRawIndex] = value;
+                this.timeseriesDataParameter.StringValues[this.timestampRawIndex] = value;
             }
         }
 
@@ -76,16 +76,16 @@ namespace QuixStreams.Streaming.Models
         {
             get
             {
-                return this.parameter.BinaryValues?[this.timestampRawIndex];
+                return this.timeseriesDataParameter.BinaryValues?[this.timestampRawIndex];
             }
             set
             {
-                if (this.parameter.BinaryValues == null)
+                if (this.timeseriesDataParameter.BinaryValues == null)
                 {
                     throw new InvalidOperationException($"The parameter '{this.ParameterId}' is not of Binary type.");
                 }
 
-                this.parameter.BinaryValues[this.timestampRawIndex] = value;
+                this.timeseriesDataParameter.BinaryValues[this.timestampRawIndex] = value;
             }
         }
 
@@ -96,9 +96,9 @@ namespace QuixStreams.Streaming.Models
         {
             get
             {
-                return (object)this.parameter.NumericValues?[this.timestampRawIndex]
-                    ?? (object)this.parameter.StringValues?[this.timestampRawIndex]
-                    ?? (object)this.parameter.BinaryValues?[this.timestampRawIndex];
+                return (object)this.timeseriesDataParameter.NumericValues?[this.timestampRawIndex]
+                    ?? (object)this.timeseriesDataParameter.StringValues?[this.timestampRawIndex]
+                    ?? (object)this.timeseriesDataParameter.BinaryValues?[this.timestampRawIndex];
             }
         }
 
@@ -165,7 +165,7 @@ namespace QuixStreams.Streaming.Models
             {
                 var hash = 397;
                 hash ^= this.timestampRawIndex.GetHashCode();
-                hash ^= this.parameter.GetHashCode();
+                hash ^= this.timeseriesDataParameter.GetHashCode();
 
                 return hash;
             }

--- a/src/CsharpClient/QuixStreams.Streaming/Models/ParameterValue.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/ParameterValue.cs
@@ -12,7 +12,12 @@ namespace QuixStreams.Streaming.Models
         private readonly long timestampRawIndex;
         private readonly TimeseriesDataParameter timeseriesDataParameter;
 
-        internal ParameterValue(long timestampRawIndex, TimeseriesDataParameter timeseriesDataParameter)
+        /// <summary>
+        /// Initializes a new instance with the of <see cref="ParameterValue"/> with the specified index and parameter
+        /// </summary>
+        /// <param name="timestampRawIndex">The index to reference to in the parameter</param>
+        /// <param name="timeseriesDataParameter">The parameter the value will be derived from</param>
+        public ParameterValue(long timestampRawIndex, TimeseriesDataParameter timeseriesDataParameter)
         {
             this.timestampRawIndex = timestampRawIndex;
             this.timeseriesDataParameter = timeseriesDataParameter;
@@ -36,11 +41,12 @@ namespace QuixStreams.Streaming.Models
         {
             get
             {
+                if (this.Type != ParameterValueType.Numeric) return null;
                 return this.timeseriesDataParameter.NumericValues?[this.timestampRawIndex];
             }
             set
             {
-                if (this.timeseriesDataParameter.NumericValues == null)
+                if (this.Type != ParameterValueType.Numeric)
                 {
                     throw new InvalidOperationException($"The parameter '{this.ParameterId}' is not of Numeric type.");
                 }
@@ -56,11 +62,12 @@ namespace QuixStreams.Streaming.Models
         {
             get
             {
+                if (this.Type != ParameterValueType.String) return null;
                 return this.timeseriesDataParameter.StringValues?[this.timestampRawIndex];
             }
             set
             {
-                if (this.timeseriesDataParameter.StringValues == null)
+                if (this.Type != ParameterValueType.String)
                 {
                     throw new InvalidOperationException($"The parameter '{this.ParameterId}' is not of String type.");
                 }
@@ -76,11 +83,12 @@ namespace QuixStreams.Streaming.Models
         {
             get
             {
+                if (this.Type != ParameterValueType.Binary) return null;
                 return this.timeseriesDataParameter.BinaryValues?[this.timestampRawIndex];
             }
             set
             {
-                if (this.timeseriesDataParameter.BinaryValues == null)
+                if (this.Type != ParameterValueType.Binary)
                 {
                     throw new InvalidOperationException($"The parameter '{this.ParameterId}' is not of Binary type.");
                 }
@@ -96,9 +104,19 @@ namespace QuixStreams.Streaming.Models
         {
             get
             {
-                return (object)this.timeseriesDataParameter.NumericValues?[this.timestampRawIndex]
-                    ?? (object)this.timeseriesDataParameter.StringValues?[this.timestampRawIndex]
-                    ?? (object)this.timeseriesDataParameter.BinaryValues?[this.timestampRawIndex];
+                switch (Type)
+                {
+                    case ParameterValueType.Empty:
+                        return null;
+                    case ParameterValueType.Numeric:
+                        return this.timeseriesDataParameter.NumericValues?[this.timestampRawIndex];
+                    case ParameterValueType.String:
+                        return this.timeseriesDataParameter.StringValues?[this.timestampRawIndex];
+                    case ParameterValueType.Binary:
+                        return this.timeseriesDataParameter.BinaryValues?[this.timestampRawIndex];
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
             }
         }
 
@@ -113,7 +131,7 @@ namespace QuixStreams.Streaming.Models
             var lhsValue = lhs.Value;
             var rhsValue = rhs.Value;
 
-            if (lhsValue?.GetType() != rhsValue?.GetType())
+            if (lhs.Type != rhs.Type)
             {
                 return false;
             }

--- a/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesData.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesData.cs
@@ -15,7 +15,7 @@ namespace QuixStreams.Streaming.Models
     {
         private static Lazy<ILogger> logger = new Lazy<ILogger>(() => Logging.CreateLogger<TimeseriesData>());
         internal QuixStreams.Telemetry.Models.TimeseriesDataRaw rawData;
-        internal Dictionary<string, Parameter> parameterList;
+        internal Dictionary<string, TimeseriesDataParameter> parameterList;
         internal List<int> timestampsList;
 
         private int nextIndexRawData = 0;
@@ -33,7 +33,7 @@ namespace QuixStreams.Streaming.Models
             this.rawData = this.EmptyRawData(capacity);
             this.epochsIncluded = new bool[capacity];
             this.timestampsList = new List<int>();
-            this.parameterList = new Dictionary<string, Parameter>();
+            this.parameterList = new Dictionary<string, TimeseriesDataParameter>();
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace QuixStreams.Streaming.Models
             this.rawData = this.EmptyRawData(timestamps.Count);
             this.epochsIncluded = new bool[timestamps.Count];
             this.timestampsList = new List<int>();
-            this.parameterList = new Dictionary<string, Parameter>();
+            this.parameterList = new Dictionary<string, TimeseriesDataParameter>();
 
             AddTimestamps(timestamps);
 
@@ -120,20 +120,20 @@ namespace QuixStreams.Streaming.Models
             }
         }
 
-        private Dictionary<string, Parameter> GetParameterList()
+        private Dictionary<string, TimeseriesDataParameter> GetParameterList()
         {
-            var list = new Dictionary<string, Parameter>();
+            var list = new Dictionary<string, TimeseriesDataParameter>();
 
             foreach (var kv in this.rawData.NumericValues)
             {
-                list[kv.Key] = new Parameter(kv.Key, kv.Value);
+                list[kv.Key] = new TimeseriesDataParameter(kv.Key, kv.Value);
             }
 
             foreach (var kv in this.rawData.StringValues)
             {
                 try
                 {
-                    list.Add(kv.Key, new Parameter(kv.Key, kv.Value));
+                    list.Add(kv.Key, new TimeseriesDataParameter(kv.Key, kv.Value));
                 }
                 catch (ArgumentException)
                 {
@@ -146,7 +146,7 @@ namespace QuixStreams.Streaming.Models
             {
                 try
                 {
-                    list.Add(kv.Key, new Parameter(kv.Key, kv.Value));
+                    list.Add(kv.Key, new TimeseriesDataParameter(kv.Key, kv.Value));
                 }
                 catch (ArgumentException)
                 {
@@ -590,43 +590,80 @@ namespace QuixStreams.Streaming.Models
         Binary = 3
     }
 
-    internal class Parameter
+    /// <summary>
+    /// Timeseries data parameter
+    /// </summary>
+    public class TimeseriesDataParameter
     {
-        public Parameter(string parameterId)
+        /// <summary>
+        /// Initializes a new instance of Timeseries data parameter with empty type
+        /// </summary>
+        /// <param name="parameterId">The id of the parameter</param>
+        public TimeseriesDataParameter(string parameterId)
         {
             this.ParameterId = parameterId;
             this.ValueType = ParameterValueType.Empty;
         }
 
-        public Parameter(string parameterId, double?[] numericValues)
+        /// <summary>
+        /// Initializes a new instance of Timeseries data parameter with double type
+        /// </summary>
+        /// <param name="parameterId">The id of the parameter</param>
+        /// <param name="numericValues">The values</param>
+        public TimeseriesDataParameter(string parameterId, double?[] numericValues)
         {
             this.ParameterId = parameterId;
             this.NumericValues = numericValues;
             this.ValueType = numericValues == null ? ParameterValueType.Empty : ParameterValueType.Numeric;
         }
 
-        public Parameter(string parameterId, string[] stringValues)
+        /// <summary>
+        /// Initializes a new instance of Timeseries data parameter with string type
+        /// </summary>
+        /// <param name="parameterId">The id of the parameter</param>
+        /// <param name="stringValues">The values</param>
+        public TimeseriesDataParameter(string parameterId, string[] stringValues)
         {
             this.ParameterId = parameterId;
             this.StringValues = stringValues;
             this.ValueType = stringValues == null ? ParameterValueType.Empty : ParameterValueType.String;
         }
 
-        public Parameter(string parameterId, byte[][] binaryValues)
+        /// <summary>
+        /// Initializes a new instance of Timeseries data parameter with binary type
+        /// </summary>
+        /// <param name="parameterId">The id of the parameter</param>
+        /// <param name="binaryValues">The values</param>
+        public TimeseriesDataParameter(string parameterId, byte[][] binaryValues)
         {
             this.ParameterId = parameterId;
             this.BinaryValues = binaryValues;
             this.ValueType = binaryValues == null ? ParameterValueType.Empty : ParameterValueType.Binary;
         }
 
+        /// <summary>
+        /// The type of the parameter values
+        /// </summary>
         public readonly ParameterValueType ValueType;
 
+        /// <summary>
+        /// The parameter id
+        /// </summary>
         public readonly string ParameterId;
 
+        /// <summary>
+        /// The numeric values
+        /// </summary>
         public readonly double?[] NumericValues;
 
+        /// <summary>
+        /// The string values
+        /// </summary>
         public readonly string[] StringValues;
 
+        /// <summary>
+        /// The binary values
+        /// </summary>
         public readonly byte[][] BinaryValues;
 
         public override bool Equals(Object obj)

--- a/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesDataTimestamp.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesDataTimestamp.cs
@@ -14,9 +14,9 @@ namespace QuixStreams.Streaming.Models
         internal readonly TimeseriesData TimeseriesData;
         internal readonly long timestampRawIndex;
 
-        internal TimeseriesDataTimestamp(TimeseriesData TimeseriesData, long rawIndex)
+        internal TimeseriesDataTimestamp(TimeseriesData timeseriesData, long rawIndex)
         {
-            this.TimeseriesData = TimeseriesData;
+            this.TimeseriesData = timeseriesData;
             this.timestampRawIndex = rawIndex;
         }
 
@@ -87,7 +87,7 @@ namespace QuixStreams.Streaming.Models
                 values = new double?[this.TimeseriesData.rawData.Timestamps.Length];
                 this.TimeseriesData.rawData.NumericValues.Add(parameterId, values);
 
-                this.TimeseriesData.parameterList[parameterId] = new Parameter(parameterId, values);
+                this.TimeseriesData.parameterList[parameterId] = new TimeseriesDataParameter(parameterId, values);
             }
 
             values[this.timestampRawIndex] = value;
@@ -108,7 +108,7 @@ namespace QuixStreams.Streaming.Models
                 values = new string[this.TimeseriesData.rawData.Timestamps.Length];
                 this.TimeseriesData.rawData.StringValues.Add(parameterId, values);
 
-                this.TimeseriesData.parameterList[parameterId] = new Parameter(parameterId, values);
+                this.TimeseriesData.parameterList[parameterId] = new TimeseriesDataParameter(parameterId, values);
             }
 
             values[this.timestampRawIndex] = value;
@@ -129,7 +129,7 @@ namespace QuixStreams.Streaming.Models
                 values = new byte[this.TimeseriesData.rawData.Timestamps.Length][];
                 this.TimeseriesData.rawData.BinaryValues.Add(parameterId, values);
 
-                this.TimeseriesData.parameterList[parameterId] = new Parameter(parameterId, values);
+                this.TimeseriesData.parameterList[parameterId] = new TimeseriesDataParameter(parameterId, values);
             }
 
             values[this.timestampRawIndex] = value;

--- a/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesDataTimestampValues.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesDataTimestampValues.cs
@@ -77,7 +77,7 @@ namespace QuixStreams.Streaming
             {
                 if (!this.TimeseriesData.parameterList.TryGetValue(key, out var parameter))
                 {
-                    parameter = new Parameter(key);
+                    parameter = new TimeseriesDataParameter(key);
                 }
 
                 return new ParameterValue(this.timestampRawIndex, parameter);

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/MethodWriter.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/CsharpInteropWriter/MethodWriter.cs
@@ -626,7 +626,9 @@ public class MethodWriter : BaseWriter
                 var elementTypeAsUnmanagedText = typeWriter.GetInteropTypeString(generic, false);
                 writer.Write($"var {unmanagedArrayName} = {nameof(InteropUtils)}.{nameof(InteropUtils.FromArrayUPtr)}({sourceName}, typeof({elementTypeAsUnmanagedText})) as {elementTypeAsUnmanagedText}[];");
                 targetName ??= $"{sourceName}Arr";
-                writer.Write($"{targetVarCreate}{targetName} = {unmanagedArrayName} == null ? null : new {elementTypeAsText}[{unmanagedArrayName}.Length];");
+                
+                // There seem to be a bug in NAOT where byte[][len] is not working but (byte[][])Array.CreateInstance(typeof(byte[]), len) does
+                writer.Write($"{targetVarCreate}{targetName} = {unmanagedArrayName} == null ? null : ({elementTypeAsText}[])Array.CreateInstance(typeof({elementTypeAsText}), {unmanagedArrayName}.Length);");
                 writer.Write($"if ({targetName} != null) {{"); // start of null check
                 writer.IncrementIndent();
                 writer.Write($"for (var {targetName}Index = 0; {targetName}Index < {targetName}.Length; {targetName}Index++) {{"); // start of for

--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/InteropUtils.py
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/InteropUtils.py
@@ -273,26 +273,46 @@ class InteropUtils(object):
         hptr: c_void_p
             Pointer to .Net GC Handle
         """
-        if InteropUtils.DebugEnabled and hptr in InteropUtils.__logged_ptrs:
-            stack_trace = inspect.stack()
-
-            # Format the stack trace into a readable string
-            InteropUtils.log_debug(f"Freeing HPTR {hptr}")
-            msg = ""
-            for frame_info in stack_trace:
-                msg = msg + f"File: {frame_info.filename}, Line: {frame_info.lineno}, Function: {frame_info.function}\n"
-
-            InteropUtils.log_debug(msg)
+        
+        InteropUtils.log_pointer(hptr)
 
         return InteropUtils.invoke("interoputils_free_hptr", hptr)
 
     @staticmethod
-    def add_logged(ptr: c_void_p):
+    def add_logged_pointer(ptr: c_void_p):
         """
         Adds the specified pointer to the logged pointer list, so it is easier to trace where it is used
         """
+        if not InteropUtils.DebugEnabled:
+            return
+
         if ptr not in InteropUtils.__logged_ptrs:
             InteropUtils.__logged_ptrs.append(ptr)
+    
+    @staticmethod
+    def is_logged_pointer(ptr: c_void_p):
+        """
+        Returns whether the pointer is logged
+        """
+        if not InteropUtils.DebugEnabled:
+            return False
+        return ptr in InteropUtils.__logged_ptrs
+
+    @staticmethod
+    def log_pointer(ptr: c_void_p):
+        """
+        Logs the pointer if it was previously added to the logged pointer
+        """
+
+        if not InteropUtils.is_logged_pointer(ptr):
+            return
+
+        stack_trace = inspect.stack()
+        msg = ""
+        for frame_info in stack_trace:
+            msg = msg + f"File: {frame_info.filename}, Line: {frame_info.lineno}, Function: {frame_info.function}\n"
+
+        InteropUtils.log_debug(msg)
 
     @staticmethod
     def free_uptr(uptr: c_void_p) -> None:

--- a/src/PythonClient/src/quixstreams/helpers/defaultdictkeyed.py
+++ b/src/PythonClient/src/quixstreams/helpers/defaultdictkeyed.py
@@ -1,0 +1,9 @@
+from collections import defaultdict
+
+class defaultdictkeyed(defaultdict):
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        else:
+            ret = self[key] = self.default_factory(key)
+            return ret

--- a/src/PythonClient/src/quixstreams/helpers/exceptionconverter.py
+++ b/src/PythonClient/src/quixstreams/helpers/exceptionconverter.py
@@ -18,4 +18,5 @@ class ExceptionConverter:
         if exception.exc_type == "System.Collections.Generic.KeyNotFoundException":
             raise KeyError(exception.message + "\n" + exception.exc_stack)
 
-        raise exception  # when not able to do better
+        # Unable to raise a more specific exception
+        raise exception

--- a/src/PythonClient/src/quixstreams/models/parametervalue.py
+++ b/src/PythonClient/src/quixstreams/models/parametervalue.py
@@ -5,7 +5,9 @@ from typing import Union
 from ..helpers.enumconverter import EnumConverter as ec
 from ..helpers.nativedecorator import nativedecorator
 from ..native.Python.InteropHelpers.ExternalTypes.System.Array import Array as ai
+from ..native.Python.InteropHelpers.InteropUtils import InteropUtils
 from ..native.Python.QuixStreamsStreaming.Models.ParameterValue import ParameterValue as pvi
+from ..native.Python.QuixStreamsStreaming.Models.TimeseriesDataParameter import TimeseriesDataParameter as tsdpi
 
 
 class ParameterValueType(Enum):
@@ -48,6 +50,16 @@ class ParameterValue(object):
         elif self._type == ParameterValueType.Numeric:
             self._numeric = self._interop.get_NumericValue()
             self._value = self._numeric
+
+    @staticmethod
+    def create_empty_instance(parameter_id: str):
+        tsdp_hptr = tsdpi.Constructor(parameter_id)
+        try:
+            pv_hptr = pvi.Constructor(0, tsdp_hptr)
+            return ParameterValue(pv_hptr)
+        finally:
+            InteropUtils.free_hptr(tsdp_hptr)
+
 
     @property
     def numeric_value(self) -> float:

--- a/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
@@ -81,14 +81,7 @@ class TimeseriesDataTimestamp:
                 if str is None:
                     return None
 
-                parameters_hptr = self._interop.get_Parameters()
-                try:
-                    key_uptr = iu.utf8_to_uptr(key)
-                    return _value_converter_to_python(di.GetValue(parameters_hptr, key_uptr))
-                finally:
-                    iu.free_hptr(parameters_hptr)
-
-
+                return ParameterValue.create_empty_instance(key)
 
             parameters_hptr = self._interop.get_Parameters()
             try:

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -2072,6 +2072,54 @@ class TestDictionary(BaseIntegrationTest):
 
 class TestMultipleStreams(BaseIntegrationTest):
 
+    def test_read_unavailable_parameter(self,
+                                           test_name,
+                                           topic_producer,
+                                           topic_consumer_earliest,
+                                           topic_name):
+        # Arrange
+        print(f'Starting Integration test "{test_name}"')
+        event = threading.Event()  # used for assertion
+
+
+        print("---- Subscribe to streams ----")
+
+        def on_dataframe_received_handler(stream_consumer: qx.StreamConsumer,
+                                          data: qx.TimeseriesData):
+            for row in data.timestamps:
+                some_integer = row.parameters["some_integer"].numeric_value
+                event.set()
+
+        def on_stream_received_handler(stream_consumer: qx.StreamConsumer):
+            print(f"Received stream {stream_consumer.stream_id}")
+            stream_consumer.timeseries.on_data_received = on_dataframe_received_handler
+
+
+
+        topic_consumer_earliest.on_stream_received = on_stream_received_handler
+
+        event = threading.Event()  # used to block sending until the consumer actually subscribed
+        print("---- Start publishing ----")
+
+        output_stream = topic_producer.create_stream(f"test-stream")
+        output_stream.timeseries.buffer \
+            .add_timestamp_nanoseconds(1) \
+            .add_value("some_string_param", "test") \
+            .publish()
+        output_stream.close()
+
+        InteropUtils.log_debug("-------- FLUSHING PRODUCER ---------")
+        topic_producer.flush()
+
+        InteropUtils.log_debug("-------- SUBSCRIBING TO CONSUMER ---------")
+
+        topic_consumer_earliest.subscribe()
+
+        InteropUtils.log_debug("-------- WAITING FOR MSGS ---------")
+
+        self.wait_for_result(event, 20)
+        InteropUtils.log_debug("-------- TEST DONE ---------")
+
     def test_multiple_streams_created_and_closed(self,
                                            test_name,
                                            topic_producer,

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -759,6 +759,55 @@ class TestGetOrCreateStream(BaseIntegrationTest):
 
 
 class TestTimeseriesData(BaseIntegrationTest):
+
+    def test_read_unavailable_parameter(self,
+                                           test_name,
+                                           topic_producer,
+                                           topic_consumer_earliest,
+                                           topic_name):
+        # Arrange
+        print(f'Starting Integration test "{test_name}"')
+        event = threading.Event()  # used for assertion
+
+
+        print("---- Subscribe to streams ----")
+
+        def on_dataframe_received_handler(stream_consumer: qx.StreamConsumer,
+                                          data: qx.TimeseriesData):
+            for row in data.timestamps:
+                some_integer = row.parameters["some_integer"].numeric_value
+                event.set()
+
+        def on_stream_received_handler(stream_consumer: qx.StreamConsumer):
+            print(f"Received stream {stream_consumer.stream_id}")
+            stream_consumer.timeseries.on_data_received = on_dataframe_received_handler
+
+
+
+        topic_consumer_earliest.on_stream_received = on_stream_received_handler
+
+        event = threading.Event()  # used to block sending until the consumer actually subscribed
+        print("---- Start publishing ----")
+
+        output_stream = topic_producer.create_stream(f"test-stream")
+        output_stream.timeseries.buffer \
+            .add_timestamp_nanoseconds(1) \
+            .add_value("some_string_param", "test") \
+            .publish()
+        output_stream.close()
+
+        InteropUtils.log_debug("-------- FLUSHING PRODUCER ---------")
+        topic_producer.flush()
+
+        InteropUtils.log_debug("-------- SUBSCRIBING TO CONSUMER ---------")
+
+        topic_consumer_earliest.subscribe()
+
+        InteropUtils.log_debug("-------- WAITING FOR MSGS ---------")
+
+        self.wait_for_result(event, 20)
+        InteropUtils.log_debug("-------- TEST DONE ---------")
+
     def test_timeseries_builder_works_with_any_number_type_and_none(self,
                                                                     test_name,
                                                                     topic_producer):
@@ -2071,54 +2120,6 @@ class TestDictionary(BaseIntegrationTest):
         assert state["statekey"] == "statevalue"
 
 class TestMultipleStreams(BaseIntegrationTest):
-
-    def test_read_unavailable_parameter(self,
-                                           test_name,
-                                           topic_producer,
-                                           topic_consumer_earliest,
-                                           topic_name):
-        # Arrange
-        print(f'Starting Integration test "{test_name}"')
-        event = threading.Event()  # used for assertion
-
-
-        print("---- Subscribe to streams ----")
-
-        def on_dataframe_received_handler(stream_consumer: qx.StreamConsumer,
-                                          data: qx.TimeseriesData):
-            for row in data.timestamps:
-                some_integer = row.parameters["some_integer"].numeric_value
-                event.set()
-
-        def on_stream_received_handler(stream_consumer: qx.StreamConsumer):
-            print(f"Received stream {stream_consumer.stream_id}")
-            stream_consumer.timeseries.on_data_received = on_dataframe_received_handler
-
-
-
-        topic_consumer_earliest.on_stream_received = on_stream_received_handler
-
-        event = threading.Event()  # used to block sending until the consumer actually subscribed
-        print("---- Start publishing ----")
-
-        output_stream = topic_producer.create_stream(f"test-stream")
-        output_stream.timeseries.buffer \
-            .add_timestamp_nanoseconds(1) \
-            .add_value("some_string_param", "test") \
-            .publish()
-        output_stream.close()
-
-        InteropUtils.log_debug("-------- FLUSHING PRODUCER ---------")
-        topic_producer.flush()
-
-        InteropUtils.log_debug("-------- SUBSCRIBING TO CONSUMER ---------")
-
-        topic_consumer_earliest.subscribe()
-
-        InteropUtils.log_debug("-------- WAITING FOR MSGS ---------")
-
-        self.wait_for_result(event, 20)
-        InteropUtils.log_debug("-------- TEST DONE ---------")
 
     def test_multiple_streams_created_and_closed(self,
                                            test_name,


### PR DESCRIPTION
Bugfix:
- When a parameter is missing from the parameters dictionary of a timestamp, it returns empty value in python rather than exception, identical to how it works in C# and worked before 0.5.0

Other:
- Allow ParameterValue to be instantiated publicly
- rename internal helper class "Parameter" to TimeseriesDataParameter
- Expose TimeseriesDataParameter publicly to allow instantiating empty ParameterValue with it
- Several improvements around Interop Generator (fix multi-dimensional array, InteropUtils improvements)
- In Python improved the comment around interop exception when the type can't be further specified
