### PR TITLE
Malloc/memleak fixes 

### DIFF
--- a/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/ExternalTypes/System/Dictionary.py
+++ b/src/InteropGenerator/Quix.InteropGenerator/Writers/PythonWrapperWriter/InteropHelpers/ExternalTypes/System/Dictionary.py
@@ -212,6 +212,14 @@ class Dictionary:
     def GetValue(dictionary_hptr: c_void_p, key_hptr: c_void_p) -> Any:
         ptr = InteropUtils.invoke("dictionary_get_value", dictionary_hptr, key_hptr)
         return c_void_p(ptr) if ptr is not None else None
+    
+    # ctypes function return type//parameter fix
+    interop_func = InteropUtils.get_function("dictionary_contains")
+    interop_func.argtypes = [c_void_p, c_void_p]
+    interop_func.restype = c_bool
+    @staticmethod
+    def Contains(dictionary_hptr: c_void_p, key_hptr: c_void_p) -> Any:
+        return InteropUtils.invoke("dictionary_contains", dictionary_hptr, key_hptr)
         
     # ctypes function return type//parameter fix
     interop_func = InteropUtils.get_function("dictionary_get_keys")

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.5.dev6"
+package_version = "0.5.5.dev9"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.5.dev10"
+package_version = "0.5.5.dev11"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.5.dev9"
+package_version = "0.5.5.dev10"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/src/quixstreams/__init__.py
+++ b/src/PythonClient/src/quixstreams/__init__.py
@@ -59,3 +59,5 @@ from .streamproducer import StreamProducer
 
 from .logging import Logging, LogLevel
 from .state import *
+from .states import *
+

--- a/src/PythonClient/src/quixstreams/helpers/nativedecorator.py
+++ b/src/PythonClient/src/quixstreams/helpers/nativedecorator.py
@@ -28,7 +28,7 @@ def nativedecorator(cls):
 
         ptr = getattr(self, "_interop").get_interop_ptr__()
 
-        InteropUtils.log_debug(f"Finalizing {cls.__name__} ({ptr.value})")
+        InteropUtils.log_debug(f"Finalizing {cls.__name__} ({ptr.value}) of object {id(self)}")
         InteropUtils.log_debug_indent_increment()
 
         self._nativedecorator_finalized = True
@@ -37,7 +37,7 @@ def nativedecorator(cls):
         getattr(self, "_interop").dispose_ptr__()
 
         InteropUtils.log_debug_indent_decrement()
-        InteropUtils.log_debug(f"Finalized {cls.__name__} ({ptr.value})")
+        InteropUtils.log_debug(f"Finalized {cls.__name__} ({ptr.value}) of object {id(self)}")
 
 
     def new_del(self):
@@ -61,7 +61,7 @@ def nativedecorator(cls):
 
         ptr = getattr(self, "_interop").get_interop_ptr__()
 
-        InteropUtils.log_debug(f"Disposing {cls.__name__} ({ptr.value})")
+        InteropUtils.log_debug(f"Disposing {cls.__name__} ({ptr.value}) of object {id(self)}")
         InteropUtils.log_debug_indent_increment()
 
         if self._nativedecorator_finalized:
@@ -71,7 +71,7 @@ def nativedecorator(cls):
         new_finalizerfunc(self)
 
         InteropUtils.log_debug_indent_decrement()
-        InteropUtils.log_debug(f"Disposed {cls.__name__} ({ptr.value})")
+        InteropUtils.log_debug(f"Disposed {cls.__name__} ({ptr.value}) of object {id(self)}")
 
     cls.__init__ = new_init
     cls._finalizerfunc = new_finalizerfunc

--- a/src/PythonClient/src/quixstreams/helpers/nativedecorator.py
+++ b/src/PythonClient/src/quixstreams/helpers/nativedecorator.py
@@ -18,6 +18,11 @@ def nativedecorator(cls):
         orig_init(self, *args, **kwargs)
 
     def new_finalizerfunc(self):
+        """
+        Finalizes the underlying object
+        Finalize is implementation specific but generally de-references the underlying objects which
+        may or may not result in garbage collection of the de-referenced objects
+        """
         if self._nativedecorator_finalized:
             return
 
@@ -47,7 +52,12 @@ def nativedecorator(cls):
         new_dispose(self)
         return result
 
-    def new_dispose(self, *args, **kwargs):
+    def new_dispose(self, *args, **kwargs) -> None:
+        """
+        Disposes the underlying object in addition to finalizing it
+        Dispose is implementation specific but it generally frees underlying resources rather than just
+        de-references
+        """
 
         ptr = getattr(self, "_interop").get_interop_ptr__()
 

