### PR TITLE
Reduce debug log verbosity when broker connections are reaped due to inactivity or other

### DIFF
--- a/src/CsharpClient/QuixStreams.Transport.Kafka/KafkaProducer.cs
+++ b/src/CsharpClient/QuixStreams.Transport.Kafka/KafkaProducer.cs
@@ -104,6 +104,8 @@ namespace QuixStreams.Transport.Kafka
             lock (this.openLock)
             {
                 if (this.producer != null) return;
+                lastReportedBrokerDownMessage = string.Empty;
+                checkBrokerStateBeforeSend = false;
 
                 this.producer = new ProducerBuilder<byte[], byte[]>(this.config)
                     .SetErrorHandler(this.ErrorHandler)

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.5"
+package_version = "0.5.6.dev2"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -6,9 +6,9 @@ import shutil
 import fileinput
 from typing import List
 
-version = "0.5.5.0"
-informal_version = "0.5.5.0"
-nuget_version = "0.5.5.0"
+version = "0.5.6.0"
+informal_version = "0.5.6.0-dev2"
+nuget_version = "0.5.6.0-dev2"
 
 
 def updatecsproj(projfilepath):


### PR DESCRIPTION
Only log if the message is different or there was a reconnect since.