--- a/src/PythonClient/src/quixstreams/models/netdict.py
+++ b/src/PythonClient/src/quixstreams/models/netdict.py
@@ -55,7 +55,7 @@ class ReadOnlyNetDict(object):
         self._finalizer.detach()
         InteropUtils.free_hptr(self._pointer)
 
-    def dispose(self):
+    def dispose(self) -> None:
         self._finalizer()
 
     def _get_actual_key_from(self, key) -> Any:

--- a/src/PythonClient/src/quixstreams/models/netdict.py
+++ b/src/PythonClient/src/quixstreams/models/netdict.py
@@ -139,15 +139,14 @@ class NetDict(ReadOnlyNetDict):
                  key_converter_to_python_list=None, val_converter_to_python_list=None,
                  self_dispose: bool = True):
 
-        ReadOnlyNetDict.__init__(self,
-                                 net_pointer=net_pointer,
-                                 key_converter_to_python=key_converter_to_python,
-                                 key_converter_from_python=key_converter_from_python,
-                                 val_converter_to_python=val_converter_to_python,
-                                 val_converter_from_python=val_converter_from_python,
-                                 key_converter_to_python_list=key_converter_to_python_list,
-                                 val_converter_to_python_list=val_converter_to_python_list,
-                                 self_dispose=self_dispose)
+        super().__init__(net_pointer=net_pointer,
+                         key_converter_to_python=key_converter_to_python,
+                         key_converter_from_python=key_converter_from_python,
+                         val_converter_to_python=val_converter_to_python,
+                         val_converter_from_python=val_converter_from_python,
+                         key_converter_to_python_list=key_converter_to_python_list,
+                         val_converter_to_python_list=val_converter_to_python_list,
+                         self_dispose=self_dispose)
 
     @staticmethod
     def constructor_for_string_string(net_pointer=None):

--- a/src/PythonClient/src/quixstreams/models/netdict.py
+++ b/src/PythonClient/src/quixstreams/models/netdict.py
@@ -80,9 +80,9 @@ class ReadOnlyNetDict(object):
         item = di.GetValue(self._pointer, actual_key)
         return self._get_actual_value_to(item)
 
-    def __contains__(self, item) -> bool:
-        actual_item = self._get_actual_value_from(item)
-        return di.GetValue(self._pointer, actual_item)
+    def __contains__(self, key) -> bool:
+        actual_key = self._get_actual_key_from(key)
+        return di.Contains(self._pointer, actual_key)
 
     def __str__(self) -> str:
         text = "{"

--- a/src/PythonClient/src/quixstreams/models/netdict.py
+++ b/src/PythonClient/src/quixstreams/models/netdict.py
@@ -57,7 +57,6 @@ class ReadOnlyNetDict(object):
 
     def _finalizerfunc(self):
         self._finalizer.detach()
-        InteropUtils.log_pointer(self._pointer, True)
         InteropUtils.free_hptr(self._pointer)
 
     def dispose(self) -> None:

--- a/src/PythonClient/src/quixstreams/models/netdict.py
+++ b/src/PythonClient/src/quixstreams/models/netdict.py
@@ -18,7 +18,8 @@ class ReadOnlyNetDict(object):
 
     def __init__(self, net_pointer, key_converter_to_python=None, key_converter_from_python=None,
                  val_converter_to_python=None, val_converter_from_python=None,
-                 key_converter_to_python_list=None, val_converter_to_python_list=None):
+                 key_converter_to_python_list=None, val_converter_to_python_list=None,
+                 self_dispose: bool = True):
 
         self._pointer = net_pointer
         self._key_converter_to_python = key_converter_to_python
@@ -49,10 +50,14 @@ class ReadOnlyNetDict(object):
                                                                                      converter_to_python=self._val_converter_to_python,
                                                                                      converter_from_python=self._val_converter_from_python)
 
-        self._finalizer = weakref.finalize(self, self._finalizerfunc)
+        if self_dispose:
+            self._finalizer = weakref.finalize(self, self._finalizerfunc)
+        else:
+            self._finalizer = lambda x: None
 
     def _finalizerfunc(self):
         self._finalizer.detach()
+        InteropUtils.log_pointer(self._pointer, True)
         InteropUtils.free_hptr(self._pointer)
 
     def dispose(self) -> None:
@@ -132,7 +137,8 @@ class NetDict(ReadOnlyNetDict):
 
     def __init__(self, net_pointer, key_converter_to_python=None, key_converter_from_python=None,
                  val_converter_to_python=None, val_converter_from_python=None,
-                 key_converter_to_python_list=None, val_converter_to_python_list=None):
+                 key_converter_to_python_list=None, val_converter_to_python_list=None,
+                 self_dispose: bool = True):
 
         ReadOnlyNetDict.__init__(self,
                                  net_pointer=net_pointer,
@@ -141,7 +147,8 @@ class NetDict(ReadOnlyNetDict):
                                  val_converter_to_python=val_converter_to_python,
                                  val_converter_from_python=val_converter_from_python,
                                  key_converter_to_python_list=key_converter_to_python_list,
-                                 val_converter_to_python_list=val_converter_to_python_list)
+                                 val_converter_to_python_list=val_converter_to_python_list,
+                                 self_dispose=self_dispose)
 
     @staticmethod
     def constructor_for_string_string(net_pointer=None):

--- a/src/PythonClient/src/quixstreams/models/netlist.py
+++ b/src/PythonClient/src/quixstreams/models/netlist.py
@@ -82,7 +82,7 @@ class NetList(NetReadOnlyList):
     """
 
     def __init__(self, net_pointer, converter_to_python=None, converter_from_python=None):
-        NetReadOnlyList.__init__(self, net_pointer, converter_to_python, converter_from_python)
+        super().__init__(net_pointer, converter_to_python, converter_from_python)
 
     @staticmethod
     def constructor_for_string(net_pointer=None):

--- a/src/PythonClient/src/quixstreams/models/netlist.py
+++ b/src/PythonClient/src/quixstreams/models/netlist.py
@@ -28,7 +28,7 @@ class NetReadOnlyList(object):
         self._finalizer.detach()
         InteropUtils.free_hptr(self._pointer)
 
-    def dispose(self):
+    def dispose(self) -> None:
         self._finalizer()
 
     def _get_actual_from(self, value):

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/streampropertiesconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/streampropertiesconsumer.py
@@ -42,8 +42,6 @@ class StreamPropertiesConsumer(object):
         self._parents = None
 
     def _finalizerfunc(self):
-        del self._metadata
-        del self._parents
         self._on_changed_dispose()
 
     def dispose(self) -> None:

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/streampropertiesconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/streampropertiesconsumer.py
@@ -42,6 +42,11 @@ class StreamPropertiesConsumer(object):
         self._parents = None
 
     def _finalizerfunc(self):
+        del self._metadata
+        del self._parents
+        self._on_changed_dispose()
+
+    def dispose(self) -> None:
         if self._metadata is not None:
             self._metadata.dispose()
         if self._parents is not None:

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/streamtimeseriesconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/streamtimeseriesconsumer.py
@@ -56,7 +56,6 @@ class StreamTimeseriesConsumer(object):
         self._on_definitions_changed_refs = None  # Keeping references to avoid GC.
 
     def _finalizerfunc(self):
-        del self._buffers
         self._on_data_received_dispose()
         self._on_raw_received_dispose()
         self._on_dataframe_received_dispose()

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/streamtimeseriesconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/streamtimeseriesconsumer.py
@@ -56,6 +56,13 @@ class StreamTimeseriesConsumer(object):
         self._on_definitions_changed_refs = None  # Keeping references to avoid GC.
 
     def _finalizerfunc(self):
+        del self._buffers
+        self._on_data_received_dispose()
+        self._on_raw_received_dispose()
+        self._on_dataframe_received_dispose()
+        self._on_definitions_changed_dispose()
+
+    def dispose(self) -> None:
         [buffer.dispose() for buffer in self._buffers]
         self._on_data_received_dispose()
         self._on_raw_received_dispose()

--- a/src/PythonClient/src/quixstreams/models/streamconsumer/timeseriesbufferconsumer.py
+++ b/src/PythonClient/src/quixstreams/models/streamconsumer/timeseriesbufferconsumer.py
@@ -28,7 +28,7 @@ class TimeseriesBufferConsumer(TimeseriesBuffer):
             raise Exception("TimeseriesBufferConsumer is none")
 
         self._interop = tsbci(net_pointer)
-        TimeseriesBuffer.__init__(self, stream_consumer, net_pointer)
+        super().__init__(stream_consumer, net_pointer)
 
     def get_net_pointer(self) -> ctypes.c_void_p:
         """

--- a/src/PythonClient/src/quixstreams/models/streamproducer/streamtimeseriesproducer.py
+++ b/src/PythonClient/src/quixstreams/models/streamproducer/streamtimeseriesproducer.py
@@ -33,7 +33,7 @@ class StreamTimeseriesProducer(object):
         self._stream_producer = stream_producer
 
     def _finalizerfunc(self):
-        del self._buffer
+        pass
 
     def dispose(self):
         if self._buffer is not None:

--- a/src/PythonClient/src/quixstreams/models/streamproducer/streamtimeseriesproducer.py
+++ b/src/PythonClient/src/quixstreams/models/streamproducer/streamtimeseriesproducer.py
@@ -33,6 +33,9 @@ class StreamTimeseriesProducer(object):
         self._stream_producer = stream_producer
 
     def _finalizerfunc(self):
+        del self._buffer
+
+    def dispose(self):
         if self._buffer is not None:
             self._buffer.dispose()
 

--- a/src/PythonClient/src/quixstreams/models/streamproducer/timeseriesbufferproducer.py
+++ b/src/PythonClient/src/quixstreams/models/streamproducer/timeseriesbufferproducer.py
@@ -37,7 +37,7 @@ class TimeseriesBufferProducer(TimeseriesBuffer):
             raise Exception("TimeseriesBufferProducer is none")
 
         self._interop = tsbpi(net_pointer)
-        super().__init_(stream_producer, net_pointer)
+        super().__init__(stream_producer, net_pointer)
 
     @property
     def default_tags(self) -> Dict[str, str]:

--- a/src/PythonClient/src/quixstreams/models/streamproducer/timeseriesbufferproducer.py
+++ b/src/PythonClient/src/quixstreams/models/streamproducer/timeseriesbufferproducer.py
@@ -37,7 +37,7 @@ class TimeseriesBufferProducer(TimeseriesBuffer):
             raise Exception("TimeseriesBufferProducer is none")
 
         self._interop = tsbpi(net_pointer)
-        TimeseriesBuffer.__init__(self, stream_producer, net_pointer)
+        super().__init_(stream_producer, net_pointer)
 
     @property
     def default_tags(self) -> Dict[str, str]:

--- a/src/PythonClient/src/quixstreams/models/timeseriesdata.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesdata.py
@@ -41,7 +41,7 @@ class TimeseriesData(object):
     def _finalizerfunc(self):
         # do not dispose individual timestamps,
         # let GC deal with it, otherwise might remove still used instances
-        self._timestamps = None
+        del self._timestamps
 
 
     # TODO

--- a/src/PythonClient/src/quixstreams/models/timeseriesdata.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesdata.py
@@ -41,7 +41,7 @@ class TimeseriesData(object):
     def _finalizerfunc(self):
         # do not dispose individual timestamps,
         # let GC deal with it, otherwise might remove still used instances
-        del self._timestamps
+        pass
 
 
     # TODO

--- a/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
@@ -34,6 +34,9 @@ class TimeseriesDataTimestamp:
         self._tags = None  # to cache whatever is read from .net
 
     def _finalizerfunc(self):
+        self._parameters = None
+
+    def dispose(self) -> None:
         self._clear_parameters()
 
     def _clear_parameters(self):

--- a/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
@@ -34,7 +34,7 @@ class TimeseriesDataTimestamp:
         self._tags = None  # to cache whatever is read from .net
 
     def _finalizerfunc(self):
-        del self._parameters
+        pass
 
     def dispose(self) -> None:
         self._clear_parameters()

--- a/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
+++ b/src/PythonClient/src/quixstreams/models/timeseriesdatatimestamp.py
@@ -34,7 +34,7 @@ class TimeseriesDataTimestamp:
         self._tags = None  # to cache whatever is read from .net
 
     def _finalizerfunc(self):
-        self._parameters = None
+        del self._parameters
 
     def dispose(self) -> None:
         self._clear_parameters()

--- a/src/PythonClient/src/quixstreams/raw/rawtopicconsumer.py
+++ b/src/PythonClient/src/quixstreams/raw/rawtopicconsumer.py
@@ -40,6 +40,9 @@ class RawTopicConsumer(object):
     def _finalizerfunc(self):
         self._on_message_received_dispose()
 
+    def dispose(self) -> None:
+        self._interop.Dispose()
+
     # region on_message_received
     @property
     def on_message_received(self) -> Callable[['RawTopicConsumer', RawMessage], None]:
@@ -128,6 +131,3 @@ class RawTopicConsumer(object):
         Starts subscribing to the streams.
         """
         self._interop.Subscribe()
-
-    def dispose(self):
-        self._interop.Dispose()

--- a/src/PythonClient/src/quixstreams/state/istatestorage.py
+++ b/src/PythonClient/src/quixstreams/state/istatestorage.py
@@ -101,7 +101,9 @@ class IStateStorage(object):
                 StateValue, str, int, float, bool, bytes, bytearray, or object (via pickle).
         """
 
-        se.Set6(self._pointer, key, StateValue(value).get_net_pointer())
+        sv = StateValue(value)
+        sv_pointer = sv.get_net_pointer()
+        se.Set6(self._pointer, key, sv_pointer)
 
     def contains_key(self, key: str) -> bool:
         """

--- a/src/PythonClient/src/quixstreams/state/statevalue.py
+++ b/src/PythonClient/src/quixstreams/state/statevalue.py
@@ -5,11 +5,13 @@ from typing import Any
 
 from .statetype import StateType
 from ..helpers.enumconverter import EnumConverter as ec
+from ..helpers.nativedecorator import nativedecorator
 from ..native.Python.InteropHelpers.ExternalTypes.System.Array import Array as ai
 from ..native.Python.QuixStreamsState.StateValue import StateValue as svi
 from ..native.Python.QuixStreamsState.StateValue_StateType import StateType as StateTypeInterop
 
 
+@nativedecorator
 class StateValue(object):
     """
     A wrapper class for values that can be stored inside the storage.

--- a/src/PythonClient/src/quixstreams/states/__init__.py
+++ b/src/PythonClient/src/quixstreams/states/__init__.py
@@ -1,0 +1,8 @@
+from .appstatemanager import AppStateManager
+from .topicstatemanager import TopicStateManager
+from .streamstatemanager import StreamStateManager
+from .dictstreamstate import DictStreamState
+from .scalarstreamstate import ScalarStreamState
+
+
+

--- a/src/PythonClient/src/quixstreams/states/dictstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/dictstreamstate.py
@@ -5,6 +5,7 @@ from typing import List, Tuple
 from ..helpers.nativedecorator import nativedecorator
 from ..native.Python.InteropHelpers.InteropUtils import InteropUtils
 from ..native.Python.InteropHelpers.ExternalTypes.System.Array import Array as ai
+from ..native.Python.InteropHelpers.ExternalTypes.System.Dictionary import Dictionary as di
 from ..native.Python.QuixStreamsStreaming.States.StreamDictionaryState import StreamDictionaryState as sdsi
 
 from ..models.netdict import NetDict
@@ -14,6 +15,44 @@ from typing import TypeVar, Generic, Callable
 
 StreamStateType = TypeVar('StreamStateType')
 
+class _UnderlyingNetDict(NetDict):
+    def __init__(self, net_pointer):
+
+        def value_converter(val):
+            return StateValue(val)
+
+        def convert_val_to_python(val_hptr: ctypes.c_void_p) -> StreamStateType:
+            if val_hptr is None:
+                return None
+            return StateValue(val_hptr).value
+
+        def convert_val_from_python(val: StreamStateType) -> ctypes.c_void_p:
+            if val is None:
+                return None
+            return value_converter(val)
+
+        def convert_val_to_python_list(arr_uptr: ctypes.c_void_p) -> List[StateValue]:
+            hptrs = ai.ReadPointers(arr_uptr)
+            return [StateValue(hptr) for hptr in hptrs]
+
+        NetDict.__init__(self,
+                         net_pointer=net_pointer,
+                         key_converter_to_python=InteropUtils.ptr_to_utf8,
+                         key_converter_from_python=InteropUtils.utf8_to_ptr,
+                         val_converter_to_python=convert_val_to_python,
+                         val_converter_from_python=convert_val_from_python,
+                         key_converter_to_python_list=ai.ReadStrings,
+                         val_converter_to_python_list=convert_val_to_python_list,
+                         self_dispose=False)
+
+    def __setitem__(self, key, value):
+        actual_key = self._get_actual_key_from(key)
+        intermediate_val = self._get_actual_value_from(value)
+        if intermediate_val is None:
+            di.SetValue(self._pointer, actual_key, None)
+        else:
+            actual_value = intermediate_val.get_net_pointer()
+            di.SetValue(self._pointer, actual_key, actual_value)
 
 @nativedecorator
 class DictStreamState(Generic[StreamStateType]):
@@ -43,32 +82,9 @@ class DictStreamState(Generic[StreamStateType]):
         self._default_value_factory = default_value_factory
         self._type = state_type
 
-        def value_converter(val):
-            return StateValue(val)
-
-        def convert_val_to_python(val_hptr : ctypes.c_void_p) -> StreamStateType:
-            if val_hptr is None:
-                return None
-            return StateValue(val_hptr).value
-
-        def convert_val_from_python(val: StreamStateType) -> ctypes.c_void_p:
-            if val is None:
-                return None
-            return value_converter(val).get_net_pointer()
-
-        def convert_val_to_python_list(arr_uptr: ctypes.c_void_p) -> List[StateValue]:
-            hptrs = ai.ReadPointers(arr_uptr)
-            return [StateValue(hptr) for hptr in hptrs]
 
         self._in_memory = {}
-        self._underlying = NetDict(net_pointer=net_pointer,
-                                   key_converter_to_python=InteropUtils.ptr_to_utf8,
-                                   key_converter_from_python=InteropUtils.utf8_to_ptr,
-                                   val_converter_to_python=convert_val_to_python,
-                                   val_converter_from_python=convert_val_from_python,
-                                   key_converter_to_python_list=ai.ReadStrings,
-                                   val_converter_to_python_list=convert_val_to_python_list,
-                                   self_dispose=False)
+        self._underlying = _UnderlyingNetDict(net_pointer=net_pointer)
 
         # Define events and their reference holders
         self._on_flushed = None

--- a/src/PythonClient/src/quixstreams/states/dictstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/dictstreamstate.py
@@ -67,7 +67,8 @@ class DictStreamState(Generic[StreamStateType]):
                                    val_converter_to_python=convert_val_to_python,
                                    val_converter_from_python=convert_val_from_python,
                                    key_converter_to_python_list=ai.ReadStrings,
-                                   val_converter_to_python_list=convert_val_to_python_list)
+                                   val_converter_to_python_list=convert_val_to_python_list,
+                                   self_dispose=False)
 
         # Define events and their reference holders
         self._on_flushed = None

--- a/src/PythonClient/src/quixstreams/states/dictstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/dictstreamstate.py
@@ -35,8 +35,7 @@ class _UnderlyingNetDict(NetDict):
             hptrs = ai.ReadPointers(arr_uptr)
             return [StateValue(hptr) for hptr in hptrs]
 
-        NetDict.__init__(self,
-                         net_pointer=net_pointer,
+        super().__init__(net_pointer=net_pointer,
                          key_converter_to_python=InteropUtils.ptr_to_utf8,
                          key_converter_from_python=InteropUtils.utf8_to_ptr,
                          val_converter_to_python=convert_val_to_python,

--- a/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
@@ -104,7 +104,7 @@ class ScalarStreamState(Generic[StreamStateType]):
 
     def _on_flushed_wrapper(self, sender_hptr, args_hptr):
         try:
-            self._on_flushed(self._stream_consumer)
+            self._on_flushed()
         except:
             traceback.print_exc()
         finally:

--- a/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
+++ b/src/PythonClient/src/quixstreams/states/scalarstreamstate.py
@@ -192,9 +192,9 @@ class ScalarStreamState(Generic[StreamStateType]):
     def _underlying_value(self, python_value: StreamStateType):
         if python_value is None:
             return None
-        net_value = StateValue(python_value).get_net_pointer()
+        sv = StateValue(python_value)
+        net_value = sv.get_net_pointer()
         self._interop.set_Value(net_value)
-
 
     @property
     def value(self):
@@ -207,18 +207,16 @@ class ScalarStreamState(Generic[StreamStateType]):
 
         if self._in_memory_value is not None:
             return self._in_memory_value
-        else:
-            if self._underlying_value is not None:
-                _value = self._underlying_value
-            else:
-                if self._default_value_factory is None:
-                    raise
 
-                value = self._default_value_factory()
-                return value
+        if self._underlying_value is None:
+            if self._default_value_factory is None:
+                return None
 
-            self._in_memory_value = _value
-            return _value
+            value = self._default_value_factory()
+            return value
+
+        self._in_memory_value = self._underlying_value
+        return self._in_memory_value
 
     @value.setter
     def value(self, val: StreamStateType):

--- a/src/PythonClient/src/quixstreams/states/streamstatemanager.py
+++ b/src/PythonClient/src/quixstreams/states/streamstatemanager.py
@@ -38,7 +38,7 @@ class StreamStateManager(object):
         self._interop = ssmi(net_pointer)
 
     def _finalizerfunc(self):
-        del self._cache
+        pass
 
     def dispose(self) -> None:
         for (k, v) in self._cache.items():

--- a/src/PythonClient/src/quixstreams/states/streamstatemanager.py
+++ b/src/PythonClient/src/quixstreams/states/streamstatemanager.py
@@ -38,6 +38,9 @@ class StreamStateManager(object):
         self._interop = ssmi(net_pointer)
 
     def _finalizerfunc(self):
+        del self._cache
+
+    def dispose(self) -> None:
         for (k, v) in self._cache.items():
             v.dispose()
 

--- a/src/PythonClient/src/quixstreams/streamconsumer.py
+++ b/src/PythonClient/src/quixstreams/streamconsumer.py
@@ -59,6 +59,10 @@ class StreamConsumer(object):
         self._stream_state_manager = None
 
     def _finalizerfunc(self):
+        self._on_stream_closed_dispose()
+        self._on_package_received_dispose()
+
+    def dispose(self):
         if self._streamTimeseriesConsumer is not None:
             self._streamTimeseriesConsumer.dispose()
         if self._streamEventsConsumer is not None:
@@ -107,7 +111,7 @@ class StreamConsumer(object):
         self._on_stream_closed_dispose()
 
         if self._on_stream_closed is None and self._on_stream_closed_internal is None:
-            return # there is nothing to subscribe for
+            return  # there is nothing to subscribe for
 
         self._on_stream_closed_refs = self._interop.add_OnStreamClosed(self._on_stream_closed_wrapper)
 

--- a/src/PythonClient/src/quixstreams/streamproducer.py
+++ b/src/PythonClient/src/quixstreams/streamproducer.py
@@ -47,9 +47,6 @@ class StreamProducer(object):
         self._stream_id = self._interop.get_StreamId()
 
     def _finalizerfunc(self):
-        del self._streamTimeseriesProducer
-        del self._streamEventsProducer
-        del self._streamPropertiesProducer
         self._on_write_exception_dispose()
 
     def dispose(self) -> None:

--- a/src/PythonClient/src/quixstreams/streamproducer.py
+++ b/src/PythonClient/src/quixstreams/streamproducer.py
@@ -47,6 +47,12 @@ class StreamProducer(object):
         self._stream_id = self._interop.get_StreamId()
 
     def _finalizerfunc(self):
+        del self._streamTimeseriesProducer
+        del self._streamEventsProducer
+        del self._streamPropertiesProducer
+        self._on_write_exception_dispose()
+
+    def dispose(self) -> None:
         if self._streamTimeseriesProducer is not None:
             self._streamTimeseriesProducer.dispose()
         if self._streamEventsProducer is not None:

--- a/src/PythonClient/src/quixstreams/topicconsumer.py
+++ b/src/PythonClient/src/quixstreams/topicconsumer.py
@@ -55,6 +55,16 @@ class TopicConsumer(object):
         self._on_revoking_dispose()
         self._on_committing_dispose()
         self._on_committed_dispose()
+        del self._topic_state_manager
+
+        del self._active_streams
+
+    def dispose(self) -> None:
+        self._on_stream_received_dispose()
+        self._on_streams_revoked_dispose()
+        self._on_revoking_dispose()
+        self._on_committing_dispose()
+        self._on_committed_dispose()
         if self._topic_state_manager is not None:
             self._topic_state_manager.dispose()
 

--- a/src/PythonClient/src/quixstreams/topicconsumer.py
+++ b/src/PythonClient/src/quixstreams/topicconsumer.py
@@ -55,8 +55,6 @@ class TopicConsumer(object):
         self._on_revoking_dispose()
         self._on_committing_dispose()
         self._on_committed_dispose()
-        del self._topic_state_manager
-        del self._active_streams
 
     def dispose(self) -> None:
         self._on_stream_received_dispose()
@@ -112,7 +110,6 @@ class TopicConsumer(object):
                     for v in self._active_streams:
                         InteropUtils.log_debug(f"  Stream {v.stream_id}");
                     self._active_streams.remove(stream)
-                    stream.dispose()
 
             stream = StreamConsumer(stream_hptr, self, remove_active_stream)
             InteropUtils.log_debug(f"Adding {stream.stream_id} to the active streams")

--- a/src/PythonClient/src/quixstreams/topicconsumer.py
+++ b/src/PythonClient/src/quixstreams/topicconsumer.py
@@ -56,7 +56,6 @@ class TopicConsumer(object):
         self._on_committing_dispose()
         self._on_committed_dispose()
         del self._topic_state_manager
-
         del self._active_streams
 
     def dispose(self) -> None:

--- a/src/PythonClient/src/quixstreams/topicproducer.py
+++ b/src/PythonClient/src/quixstreams/topicproducer.py
@@ -33,7 +33,7 @@ class TopicProducer(object):
     def _finalizerfunc(self):
         self._on_disposed_dispose()
 
-    def dispose(self):
+    def dispose(self) -> None:
         """
         Flushes pending data to the broker and disposes underlying resources
         """

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -2119,7 +2119,32 @@ class TestDictionary(BaseIntegrationTest):
 
         assert state["statekey"] == "statevalue"
 
-class TestMultipleStreams(BaseIntegrationTest):
+class TestUseCases(BaseIntegrationTest):
+
+    def test_multiple_retrieval_of_same_stream(self,
+                                               test_name,
+                                               topic_producer):
+        # Also tests if the dispose/finalize is done correctly
+
+        print(f'Starting Integration test "{test_name}"')
+
+        stream_created = 0
+        def on_stream_create(stream: qx.StreamProducer):
+            nonlocal stream_created
+            stream_created = stream_created + 1
+
+        print("---- Get stream for the first time ----")
+
+        topic_producer.get_or_create_stream("test", on_stream_create).properties.location = "test"
+
+        print("---- Get stream for the second time ----")
+
+        topic_producer.get_or_create_stream("test", on_stream_create).properties.location = "test"
+
+        print("---- Assert ----")
+
+        assert stream_created == 1
+
 
     def test_multiple_streams_created_and_closed(self,
                                            test_name,

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -1799,6 +1799,21 @@ class TestRawData(BaseIntegrationTest):
         assert len(received_messages) == 3
 
 class TestStreamState(BaseIntegrationTest):
+
+    def test_in_dict_state(self):
+        app_state_manager = qx.App.get_state_manager()
+        topic_state_manager = app_state_manager.get_topic_state_manager("topic")
+        stream_state_manager = topic_state_manager.get_stream_state_manager("test-stream")
+        dict_state = stream_state_manager.get_dict_state("test")
+
+        if "a" in dict_state:
+            assert False
+
+        dict_state["a"] = "b"
+
+        if "a" not in dict_state:
+            assert False
+
     def test_stream_state_manager(self,
                                   test_name,
                                   topic_consumer_earliest,

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -1806,13 +1806,11 @@ class TestStreamState(BaseIntegrationTest):
         stream_state_manager = topic_state_manager.get_stream_state_manager("test-stream")
         dict_state = stream_state_manager.get_dict_state("test")
 
-        if "a" in dict_state:
-            assert False
+        assert "a" in dict_state
 
         dict_state["a"] = "b"
 
-        if "a" not in dict_state:
-            assert False
+        assert "a" not in dict_state
 
     def test_stream_state_manager(self,
                                   test_name,

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -223,6 +223,7 @@ class TestStreamProperties(BaseIntegrationTest):
                                      test_name,
                                      topic_producer: qx.TopicProducer
                                      ):
+
         # Arrange
         print(f'Starting Integration test "{test_name}"')
         print("---- Start publishing ----")
@@ -236,8 +237,7 @@ class TestStreamProperties(BaseIntegrationTest):
             self,
             test_name,
             topic_consumer_earliest: qx.TopicConsumer,
-            topic_producer: qx.TopicProducer
-    ):
+            topic_producer: qx.TopicProducer):
         # Arrange
         print(f'Starting Integration test "{test_name}"')
         event = threading.Event()  # used to trigger evaluation

--- a/src/PythonClient/tests/quixstreams/manual/manual_test_consume.py
+++ b/src/PythonClient/tests/quixstreams/manual/manual_test_consume.py
@@ -19,7 +19,7 @@ commit_settings = qx.CommitOptions()
 commit_settings.commit_every = 10000
 commit_settings.commit_interval = None
 commit_settings.auto_commit_enabled = False
-topic_consumer = client.get_topic_consumer('generated-data', 'whateva', auto_offset_reset=AutoOffsetReset.Latest)
+topic_consumer = client.get_topic_consumer('generated-data', 'whateva', auto_offset_reset=AutoOffsetReset.Earliest)
 
 
 def on_streams_revoked_handler(topic_consumer: qx.TopicConsumer, readers: [qx.StreamConsumer]):
@@ -45,7 +45,7 @@ def on_revoking_handler(topic_consumer: qx.topicconsumer):
 
 from src.quixstreams.state import LocalFileStorage, InMemoryStorage
 
-storage = InMemoryStorage(LocalFileStorage("state/test"))
+storage = InMemoryStorage()
 storage.clear()
 storage.set("floatval", 12.51)
 storage.set("stringval", "str")
@@ -54,7 +54,6 @@ storage.set("objval", {"dic": "tionary"})
 
 topic_consumer.on_streams_revoked = on_streams_revoked_handler
 topic_consumer.on_committed = on_committed_handler
-topic_consumer.on_committing = storage.flush
 topic_consumer.on_revoking = on_revoking_handler
 
 #read streams

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.5.0"
-informal_version = "0.5.5.0-dev9"
-nuget_version = "0.5.5.0-dev9"
+informal_version = "0.5.5.0-10"
+nuget_version = "0.5.5.0-dev10"
 
 
 def updatecsproj(projfilepath):

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.5.0"
-informal_version = "0.5.5.0-dev6"
-nuget_version = "0.5.5.0-dev6"
+informal_version = "0.5.5.0-dev9"
+nuget_version = "0.5.5.0-dev9"
 
 
 def updatecsproj(projfilepath):

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,7 +7,7 @@ import fileinput
 from typing import List
 
 version = "0.5.5.0"
-informal_version = "0.5.5.0-10"
+informal_version = "0.5.5.0-dev10"
 nuget_version = "0.5.5.0-dev10"
 
 

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.5.0"
-informal_version = "0.5.5.0-dev10"
-nuget_version = "0.5.5.0-dev10"
+informal_version = "0.5.5.0-dev11"
+nuget_version = "0.5.5.0-dev11"
 
 
 def updatecsproj(projfilepath):


### PR DESCRIPTION
- Update how finalize and dispose works
- Avoid exception due to disposing dictionary twice when it is linked to the same pointer
- Fix 'contains' implementation for netdict
- Fix incorrect scalar state callback value for on_flushed event
- Fix statevalue leaks

Other:
- Use super().__init__ instaed of <classname>.__init__