### PR TITLE
0.5.6 update and improving file based storage resiliency

### DIFF
--- a/src/CsharpClient/QuixStreams.RawReadSamples/QuixStreams.RawReadSamples.csproj
+++ b/src/CsharpClient/QuixStreams.RawReadSamples/QuixStreams.RawReadSamples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Configurations>Debug;Release;Python</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>

--- a/src/CsharpClient/QuixStreams.State.UnitTests/LocalCrudShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/LocalCrudShould.cs
@@ -1,15 +1,20 @@
+using Quix.TestBase.Extensions;
 using QuixStreams.State.Storage;
 using QuixStreams.State.Storage.FileStorage;
 using QuixStreams.State.Storage.FileStorage.LocalFileStorage;
+using Xunit.Abstractions;
 
 namespace QuixStreams.State.UnitTests
 {
     public class LocalCRUDShould : BaseCRUDShould
     {
-        override
-        protected BaseFileStorage GetStorage()
+        public LocalCRUDShould(ITestOutputHelper output) : base(output)
         {
-            var storage = new LocalFileStorage();
+        }
+        
+        protected override BaseFileStorage GetStorage()
+        {
+            var storage = new LocalFileStorage(loggerFactory:this.output.CreateLoggerFactory());
             storage.Clear();
             return storage;
         }

--- a/src/CsharpClient/QuixStreams.State.UnitTests/QuixStreams.State.UnitTests.csproj
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/QuixStreams.State.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release;Python</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/src/CsharpClient/QuixStreams.State.UnitTests/QuixStreams.State.UnitTests.csproj
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/QuixStreams.State.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release;Python</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/src/CsharpClient/QuixStreams.State.UnitTests/ScalarStateShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/ScalarStateShould.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using QuixStreams.State.Storage;
 using Xunit;
@@ -62,6 +63,36 @@ namespace QuixStreams.State.UnitTests
 
             // Assert
             storage.Get(ScalarState.StorageKey).StringValue.Should().BeEquivalentTo("value");
+        }
+        
+        [Fact]
+        public void ListConversion_ShouldStoreAndRetrieveCorrectly()
+        {
+            var storage = new InMemoryStorage();
+            var key = "TestKey";
+            var state = new DictionaryState<List<int>>(storage);
+            state.Clear();
+
+            var list = new List<int>();
+            state[key] = list;
+            state[key].Add(1);
+            list.Add(2);
+            list.Add(3);
+
+            // No change is expected!
+            state[key].Should().BeEquivalentTo(new List<StateTemplatedShould.CustomClass>());
+
+            state[key] = list;
+
+            state[key].Count.Should().Be(2);
+            state[key].Should().BeEquivalentTo(list, o => o.WithStrictOrdering());
+
+            state.Flush();
+
+            var state2 = new DictionaryState<List<int>>(storage);
+
+            state2[key].Count.Should().Be(2);
+            state2[key].Should().BeEquivalentTo(list, o => o.WithStrictOrdering());
         }
         
         [Fact]

--- a/src/CsharpClient/QuixStreams.State.UnitTests/StateTemplatedShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/StateTemplatedShould.cs
@@ -334,12 +334,19 @@ namespace QuixStreams.State.UnitTests
             state.Clear();
 
             var customObject = new CustomClass { Id = 1, Name = "TestObject" };
-            state[key] = new List<CustomClass>();
+            var list = new List<CustomClass>();
+            state[key] = list;
             state[key].Add(customObject);
-            state[key].Add(customObject);
+            list.Add(customObject);
+            list.Add(customObject);
+
+            // No change is expected!
+            state[key].Should().BeEquivalentTo(new List<CustomClass>());
+
+            state[key] = list;
 
             state[key].Count.Should().Be(2);
-            state[key].All(y => y == customObject).Should().BeTrue();
+            state[key].All(y => y.Equals(customObject)).Should().BeTrue();
 
             state.Flush();
 

--- a/src/CsharpClient/QuixStreams.State.UnitTests/StateTemplatedShould.cs
+++ b/src/CsharpClient/QuixStreams.State.UnitTests/StateTemplatedShould.cs
@@ -6,496 +6,497 @@ using FluentAssertions.Common;
 using QuixStreams.State.Storage;
 using Xunit;
 
-namespace QuixStreams.State.UnitTests;
-
-public class StateTemplatedShould
+namespace QuixStreams.State.UnitTests
 {
-    [Fact]
-    public void Constructor_ShouldCreateState()
+    public class StateTemplatedShould
     {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<int>(storage);
-
-        state.Should().NotBeNull();
-    }
-
-    [Fact]
-    public void Constructor_WithNullStateStorage_ShouldThrowArgumentNullException()
-    {
-        Action nullTopicName = () => new DictionaryState<int>((IStateStorage)null);
-
-        nullTopicName.Should().Throw<ArgumentNullException>().WithMessage("*storage*");
-    }
-
-
-    [Theory]
-    [InlineData("TestKey", "TestValue")]
-    public void StringConversion_ShouldStoreAndRetrieveCorrectly(string key, string value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<string>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<string>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", 3.14)]
-    public void DoubleConversion_ShouldStoreAndRetrieveCorrectly(string key, double value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<double>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<double>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", 3.146546597897)]
-    public void DecimalConversion_ShouldStoreAndRetrieveCorrectly(string key, decimal value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<decimal>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<decimal>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", 42.0f)]
-    public void FloatConversion_ShouldStoreAndRetrieveCorrectly(string key, float value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<float>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<float>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", true)]
-    [InlineData("TestKey", false)]
-    public void BoolConversion_ShouldStoreAndRetrieveCorrectly(string key, bool value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<bool>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<bool>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-
-    [Theory]
-    [InlineData("TestKey", 'A')]
-    public void CharConversion_ShouldStoreAndRetrieveCorrectly(string key, char value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<char>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<char>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", 1234567890123456789L)]
-    public void LongConversion_ShouldStoreAndRetrieveCorrectly(string key, long value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<long>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<long>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", 1234567890123456789UL)]
-    public void UlongConversion_ShouldStoreAndRetrieveCorrectly(string key, ulong value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<ulong>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<ulong>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-
-    [Theory]
-    [InlineData("TestKey", 42)]
-    public void IntConversion_ShouldStoreAndRetrieveCorrectly(string key, int value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<int>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<int>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", 42u)]
-    public void UintConversion_ShouldStoreAndRetrieveCorrectly(string key, uint value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<uint>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<uint>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", (short)42)]
-    public void ShortConversion_ShouldStoreAndRetrieveCorrectly(string key, short value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<short>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<short>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", (ushort)42u)]
-    public void UshortConversion_ShouldStoreAndRetrieveCorrectly(string key, ushort value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<ushort>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<ushort>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", (byte)42)]
-    public void ByteConversion_ShouldStoreAndRetrieveCorrectly(string key, byte value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<byte>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<byte>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [InlineData("TestKey", (sbyte)42u)]
-    public void SbyteConversion_ShouldStoreAndRetrieveCorrectly(string key, sbyte value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<sbyte>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<sbyte>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    [Theory]
-    [MemberData(nameof(GetDateTimeValues))]
-    public void DatetimeConversion_ShouldStoreAndRetrieveCorrectly(string key, DateTime value)
-    {
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<DateTime>(storage);
-
-        state[key] = value;
-
-        state[key].Should().Be(value);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<DateTime>(storage);
-
-        state2[key].Should().Be(value);
-    }
-
-    public static IEnumerable<object[]> GetDateTimeValues()
-    {
-        yield return new object[] { "someKey", DateTime.UtcNow };
-    }
-
-    [Fact]
-    public void CustomClassConversion_ShouldStoreAndRetrieveCorrectly()
-    {
-        var storage = new InMemoryStorage();
-        var key = "TestKey";
-        var state = new DictionaryState<CustomClass>(storage);
-
-        var customObject = new CustomClass { Id = 1, Name = "TestObject" };
-        state[key] = customObject;
-
-        state[key].Should().BeEquivalentTo(customObject);
-
-        state.Flush();
-
-        var state2 = new DictionaryState<CustomClass>(storage);
-
-        state2[key].Should().BeEquivalentTo(customObject);
-    }
-
-    [Fact]
-    public void ListCustomClassConversion_ShouldStoreAndRetrieveCorrectly()
-    {
-        var storage = new InMemoryStorage();
-        var key = "TestKey";
-        var state = new DictionaryState<List<CustomClass>>(storage);
-        state.Clear();
-
-        var customObject = new CustomClass { Id = 1, Name = "TestObject" };
-        state[key] = new List<CustomClass>();
-        state[key].Add(customObject);
-        state[key].Add(customObject);
-
-        state[key].Count.Should().Be(2);
-        state[key].All(y => y == customObject).Should().BeTrue();
-
-        state.Flush();
-
-        var state2 = new DictionaryState<List<CustomClass>>(storage);
-
-        state2[key].Count.Should().Be(2);
-        state2[key].All(y => y.IsSameOrEqualTo(customObject)).Should().BeTrue();
-    }
-
-    [Fact]
-    public void OperationWithElement_ShouldStoreAndRetrieveCorrectly()
-    {
-        var storage = new InMemoryStorage();
-        var key = "TestKey";
-        var state = new DictionaryState<int>(storage);
-
-        state[key] += 2;
-        state[key] -= 1;
-        state[key] *= 8;
-
-        state[key].Should().Be(8);
-    }
-
-
-    [Fact]
-    public void Clear_ShouldRemoveAllValues()
-    {
-        var storage = new InMemoryStorage();
-        // Arrange
-        var state = new DictionaryState<string>(storage);
-        state.Add("Key1", "Value1");
-        state.Add("Key2", "Value2");
-
-        // Act
-        state.Clear();
-        state.Count.Should().Be(0);
-        state.Flush();
-        var state2 = new DictionaryState<string>(storage);
-
-        // Assert
-        state2.Count.Should().Be(0);
-    }
-
-    [Fact]
-    public void ComplexModifications_ShouldHaveExpectedValues()
-    {
-        var storage = new InMemoryStorage();
-        // Arrange
-        var state = new DictionaryState<string>(storage);
-
-        // Act 1
-        state.Add("Key1", "Value1"); // will keep as is, before clear
-        state.Add("Key2", "Value2"); // will remove, before clear
-        state.Add("Key3", "Value3"); // will override, before clear
-        state["Key4"] = "Value4"; // leave as is
-        state.Remove("Key2");
-        state["Key3"] = "Value3b";
-        state.Clear();
-        state.Add("Key5", "Value5"); // will keep as is
-        state.Add("Key6", "Value6"); // will remove
-        state.Add("Key7", "Value7"); // will override
-        state["Key8"] = "Value8"; // leave as is
-        state.Remove("Key5");
-        state["Key6"] = "Value6b";
-
-        // Assert 1
-        state.Count.Should().Be(3);
-        state["Key6"].Should().Be("Value6b");
-        state["Key7"].Should().Be("Value7");
-        state["Key8"].Should().Be("Value8");
-
-        // Act 2
-        state.Flush();
-        state["Key8"] = "Value8";
-        state.Flush();
-
-        // Assert 2
-        state.Count.Should().Be(3);
-        state["Key6"].Should().Be("Value6b");
-        state["Key7"].Should().Be("Value7");
-        state["Key8"].Should().Be("Value8");
-
-        // Act 3
-        var state2 = new DictionaryState<string>(storage);
-
-        // Assert 3
-        state2.Count.Should().Be(3);
-        state2["Key6"].Should().Be("Value6b");
-        state2["Key7"].Should().Be("Value7");
-        state2["Key8"].Should().Be("Value8");
-    }
-
-    [Fact]
-    public void Reset_Modified_ShouldResetToSaved()
-    {
-        // Arrange
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<string>(storage);
-        state.Add("key", "value");
-        state.Flush();
-
-        // Act
-        state["key"] = "updatedValue";
-        state.Reset();
-
-        // Assert
-        var value = state["key"];
-        value.Should().BeEquivalentTo("value");
-    }
-
-    [Fact]
-    public void Add_WithNullValue_ShouldRemoveFromState()
-    {
-        // Arrange
-        var storage = new InMemoryStorage();
-        var state = new DictionaryState<object>(storage);
-        state.Add("key", "value");
-        state.Flush();
-        storage.ContainsKey("key").Should().BeTrue();
-
-        // Act
-        state["key"] = null;
-        state.Flush();
-
-        // Assert
-        var value = state["key"];
-        value.Should().BeNull();
-        storage.ContainsKey("key").Should().BeFalse();
-    }
-
-    public class CustomClass : IEquatable<CustomClass>
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-
-        public bool Equals(CustomClass other)
+        [Fact]
+        public void Constructor_ShouldCreateState()
         {
-            if (other == null)
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<int>(storage);
+
+            state.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Constructor_WithNullStateStorage_ShouldThrowArgumentNullException()
+        {
+            Action nullTopicName = () => new DictionaryState<int>((IStateStorage)null);
+
+            nullTopicName.Should().Throw<ArgumentNullException>().WithMessage("*storage*");
+        }
+
+
+        [Theory]
+        [InlineData("TestKey", "TestValue")]
+        public void StringConversion_ShouldStoreAndRetrieveCorrectly(string key, string value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<string>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<string>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", 3.14)]
+        public void DoubleConversion_ShouldStoreAndRetrieveCorrectly(string key, double value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<double>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<double>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", 3.146546597897)]
+        public void DecimalConversion_ShouldStoreAndRetrieveCorrectly(string key, decimal value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<decimal>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<decimal>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", 42.0f)]
+        public void FloatConversion_ShouldStoreAndRetrieveCorrectly(string key, float value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<float>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<float>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", true)]
+        [InlineData("TestKey", false)]
+        public void BoolConversion_ShouldStoreAndRetrieveCorrectly(string key, bool value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<bool>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<bool>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+
+        [Theory]
+        [InlineData("TestKey", 'A')]
+        public void CharConversion_ShouldStoreAndRetrieveCorrectly(string key, char value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<char>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<char>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", 1234567890123456789L)]
+        public void LongConversion_ShouldStoreAndRetrieveCorrectly(string key, long value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<long>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<long>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", 1234567890123456789UL)]
+        public void UlongConversion_ShouldStoreAndRetrieveCorrectly(string key, ulong value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<ulong>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<ulong>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+
+        [Theory]
+        [InlineData("TestKey", 42)]
+        public void IntConversion_ShouldStoreAndRetrieveCorrectly(string key, int value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<int>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<int>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", 42u)]
+        public void UintConversion_ShouldStoreAndRetrieveCorrectly(string key, uint value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<uint>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<uint>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", (short)42)]
+        public void ShortConversion_ShouldStoreAndRetrieveCorrectly(string key, short value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<short>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<short>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", (ushort)42u)]
+        public void UshortConversion_ShouldStoreAndRetrieveCorrectly(string key, ushort value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<ushort>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<ushort>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", (byte)42)]
+        public void ByteConversion_ShouldStoreAndRetrieveCorrectly(string key, byte value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<byte>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<byte>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("TestKey", (sbyte)42u)]
+        public void SbyteConversion_ShouldStoreAndRetrieveCorrectly(string key, sbyte value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<sbyte>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<sbyte>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDateTimeValues))]
+        public void DatetimeConversion_ShouldStoreAndRetrieveCorrectly(string key, DateTime value)
+        {
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<DateTime>(storage);
+
+            state[key] = value;
+
+            state[key].Should().Be(value);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<DateTime>(storage);
+
+            state2[key].Should().Be(value);
+        }
+
+        public static IEnumerable<object[]> GetDateTimeValues()
+        {
+            yield return new object[] { "someKey", DateTime.UtcNow };
+        }
+
+        [Fact]
+        public void CustomClassConversion_ShouldStoreAndRetrieveCorrectly()
+        {
+            var storage = new InMemoryStorage();
+            var key = "TestKey";
+            var state = new DictionaryState<CustomClass>(storage);
+
+            var customObject = new CustomClass { Id = 1, Name = "TestObject" };
+            state[key] = customObject;
+
+            state[key].Should().BeEquivalentTo(customObject);
+
+            state.Flush();
+
+            var state2 = new DictionaryState<CustomClass>(storage);
+
+            state2[key].Should().BeEquivalentTo(customObject);
+        }
+
+        [Fact]
+        public void ListCustomClassConversion_ShouldStoreAndRetrieveCorrectly()
+        {
+            var storage = new InMemoryStorage();
+            var key = "TestKey";
+            var state = new DictionaryState<List<CustomClass>>(storage);
+            state.Clear();
+
+            var customObject = new CustomClass { Id = 1, Name = "TestObject" };
+            state[key] = new List<CustomClass>();
+            state[key].Add(customObject);
+            state[key].Add(customObject);
+
+            state[key].Count.Should().Be(2);
+            state[key].All(y => y == customObject).Should().BeTrue();
+
+            state.Flush();
+
+            var state2 = new DictionaryState<List<CustomClass>>(storage);
+
+            state2[key].Count.Should().Be(2);
+            state2[key].All(y => y.IsSameOrEqualTo(customObject)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void OperationWithElement_ShouldStoreAndRetrieveCorrectly()
+        {
+            var storage = new InMemoryStorage();
+            var key = "TestKey";
+            var state = new DictionaryState<int>(storage);
+
+            state[key] += 2;
+            state[key] -= 1;
+            state[key] *= 8;
+
+            state[key].Should().Be(8);
+        }
+
+
+        [Fact]
+        public void Clear_ShouldRemoveAllValues()
+        {
+            var storage = new InMemoryStorage();
+            // Arrange
+            var state = new DictionaryState<string>(storage);
+            state.Add("Key1", "Value1");
+            state.Add("Key2", "Value2");
+
+            // Act
+            state.Clear();
+            state.Count.Should().Be(0);
+            state.Flush();
+            var state2 = new DictionaryState<string>(storage);
+
+            // Assert
+            state2.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void ComplexModifications_ShouldHaveExpectedValues()
+        {
+            var storage = new InMemoryStorage();
+            // Arrange
+            var state = new DictionaryState<string>(storage);
+
+            // Act 1
+            state.Add("Key1", "Value1"); // will keep as is, before clear
+            state.Add("Key2", "Value2"); // will remove, before clear
+            state.Add("Key3", "Value3"); // will override, before clear
+            state["Key4"] = "Value4"; // leave as is
+            state.Remove("Key2");
+            state["Key3"] = "Value3b";
+            state.Clear();
+            state.Add("Key5", "Value5"); // will keep as is
+            state.Add("Key6", "Value6"); // will remove
+            state.Add("Key7", "Value7"); // will override
+            state["Key8"] = "Value8"; // leave as is
+            state.Remove("Key5");
+            state["Key6"] = "Value6b";
+
+            // Assert 1
+            state.Count.Should().Be(3);
+            state["Key6"].Should().Be("Value6b");
+            state["Key7"].Should().Be("Value7");
+            state["Key8"].Should().Be("Value8");
+
+            // Act 2
+            state.Flush();
+            state["Key8"] = "Value8";
+            state.Flush();
+
+            // Assert 2
+            state.Count.Should().Be(3);
+            state["Key6"].Should().Be("Value6b");
+            state["Key7"].Should().Be("Value7");
+            state["Key8"].Should().Be("Value8");
+
+            // Act 3
+            var state2 = new DictionaryState<string>(storage);
+
+            // Assert 3
+            state2.Count.Should().Be(3);
+            state2["Key6"].Should().Be("Value6b");
+            state2["Key7"].Should().Be("Value7");
+            state2["Key8"].Should().Be("Value8");
+        }
+
+        [Fact]
+        public void Reset_Modified_ShouldResetToSaved()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<string>(storage);
+            state.Add("key", "value");
+            state.Flush();
+
+            // Act
+            state["key"] = "updatedValue";
+            state.Reset();
+
+            // Assert
+            var value = state["key"];
+            value.Should().BeEquivalentTo("value");
+        }
+
+        [Fact]
+        public void Add_WithNullValue_ShouldRemoveFromState()
+        {
+            // Arrange
+            var storage = new InMemoryStorage();
+            var state = new DictionaryState<object>(storage);
+            state.Add("key", "value");
+            state.Flush();
+            storage.ContainsKey("key").Should().BeTrue();
+
+            // Act
+            state["key"] = null;
+            state.Flush();
+
+            // Assert
+            var value = state["key"];
+            value.Should().BeNull();
+            storage.ContainsKey("key").Should().BeFalse();
+        }
+
+        public class CustomClass : IEquatable<CustomClass>
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public bool Equals(CustomClass other)
             {
-                return false;
+                if (other == null)
+                {
+                    return false;
+                }
+
+                return this.Id == other.Id && this.Name == other.Name;
             }
 
-            return this.Id == other.Id && this.Name == other.Name;
-        }
+            public override bool Equals(object obj)
+            {
+                return this.Equals(obj as CustomClass);
+            }
 
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as CustomClass);
-        }
-
-        public override int GetHashCode()
-        {
-            int hash = 17;
-            hash = hash * 31 + this.Id.GetHashCode();
-            hash = hash * 31 + (this.Name == null ? 0 : this.Name.GetHashCode());
-            return hash;
+            public override int GetHashCode()
+            {
+                int hash = 17;
+                hash = hash * 31 + this.Id.GetHashCode();
+                hash = hash * 31 + (this.Name == null ? 0 : this.Name.GetHashCode());
+                return hash;
+            }
         }
     }
 }

--- a/src/CsharpClient/QuixStreams.State/DictionaryState.cs
+++ b/src/CsharpClient/QuixStreams.State/DictionaryState.cs
@@ -86,7 +86,10 @@ namespace QuixStreams.State
         /// <inheritdoc cref="IDictionary.IsReadOnly" />
         IDictionaryEnumerator IDictionary.GetEnumerator()
         {
-            return this.inMemoryState.GetEnumerator();
+            lock (this.SyncRoot)
+            {
+                return this.inMemoryState.ToDictionary(y=> y.Key, y=> y.Value).GetEnumerator();
+            }
         }
 
         /// <inheritdoc />
@@ -104,7 +107,10 @@ namespace QuixStreams.State
         /// <returns>An enumerator for the in-memory state.</returns>
         public IEnumerator<KeyValuePair<string, StateValue>> GetEnumerator()
         {
-            return inMemoryState.GetEnumerator();
+            lock (this.SyncRoot)
+            {
+                return inMemoryState.ToDictionary(y => y.Key, y => y.Value).GetEnumerator();
+            }
         }
 
         /// <inheritdoc />
@@ -118,9 +124,12 @@ namespace QuixStreams.State
         /// </summary>
         public void Clear()
         {
-            inMemoryState.Clear();
-            changes.Clear();
-            clearBeforeFlush = true;
+            lock (this.SyncRoot)
+            {
+                inMemoryState.Clear();
+                changes.Clear();
+                clearBeforeFlush = true;
+            }
         }
         
         /// <inheritdoc/>
@@ -132,19 +141,28 @@ namespace QuixStreams.State
         /// <inheritdoc/>
         public bool Contains(KeyValuePair<string, StateValue> item)
         {
-            return this.inMemoryState.TryGetValue(item.Key, out var existing) && existing.Equals(item.Value);
+            lock (this.SyncRoot)
+            {
+                return this.inMemoryState.TryGetValue(item.Key, out var existing) && existing.Equals(item.Value);
+            }
         }
 
         /// <inheritdoc/>
         public void CopyTo(KeyValuePair<string, StateValue>[] array, int arrayIndex)
         {
-            ((IDictionary<string, StateValue>)this.inMemoryState).CopyTo(array, arrayIndex);
+            lock (this.SyncRoot)
+            {
+                ((IDictionary<string, StateValue>)this.inMemoryState).CopyTo(array, arrayIndex);
+            }
         }
 
         /// <inheritdoc/>
         public bool Remove(KeyValuePair<string, StateValue> item)
         {
-            return this.Contains(item) && this.Remove(item.Key);
+            lock (this.SyncRoot)
+            {
+                return this.Contains(item) && this.Remove(item.Key);
+            }
         }
 
         /// <inheritdoc cref="IDictionary.IsReadOnly" />
@@ -153,8 +171,20 @@ namespace QuixStreams.State
         /// <inheritdoc cref="IDictionary.IsReadOnly" />
         public object this[object key]
         {
-            get => this[(string)key];
-            set => this[(string)key] = (StateValue)value;
+            get
+            {
+                lock (this.SyncRoot)
+                {
+                    return this[(string)key];
+                }
+            }
+            set
+            {
+                lock (this.SyncRoot)
+                {
+                    this[(string)key] = (StateValue)value;
+                }
+            }
         }
 
         /// <inheritdoc cref="IDictionary.IsReadOnly" />
@@ -168,10 +198,10 @@ namespace QuixStreams.State
         /// </summary>
         public int Count => inMemoryState.Count;
 
-        /// <inheritdoc cref="IDictionary.IsReadOnly" />
+        /// <inheritdoc cref="IDictionary.IsSynchronized" />
         public bool IsSynchronized => ((IDictionary)this.inMemoryState).IsSynchronized;
         
-        /// <inheritdoc cref="IDictionary.IsReadOnly" />
+        /// <inheritdoc cref="IDictionary.SyncRoot" />
         public object SyncRoot => ((IDictionary)this.inMemoryState).SyncRoot;
 
         /// <summary>
@@ -182,10 +212,13 @@ namespace QuixStreams.State
         public void Add(string key, StateValue value)
         {
             if (!this.IsCaseSensitive) key = key.ToLower();
-            inMemoryState.Add(key, value);
-            this.changes[key] = value == null || value.IsNull() 
-                ? ChangeType.Removed
-                : ChangeType.AddedOrUpdated;
+            lock (this.SyncRoot)
+            {
+                inMemoryState.Add(key, value);
+                this.changes[key] = value == null || value.IsNull()
+                    ? ChangeType.Removed
+                    : ChangeType.AddedOrUpdated;
+            }
         }
 
         /// <summary>
@@ -196,7 +229,10 @@ namespace QuixStreams.State
         public bool ContainsKey(string key)
         {
             if (!this.IsCaseSensitive) key = key.ToLower();
-            return inMemoryState.ContainsKey(key);
+            lock (this.SyncRoot)
+            {
+                return inMemoryState.ContainsKey(key);
+            }
         }
 
         /// <summary>
@@ -207,9 +243,12 @@ namespace QuixStreams.State
         public bool Remove(string key)
         {
             if (!this.IsCaseSensitive) key = key.ToLower();
-            var success = inMemoryState.Remove(key);
-            if (success) this.changes[key] = ChangeType.Removed;
-            return success;
+            lock (this.SyncRoot)
+            {
+                var success = inMemoryState.Remove(key);
+                if (success) this.changes[key] = ChangeType.Removed;
+                return success;
+            }
         }
 
         /// <summary>
@@ -221,7 +260,10 @@ namespace QuixStreams.State
         public bool TryGetValue(string key, out StateValue value)
         {
             if (!this.IsCaseSensitive) key = key.ToLower();
-            return inMemoryState.TryGetValue(key, out value);
+            lock (this.SyncRoot)
+            {
+                return inMemoryState.TryGetValue(key, out value);
+            }
         }
 
         /// <summary>
@@ -234,78 +276,124 @@ namespace QuixStreams.State
             get
             {
                 if (!this.IsCaseSensitive) key = key.ToLower();
-                return this.inMemoryState[key];
+                lock (this.SyncRoot)
+                {
+                    return this.inMemoryState[key];
+                }
             }
             set
             {
                 if (!this.IsCaseSensitive) key = key.ToLower();
-                if (value == null || value.IsNull()) this.changes[key] = ChangeType.Removed;
-                else this.changes[key] = ChangeType.AddedOrUpdated;
-                this.inMemoryState[key] = value;
+                lock (this.SyncRoot)
+                {
+                    if (value == null || value.IsNull()) this.changes[key] = ChangeType.Removed;
+                    else this.changes[key] = ChangeType.AddedOrUpdated;
+                    this.inMemoryState[key] = value;
+                }
             }
         }
 
         /// <summary>
         /// Gets an ICollection containing the keys of the in-memory state.
         /// </summary>
-        public ICollection<string> Keys => this.inMemoryState.Keys;
+        public ICollection<string> Keys
+        {
+            get
+            {
+                lock (this.SyncRoot)
+                {
+                    return this.inMemoryState.Keys.ToArray();
+                }
+            }
+        }
 
         /// <inheritdoc cref="IDictionary.IsReadOnly" />
-        ICollection IDictionary.Values => this.inMemoryState.Values;
+        ICollection IDictionary.Values
+        {
+            get
+            {
+                lock (this.SyncRoot)
+                {
+                    return this.inMemoryState.Values.ToArray();
+                }
+            }
+        }
 
         /// <inheritdoc cref="IDictionary.IsReadOnly" />
-        ICollection IDictionary.Keys => this.inMemoryState.Keys;
+        ICollection IDictionary.Keys
+        {
+            get
+            {
+                lock (this.SyncRoot)
+                {
+                    return this.inMemoryState.Keys.ToArray();
+                }
+            }
+        }
 
         /// <summary>
         /// Gets an ICollection containing the values of the in-memory state.
         /// </summary>
-        public ICollection<StateValue> Values => this.inMemoryState.Values;
+        public ICollection<StateValue> Values
+        {
+            get
+            {
+                lock (this.SyncRoot)
+                {
+                    return this.inMemoryState.Values.ToArray();
+                }
+            }
+        }
 
         /// <summary>
         /// Flushes the changes made to the in-memory state to the specified storage.
         /// </summary>
         public void Flush()
         {
-            this.logger.LogTrace("Flushing state.");
-            OnFlushing?.Invoke(this, EventArgs.Empty);
-            
-            if (this.clearBeforeFlush)
+            lock (this.SyncRoot)
             {
-                this.storage.Clear();
-                this.clearBeforeFlush = false;
-            }
+                this.logger.LogTrace("Flushing state.");
+                OnFlushing?.Invoke(this, EventArgs.Empty);
 
-            var tasks = new List<Task>();
-            foreach (var changeType in changes)
-            {
-                if (changeType.Value == ChangeType.Removed)
+                if (this.clearBeforeFlush)
                 {
-                    this.lastFlushHash.Remove(changeType.Key);
-                    tasks.Add(this.storage.RemoveAsync(changeType.Key));
+                    this.storage.Clear();
+                    this.clearBeforeFlush = false;
                 }
-                else
+
+                var tasks = new List<Task>();
+                foreach (var changeType in changes)
                 {
-                    var value = inMemoryState[changeType.Key];
-                    if (value == null || value.IsNull())
+                    if (changeType.Value == ChangeType.Removed)
                     {
                         this.lastFlushHash.Remove(changeType.Key);
                         tasks.Add(this.storage.RemoveAsync(changeType.Key));
                     }
                     else
                     {
-                        var hash = value.GetHashCode();
-                        if (lastFlushHash.TryGetValue(changeType.Key, out var existingHash) && existingHash == hash) continue;
-                        this.lastFlushHash[changeType.Key] = hash;
-                        tasks.Add(this.storage.SetAsync(changeType.Key, inMemoryState[changeType.Key]));
+                        var value = inMemoryState[changeType.Key];
+                        if (value == null || value.IsNull())
+                        {
+                            this.lastFlushHash.Remove(changeType.Key);
+                            tasks.Add(this.storage.RemoveAsync(changeType.Key));
+                        }
+                        else
+                        {
+                            var hash = value.GetHashCode();
+                            if (lastFlushHash.TryGetValue(changeType.Key, out var existingHash) && existingHash == hash)
+                                continue;
+                            this.lastFlushHash[changeType.Key] = hash;
+                            tasks.Add(this.storage.SetAsync(changeType.Key, inMemoryState[changeType.Key]));
+                        }
                     }
                 }
+
+                this.changes.Clear();
+                Task.WaitAll(tasks.ToArray());
+
+                OnFlushed?.Invoke(this, EventArgs.Empty);
+                this.logger.LogTrace("Flushed {0} state changes.", tasks.Count());
             }
-            
-            this.changes.Clear();
-            Task.WaitAll(tasks.ToArray());
-            
-            OnFlushed?.Invoke(this, EventArgs.Empty);
-            this.logger.LogTrace("Flushed {0} state changes.", tasks.Count());
         }
 
         /// <summary>
@@ -313,47 +401,51 @@ namespace QuixStreams.State
         /// </summary>
         public void Reset()
         {
-            if (this.changes.Count == 0)
+            lock (this.SyncRoot)
             {
-                this.logger.LogTrace("Resetting state not needed, empty");
-                return;
-            }
-            this.logger.LogTrace("Resetting state");
-            // Remove current values
-            foreach (var changeType in this.changes)
-            {
-                this.inMemoryState.Remove(changeType.Key);
-            }
-
-            // Retrieve values from storage
-            var tasks = this.changes.Select(async y =>
-            {
-                try
+                if (this.changes.Count == 0)
                 {
-                    var value = await this.storage.GetAsync(y.Key);
-                    return (y.Key, value);
+                    this.logger.LogTrace("Resetting state not needed, empty");
+                    return;
                 }
-                catch
+
+                this.logger.LogTrace("Resetting state");
+                // Remove current values
+                foreach (var changeType in this.changes)
                 {
-                    // was added
-                    return (y.Key, null);
+                    this.inMemoryState.Remove(changeType.Key);
                 }
-            }).ToArray();
 
-            Task.WaitAll(tasks);
+                // Retrieve values from storage
+                var tasks = this.changes.Select(async y =>
+                {
+                    try
+                    {
+                        var value = await this.storage.GetAsync(y.Key);
+                        return (y.Key, value);
+                    }
+                    catch
+                    {
+                        // was added
+                        return (y.Key, null);
+                    }
+                }).ToArray();
 
-            // Assign result to inmemory
-            foreach (var task in tasks)
-            {
-                var (key, value) = task.Result;
-                if (value == null) continue;
-                this.inMemoryState[key] = value;
+                Task.WaitAll(tasks);
+
+                // Assign result to inmemory
+                foreach (var task in tasks)
+                {
+                    var (key, value) = task.Result;
+                    if (value == null) continue;
+                    this.inMemoryState[key] = value;
+                }
+
+                // Reset changes
+                var count = this.changes.Count;
+                this.changes.Clear();
+                this.logger.LogTrace($"Reset {count} state");
             }
-            
-            // Reset changes
-            var count = this.changes.Count;
-            this.changes.Clear();
-            this.logger.LogTrace($"Reset {count} state");
         }
 
         /// <summary>
@@ -556,12 +648,18 @@ namespace QuixStreams.State
                 this.inMemoryCache[pair.Key] = pair.Value;
             }
         }
+        
+        /// <inheritdoc cref="IDictionary.SyncRoot" />
+        public object SyncRoot => ((IDictionary)this.inMemoryCache).SyncRoot;
 
         /// <inheritdoc/>
         public IEnumerator<KeyValuePair<string, T>> GetEnumerator()
         {
-            var enumerable = this.inMemoryCache.Select(y=> new KeyValuePair<string,T>(y.Key, genericConverter(y.Value)));
-            return enumerable.GetEnumerator();
+            lock (this.SyncRoot)
+            {
+                var enumerable = this.inMemoryCache.ToDictionary(y=> y.Key, y=> genericConverter(y.Value));
+                return enumerable.GetEnumerator();
+            }
         }
 
         /// <inheritdoc/>
@@ -579,15 +677,21 @@ namespace QuixStreams.State
         /// <inheritdoc/>
         public void Clear()
         {
-            this.inMemoryCache.Clear();
-            this.clearBeforeFlush = true;
-            this.changes.Clear();
+            lock (this.SyncRoot)
+            {
+                this.inMemoryCache.Clear();
+                this.clearBeforeFlush = true;
+                this.changes.Clear();
+            }
         }
 
         /// <inheritdoc/>
         public bool Contains(KeyValuePair<string, T> item)
         {
-            return this.inMemoryCache.TryGetValue(item.Key, out var existing) && existing.Equals(item.Value);
+            lock (this.SyncRoot)
+            {
+                return this.inMemoryCache.TryGetValue(item.Key, out var existing) && existing.Equals(item.Value);
+            }
         }
 
         /// <inheritdoc/>
@@ -599,7 +703,10 @@ namespace QuixStreams.State
         /// <inheritdoc/>
         public bool Remove(KeyValuePair<string, T> item)
         {
-            return this.Contains(item) && this.Remove(item.Key);
+            lock (this.SyncRoot)
+            {
+                return this.Contains(item) && this.Remove(item.Key);
+            }
         }
 
         /// <inheritdoc/>
@@ -612,39 +719,51 @@ namespace QuixStreams.State
         public void Add(string key, T value)
         {
             if (!this.IsCaseSensitive) key = key.ToLower();
-            inMemoryCache.Add(key, stateValueConverter(value));
-            this.changes[key] = value == null 
-                ? ChangeType.Removed
-                : ChangeType.AddedOrUpdated;
+            lock (this.SyncRoot)
+            {
+                inMemoryCache.Add(key, stateValueConverter(value));
+                this.changes[key] = value == null
+                    ? ChangeType.Removed
+                    : ChangeType.AddedOrUpdated;
+            }
         }
 
         /// <inheritdoc/>
         public bool ContainsKey(string key)
         {
             if (!this.IsCaseSensitive) key = key.ToLower();
-            return this.inMemoryCache.ContainsKey(key);
+            lock (this.SyncRoot)
+            {
+                return this.inMemoryCache.ContainsKey(key);
+            }
         }
 
         /// <inheritdoc/>
         public bool Remove(string key)
         {
             if (!this.IsCaseSensitive) key = key.ToLower();
-            this.changes[key] = ChangeType.Removed;
-            return this.inMemoryCache.Remove(key);
+            lock (this.SyncRoot)
+            {
+                this.changes[key] = ChangeType.Removed;
+                return this.inMemoryCache.Remove(key);
+            }
         }
 
         /// <inheritdoc/>
         public bool TryGetValue(string key, out T value)
         {
             if (!this.IsCaseSensitive) key = key.ToLower();
-            if (!inMemoryCache.TryGetValue(key, out var stateValue))
+            lock (this.SyncRoot)
             {
-                value = default;
-                return false;
-            }
+                if (!inMemoryCache.TryGetValue(key, out var stateValue))
+                {
+                    value = default;
+                    return false;
+                }
 
-            value = genericConverter(stateValue);
-            return true;
+                value = genericConverter(stateValue);
+                return true;
+            }
         }
 
         /// <inheritdoc/>
@@ -653,67 +772,94 @@ namespace QuixStreams.State
             get
             {
                 if (!this.IsCaseSensitive) key = key.ToLower();
-                if (this.TryGetValue(key, out T val)) return val;
-                this.inMemoryCache[key] = stateValueConverter(val);
-                this.changes[key] = ChangeType.AddedOrUpdated;
-                return val;
+                lock (this.SyncRoot)
+                {
+                    if (this.TryGetValue(key, out T val)) return val;
+                    this.inMemoryCache[key] = stateValueConverter(val);
+                    this.changes[key] = ChangeType.AddedOrUpdated;
+                    return val;
+                }
             }
             set
             {
                 if (!this.IsCaseSensitive) key = key.ToLower();
-                this.changes[key] = value == null
-                    ? ChangeType.Removed
-                    : ChangeType.AddedOrUpdated;
-                this.inMemoryCache[key] = stateValueConverter(value);
+                lock (this.SyncRoot)
+                {
+                    this.changes[key] = value == null
+                        ? ChangeType.Removed
+                        : ChangeType.AddedOrUpdated;
+                    this.inMemoryCache[key] = stateValueConverter(value);
+                }
             }
         }
 
         /// <inheritdoc/>
-        public ICollection<string> Keys => this.inMemoryCache.Keys;
+        public ICollection<string> Keys
+        {
+            get
+            {
+                lock (this.SyncRoot)
+                {
+                    return this.inMemoryCache.Keys.ToArray();
+                }
+            }
+        }
 
         /// <inheritdoc/>
-        public ICollection<T> Values => this.inMemoryCache.Values.Select(y=> genericConverter(y)).ToArray();
+        public ICollection<T> Values
+        {
+            get
+            {
+                lock (this.SyncRoot)
+                {
+                    return this.inMemoryCache.Values.Select(y => genericConverter(y)).ToArray();
+                }
+            }
+        }
 
         /// <summary>
         /// Flushes the changes made to the in-memory state to the specified storage.
         /// </summary>
         public void Flush()
         {
-            this.logger.LogTrace("Flushing state");
-            OnFlushing?.Invoke(this, EventArgs.Empty);
-            
-            if (this.clearBeforeFlush)
+            lock (this.SyncRoot)
             {
-                logger.LogTrace("Clearing state before flush as clear was requested");
-                this.underlyingDictionaryState.Clear();
-                this.clearBeforeFlush = false;
-            }
+                this.logger.LogTrace("Flushing state");
+                OnFlushing?.Invoke(this, EventArgs.Empty);
 
-            // If the instance is not type by reference, loop through each change in the list of changes
-            foreach (var changeType in changes)
-            {
-                // For any change that has a value of "Removed", remove the corresponding key from the internal state
-                if (changeType.Value == ChangeType.Removed)
+                if (this.clearBeforeFlush)
                 {
-                    this.underlyingDictionaryState.Remove(changeType.Key);
-                    logger.LogTrace("Removing key '{0}' from state as part of flush", changeType.Key);
+                    logger.LogTrace("Clearing state before flush as clear was requested");
+                    this.underlyingDictionaryState.Clear();
+                    this.clearBeforeFlush = false;
                 }
-                else
-                {
-                    // For any change that is not "Removed", look up the corresponding value in the in-memory cache
-                    // Apply the state value converter to the value and store the result in the internal state with the same key
-                    this.underlyingDictionaryState[changeType.Key] = inMemoryCache[changeType.Key];
-                    logger.LogTrace("Updating key '{0}' from state as part of flush", changeType.Key);
-                }
-            }
-            
-            this.changes.Clear();
 
-            logger.LogTrace("Flushing underlying state as part of flush");
-            this.underlyingDictionaryState.Flush();
-            logger.LogTrace("Flushed underlying state as part of flush");
-            OnFlushed?.Invoke(this, EventArgs.Empty);
-            this.logger.LogTrace("Flushed state.");
+                // If the instance is not type by reference, loop through each change in the list of changes
+                foreach (var changeType in changes)
+                {
+                    // For any change that has a value of "Removed", remove the corresponding key from the internal state
+                    if (changeType.Value == ChangeType.Removed)
+                    {
+                        this.underlyingDictionaryState.Remove(changeType.Key);
+                        logger.LogTrace("Removing key '{0}' from state as part of flush", changeType.Key);
+                    }
+                    else
+                    {
+                        // For any change that is not "Removed", look up the corresponding value in the in-memory cache
+                        // Apply the state value converter to the value and store the result in the internal state with the same key
+                        this.underlyingDictionaryState[changeType.Key] = inMemoryCache[changeType.Key];
+                        logger.LogTrace("Updating key '{0}' from state as part of flush", changeType.Key);
+                    }
+                }
+
+                this.changes.Clear();
+
+                logger.LogTrace("Flushing underlying state as part of flush");
+                this.underlyingDictionaryState.Flush();
+                logger.LogTrace("Flushed underlying state as part of flush");
+                OnFlushed?.Invoke(this, EventArgs.Empty);
+                this.logger.LogTrace("Flushed state.");
+            }
         }
         
         /// <summary>
@@ -721,33 +867,37 @@ namespace QuixStreams.State
         /// </summary>
         public void Reset()
         {
-            if (this.changes.Count == 0)
+            lock (this.SyncRoot)
             {
-                this.logger.LogTrace("Resetting state not needed, empty");
-                return;
+                if (this.changes.Count == 0)
+                {
+                    this.logger.LogTrace("Resetting state not needed, empty");
+                    return;
+                }
+
+                this.logger.LogTrace("Resetting state");
+
+                // Retrieve values from storage
+                foreach (var change in this.changes)
+                {
+                    try
+                    {
+                        this.inMemoryCache.Remove(change.Key); // Remove current value
+                        var value = this.underlyingDictionaryState[change.Key];
+                        if (value == null) continue;
+                        this.inMemoryCache[change.Key] = value; // set original value
+                    }
+                    catch
+                    {
+                        // was added, missing key
+                    }
+                }
+
+                // Reset changes
+                var count = this.changes.Count;
+                this.changes.Clear();
+                this.logger.LogTrace($"Reset {count} state");
             }
-            this.logger.LogTrace("Resetting state");
-
-            // Retrieve values from storage
-            foreach (var change in this.changes)
-            {
-                try
-                {
-                    this.inMemoryCache.Remove(change.Key); // Remove current value
-                    var value = this.underlyingDictionaryState[change.Key];
-                    if (value == null) continue;
-                    this.inMemoryCache[change.Key] = value; // set original value
-                }
-                catch
-                {
-                    // was added, missing key
-                }
-            };
-
-            // Reset changes
-            var count = this.changes.Count;
-            this.changes.Clear();
-            this.logger.LogTrace($"Reset {count} state");
         }
         
         

--- a/src/CsharpClient/QuixStreams.State/QuixStreams.State.csproj
+++ b/src/CsharpClient/QuixStreams.State/QuixStreams.State.csproj
@@ -34,6 +34,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+		<PackageReference Include="murmurhash" Version="1.0.3" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
 	</ItemGroup>

--- a/src/CsharpClient/QuixStreams.State/QuixStreams.State.csproj
+++ b/src/CsharpClient/QuixStreams.State/QuixStreams.State.csproj
@@ -5,7 +5,8 @@
 		<Configurations>Debug;Release;Python</Configurations>
 		<Platforms>AnyCPU</Platforms>
 		<LangVersion>8.0</LangVersion>
-		<TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+		<TargetFramework Condition=" '$(Configuration)' == 'Python'">net8.0</TargetFramework>
+		<TargetFramework Condition=" '$(Configuration)' != 'Python'">netstandard2.0</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/CsharpClient/QuixStreams.State/QuixStreams.State.csproj
+++ b/src/CsharpClient/QuixStreams.State/QuixStreams.State.csproj
@@ -5,8 +5,7 @@
 		<Configurations>Debug;Release;Python</Configurations>
 		<Platforms>AnyCPU</Platforms>
 		<LangVersion>8.0</LangVersion>
-		<TargetFramework Condition=" '$(Configuration)' == 'Python'">net8.0</TargetFramework>
-		<TargetFramework Condition=" '$(Configuration)' != 'Python'">netstandard2.0</TargetFramework>
+		<TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/CsharpClient/QuixStreams.State/QuixStreams.State.csproj
+++ b/src/CsharpClient/QuixStreams.State/QuixStreams.State.csproj
@@ -34,7 +34,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-		<PackageReference Include="murmurhash" Version="1.0.3" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
 	</ItemGroup>

--- a/src/CsharpClient/QuixStreams.State/Storage/FileStorage/BaseFileStorage.cs
+++ b/src/CsharpClient/QuixStreams.State/Storage/FileStorage/BaseFileStorage.cs
@@ -146,9 +146,9 @@ namespace QuixStreams.State.Storage.FileStorage
 
             var end = DateTime.UtcNow;
 #if NETSTANDARD2_0
-            this.logger.LogDebug("Saved state {0} in {1:g}, temp taking {2:g} (NetStandard).", key, end-start, tempTimeEnd-tempTimeStart);
+            this.logger.LogTrace("Saved state {0} in {1:g}, temp taking {2:g} (Move/Del).", key, end-start, tempTimeEnd-tempTimeStart);
 #else
-            this.logger.LogDebug("Saved state {0} in {1:g}, temp taking {2:g} (Net).", key, end-start, tempTimeEnd-tempTimeStart);
+            this.logger.LogTrace("Saved state {0} in {1:g}, temp taking {2:g} (Move).", key, end-start, tempTimeEnd-tempTimeStart);
 #endif
         }
 

--- a/src/CsharpClient/QuixStreams.State/Storage/FileStorage/BaseFileStorage.cs
+++ b/src/CsharpClient/QuixStreams.State/Storage/FileStorage/BaseFileStorage.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace QuixStreams.State.Storage.FileStorage
 {
@@ -15,6 +17,7 @@ namespace QuixStreams.State.Storage.FileStorage
         private readonly string storageDirectory;
 
         private static readonly string DefaultDir = Path.Combine(".", "state");
+        private readonly ILogger<BaseFileStorage> logger;
         private const string FileNameSpecialCharacter = "~";
         private const string TempFileSuffix = ".tmpf";
         private const string BackupFileSuffix = ".bckf";
@@ -25,14 +28,17 @@ namespace QuixStreams.State.Storage.FileStorage
         /// </summary>
         /// <param name="storageDirectory">Directory where to store the state</param>
         /// <param name="autoCreateDir">Create the directory if it doesn't exist</param>
-        protected BaseFileStorage(string storageDirectory = null, bool autoCreateDir = true)
+        /// <param name="loggerFactory">The optional logger factory to create logger with</param>
+        protected BaseFileStorage(string storageDirectory = null, bool autoCreateDir = true, ILoggerFactory loggerFactory = null)
         {
-            this.storageDirectory = storageDirectory != null ? storageDirectory : DefaultDir;
+            this.storageDirectory = storageDirectory ?? DefaultDir;
+            this.logger = loggerFactory?.CreateLogger<BaseFileStorage>() ?? NullLogger<BaseFileStorage>.Instance;
 
             if (autoCreateDir)
             {
                 if (!Directory.Exists(this.storageDirectory))
                 {
+                    logger.LogTrace("Creating storage directory {0}", this.storageDirectory);
                     Directory.CreateDirectory(this.storageDirectory);
                 }
             }
@@ -97,6 +103,8 @@ namespace QuixStreams.State.Storage.FileStorage
             key = key.ToLower();
             var tempKey = $"{key}{TempFileSuffix}";
             var tempKeyFilePath = GetFilePath(tempKey);
+            var start = DateTime.UtcNow;
+            DateTime tempTimeStart, tempTimeEnd;
             // lock on the directory
             using (await this.LockInternalKey("", LockType.Reader))
             {
@@ -112,6 +120,7 @@ namespace QuixStreams.State.Storage.FileStorage
                     }
                     
                     var keyFilePath = GetFilePath(key);
+                    tempTimeStart = DateTime.UtcNow;
 #if NETSTANDARD2_0
                     var backupKey = $"{key}{BackupFileSuffix}";
                     var backupFilePath = GetFilePath(backupKey);
@@ -130,8 +139,16 @@ namespace QuixStreams.State.Storage.FileStorage
 #else
                     File.Move(tempKeyFilePath, keyFilePath, true);
 #endif
+                    tempTimeEnd = DateTime.UtcNow;
                 }
             }
+
+            var end = DateTime.UtcNow;
+#if NETSTANDARD2_0
+            this.logger.LogDebug("Saved state {0} in {1:g}, temp taking {2:g} (NetStandard).", key, end-start, tempTimeEnd-tempTimeStart);
+#else
+            this.logger.LogDebug("Saved state {0} in {1:g}, temp taking {2:g} (Net).", key, end-start, tempTimeEnd-tempTimeStart);
+#endif
         }
 
         /// <summary>
@@ -204,36 +221,47 @@ namespace QuixStreams.State.Storage.FileStorage
         /// <param name="folderName">Directory path to clean</param>
         private void CleanTempFiles(string folderName)
         {
-            DirectoryInfo dir = new DirectoryInfo(folderName);
+            var start = DateTime.UtcNow;
+            logger.LogTrace("Cleaning temp files");
 
-            var cutoff = DateTime.UtcNow.AddMinutes(-1);
-            var files = dir.GetFiles();
-            foreach (FileInfo fi in files)
+            void Helper(string folderToClean)
             {
-#if NETSTANDARD2_0
-                if (fi.FullName.EndsWith(BackupFileSuffix))
+                DirectoryInfo dir = new DirectoryInfo(folderToClean);
+
+                var cutoff = DateTime.UtcNow.AddMinutes(-1);
+                var files = dir.GetFiles();
+                foreach (FileInfo fi in files)
                 {
-                    var originalFile = fi.FullName.Substring(0, fi.FullName.Length-BackupFileSuffix.Length);
-                    if (files.Any(y => y.FullName == originalFile))
+#if NETSTANDARD2_0
+                    if (fi.FullName.EndsWith(BackupFileSuffix))
                     {
-                        fi.Delete(); // delete of a backup file failed as temp file successfully replaced it
+                        var originalFile = fi.FullName.Substring(0, fi.FullName.Length - BackupFileSuffix.Length);
+                        if (files.Any(y => y.FullName == originalFile))
+                        {
+                            fi.Delete(); // delete of a backup file failed as temp file successfully replaced it
+                        }
+                        else
+                        {
+                            fi.MoveTo(originalFile); // restore from backup file
+                        }
                     }
-                    else
-                    {
-                        fi.MoveTo(originalFile); // restore from backup file
-                    }
-                }
 #endif
-                
-                if (fi.LastWriteTimeUtc > cutoff) continue;
-                if (!fi.FullName.EndsWith(TempFileSuffix)) continue;
-                fi.Delete();
-            }
 
-            foreach (DirectoryInfo di in dir.GetDirectories())
-            {
-                CleanTempFiles(di.FullName);
+                    if (fi.LastWriteTimeUtc > cutoff) continue;
+                    if (!fi.FullName.EndsWith(TempFileSuffix)) continue;
+                    fi.Delete();
+                }
+
+                foreach (DirectoryInfo di in dir.GetDirectories())
+                {
+                    Helper(di.FullName);
+                }
             }
+            
+            Helper(folderName);
+            
+            var end = DateTime.UtcNow;
+            logger.LogTrace("Cleaned temp files in {0:g}", end-start);
         }
 
         /// <summary>
@@ -242,18 +270,28 @@ namespace QuixStreams.State.Storage.FileStorage
         /// <param name="folderName">Directory path to remove</param>
         private void ClearFolder(string folderName)
         {
-            DirectoryInfo dir = new DirectoryInfo(folderName);
+            var start = DateTime.UtcNow;
+            logger.LogTrace("Cleaning folders");
 
-            foreach (FileInfo fi in dir.GetFiles())
+            void Helper(string folderToClean)
             {
-                fi.Delete();
-            }
+                DirectoryInfo dir = new DirectoryInfo(folderToClean);
 
-            foreach (DirectoryInfo di in dir.GetDirectories())
-            {
-                ClearFolder(di.FullName);
-                di.Delete();
+                foreach (FileInfo fi in dir.GetFiles())
+                {
+                    fi.Delete();
+                }
+
+                foreach (DirectoryInfo di in dir.GetDirectories())
+                {
+                    ClearFolder(di.FullName);
+                    di.Delete();
+                }
             }
+            Helper(folderName);
+
+            var end = DateTime.UtcNow;
+            logger.LogTrace("Cleaned folders in {0:g}", end-start);
         }
 
         /// <summary>
@@ -346,6 +384,9 @@ namespace QuixStreams.State.Storage.FileStorage
                         //is internal ( special ) file
                         continue;
                     }
+
+                    if (filePath.EndsWith(TempFileSuffix)) continue;
+                    if (filePath.EndsWith(BackupFileSuffix)) continue;
 
                     // Migrate from potentially different cases to lower case only
                     var key = GetKeyFromPath(filePath);

--- a/src/CsharpClient/QuixStreams.State/Storage/FileStorage/BaseFileStorage.cs
+++ b/src/CsharpClient/QuixStreams.State/Storage/FileStorage/BaseFileStorage.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Murmur;
 
 namespace QuixStreams.State.Storage.FileStorage
 {
@@ -22,8 +21,6 @@ namespace QuixStreams.State.Storage.FileStorage
         private const string FileNameSpecialCharacter = "~";
         private const string TempFileSuffix = ".tmpf";
         private const string BackupFileSuffix = ".bckf";
-        private Dictionary<string, byte[]> contentHashes = new Dictionary<string, byte[]>();
-        private static Murmur128 murmurHash = MurmurHash.Create128(823746123);
 
 
         /// <summary>
@@ -105,13 +102,6 @@ namespace QuixStreams.State.Storage.FileStorage
         {
             key = key.ToLower();
             
-            // check hash of existing value
-            var hash = murmurHash.ComputeHash(data);
-            if (this.contentHashes.TryGetValue(key, out var existingHash))
-            {
-                if (existingHash.SequenceEqual(hash)) return;
-            }
-            
             var tempKey = $"{key}{TempFileSuffix}";
             var tempKeyFilePath = GetFilePath(tempKey);
             var start = DateTime.UtcNow;
@@ -151,8 +141,6 @@ namespace QuixStreams.State.Storage.FileStorage
                     File.Move(tempKeyFilePath, keyFilePath, true);
 #endif
                     tempTimeEnd = DateTime.UtcNow;
-            
-                    this.contentHashes[key] = hash;
                 }
             }
 
@@ -190,11 +178,6 @@ namespace QuixStreams.State.Storage.FileStorage
                         sourceStream.Close();
                         sourceStream.Dispose();
                     }
-                    
-            
-                    // check hash of existing value
-                    var hash = murmurHash.ComputeHash(result);
-                    this.contentHashes[key] = hash;
                 }
             }
             return result;
@@ -215,9 +198,6 @@ namespace QuixStreams.State.Storage.FileStorage
                 {
                     File.Delete(path);
                 }
-
-
-                this.contentHashes.Remove(key);
             }
         }
 
@@ -323,7 +303,6 @@ namespace QuixStreams.State.Storage.FileStorage
             using ( await this.LockInternalKey("", LockType.Writer) )
             {
                 ClearFolder(this.storageDirectory);
-                this.contentHashes.Clear();
             }
         }
 

--- a/src/CsharpClient/QuixStreams.State/Storage/FileStorage/LocalFileStorage/LocalFileStorage.cs
+++ b/src/CsharpClient/QuixStreams.State/Storage/FileStorage/LocalFileStorage/LocalFileStorage.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace QuixStreams.State.Storage.FileStorage.LocalFileStorage
 {
@@ -34,13 +35,17 @@ namespace QuixStreams.State.Storage.FileStorage.LocalFileStorage
         /// </summary>
         private readonly ConcurrentDictionary<string, CountedLock> internalLocks = new ConcurrentDictionary<string, CountedLock>();
 
+        private readonly ILoggerFactory loggerFactory;
+
         /// <summary>
         /// Instantiates a new instance of <see cref="LocalFileStorage"/>
         /// </summary>
         /// <param name="storageDirectory">The directory for storing the states</param>
         /// <param name="autoCreateDir">Whether the directory should be automatically created if does not exist already</param>
-        public LocalFileStorage(string storageDirectory = null, bool autoCreateDir = true) : base(storageDirectory, autoCreateDir)
+        /// <param name="loggerFactory">The optional logger factory to create logger with</param>
+        public LocalFileStorage(string storageDirectory = null, bool autoCreateDir = true, ILoggerFactory loggerFactory = null) : base(storageDirectory, autoCreateDir, loggerFactory)
         {
+            this.loggerFactory = loggerFactory;
         }
 
         /// <inheritdoc />
@@ -51,7 +56,7 @@ namespace QuixStreams.State.Storage.FileStorage.LocalFileStorage
         /// <inheritdoc />
         protected override IStateStorage CreateNewStorageInstance(string path)
         {
-            return new LocalFileStorage(path, true);
+            return new LocalFileStorage(path, true, this.loggerFactory);
         }
 
         /// <inheritdoc />

--- a/src/CsharpClient/QuixStreams.Streaming/App.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/App.cs
@@ -240,7 +240,7 @@ namespace QuixStreams.Streaming
         /// <returns></returns>
         public static AppStateManager GetStateManager()
         {
-            if (App.stateManager == null) SetStateStorage(new LocalFileStorage(autoCreateDir: true));
+            if (App.stateManager == null) SetStateStorage(new LocalFileStorage(autoCreateDir: true, loggerFactory: Logging.Factory));
             return App.stateManager;
         }
 

--- a/src/CsharpClient/QuixStreams.Telemetry.Common.Test/QuixStreams.Telemetry.Common.Test.csproj
+++ b/src/CsharpClient/QuixStreams.Telemetry.Common.Test/QuixStreams.Telemetry.Common.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Configurations>Debug;Release;Python</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>

--- a/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/CodecRegistry.cs
+++ b/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/CodecRegistry.cs
@@ -71,8 +71,9 @@ namespace QuixStreams.Telemetry.Models
                     {
                         if (typeof(TimeseriesDataRaw) == modelType)
                         {
-                            QuixStreams.Transport.Registry.CodecRegistry.RegisterCodec(modelKey, new TimeseriesDataJsonCodec());
-                            continue;
+                            // Disable for now to avoid a bug
+                            //QuixStreams.Transport.Registry.CodecRegistry.RegisterCodec(modelKey, new TimeseriesDataJsonCodec());
+                            //continue;
                         }
 
                         QuixStreams.Transport.Registry.CodecRegistry.RegisterCodec(modelKey, new DefaultJsonCodec<TType>());   

--- a/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/CodecRegistry.cs
+++ b/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/CodecRegistry.cs
@@ -69,13 +69,6 @@ namespace QuixStreams.Telemetry.Models
                 case CodecType.Json:
                     foreach (var modelKey in modelKeys)
                     {
-                        if (typeof(TimeseriesDataRaw) == modelType)
-                        {
-                            // Disable for now to avoid a bug
-                            //QuixStreams.Transport.Registry.CodecRegistry.RegisterCodec(modelKey, new TimeseriesDataJsonCodec());
-                            //continue;
-                        }
-
                         QuixStreams.Transport.Registry.CodecRegistry.RegisterCodec(modelKey, new DefaultJsonCodec<TType>());   
                     }
                     break;

--- a/src/CsharpClient/QuixStreams.Transport.Kafka/KafkaProducer.cs
+++ b/src/CsharpClient/QuixStreams.Transport.Kafka/KafkaProducer.cs
@@ -300,7 +300,7 @@ namespace QuixStreams.Transport.Kafka
                     }
                     else
                     {
-                        this.logger.LogDebug("[{0}] {1}/{2} brokers are up (after all being marked down)", this.configId, upBrokerCount, this.brokerStates.Count);
+                        this.logger.LogDebug("[{0}] At least {1}/{2} brokers are up (after all being marked down).", this.configId, upBrokerCount, this.brokerStates.Count);
                     }
                 } 
                 do

--- a/src/InteropGenerator/Quix.InteropGenerator/Utils.cs
+++ b/src/InteropGenerator/Quix.InteropGenerator/Utils.cs
@@ -447,11 +447,11 @@ public class Utils
         // The type will not be inferrable without some magic of replacing the method signature with the type it is getting created for
         if (methodInfo.IsGenericMethod && (methodInfo.DeclaringType?.IsAbstract ?? true) && methodInfo.GetParameters().All(y=> y.ParameterType.IsAbstract))
         {
-            logger.LogDebug("Method {0} is not supported because involved types would not be inferrable (as of now)", methodInfo.ToString());
+            logger.LogDebug("Type {0} Method {1} is not supported because involved types would not be inferrable (as of now)", methodInfo.DeclaringType?.FullName, methodInfo.ToString());
             return false;
         }
 
-        logger.LogTrace("Method {0} is supported", methodInfo.ToString());
+        logger.LogTrace("Type {0} Method {1} is supported", methodInfo.DeclaringType?.FullName, methodInfo.ToString());
         return true;
     }
 }

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.6.dev5"
+package_version = "0.5.6.dev6"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -23,7 +23,7 @@ QUIXSTREAMS_PACKAGE_DATA = []
 def rec_incl_with_filter(directory, filters, trim):
     trimfirstn=len(trim) + 1
     for (path, directories, filenames) in os.walk(directory):
-        for filename in filenames:
+        for filename in filenames:  
             for filter in filters:
                 match = re.match(filter, filename)
                 if match is not None:

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.6.dev3"
+package_version = "0.5.6.dev4"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.6"
+package_version = "0.5.6.dev8"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.6.dev6"
+package_version = "0.5.6.dev7"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.6.dev8"
+package_version = "0.5.6"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.6.dev2"
+package_version = "0.5.6.dev3"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.6.dev4"
+package_version = "0.5.6.dev5"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/setup.py
+++ b/src/PythonClient/setup.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import fileinput
 
-package_version = "0.5.6.dev7"
+package_version = "0.5.6"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/src/PythonClient/src/quixstreams/logging.py
+++ b/src/PythonClient/src/quixstreams/logging.py
@@ -21,3 +21,4 @@ class Logging:
     def update_factory(level: LogLevel):
         net_loglevel = ec.enum_to_another(level, LogLevelInterop)
         LoggingInterop.UpdateFactory(net_loglevel)
+

--- a/src/PythonClient/src/quixstreams/state/localfilestorage.py
+++ b/src/PythonClient/src/quixstreams/state/localfilestorage.py
@@ -1,5 +1,6 @@
 from .istatestorage import IStateStorage
 from ..native.Python.QuixStreamsState.Storage.FileStorage.LocalFileStorage.LocalFileStorage import LocalFileStorage as lfsi
+from ..native.Python.QuixStreamsTransport.QuixStreams.Logging import Logging as LoggingInterop
 
 
 class LocalFileStorage(IStateStorage):
@@ -16,4 +17,4 @@ class LocalFileStorage(IStateStorage):
             storage_directory: The path to the storage directory.
             auto_create_dir: If True, automatically creates the storage directory if it doesn't exist.
         """
-        super().__init__(lfsi.Constructor(storage_directory, auto_create_dir))
+        super().__init__(lfsi.Constructor(storage_directory, auto_create_dir, LoggingInterop.get_Factory()))

--- a/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
+++ b/src/PythonClient/tests/quixstreams/integrationtests/test_integration.py
@@ -1806,11 +1806,11 @@ class TestStreamState(BaseIntegrationTest):
         stream_state_manager = topic_state_manager.get_stream_state_manager("test-stream")
         dict_state = stream_state_manager.get_dict_state("test")
 
-        assert "a" in dict_state
+        assert "a" not in dict_state
 
         dict_state["a"] = "b"
 
-        assert "a" not in dict_state
+        assert "a" in dict_state
 
     def test_stream_state_manager(self,
                                   test_name,
@@ -1831,7 +1831,11 @@ class TestStreamState(BaseIntegrationTest):
             rolling_sum_state['somevalue'] = 5
             object_state = stream_consumer.get_dict_state("objectstate",
                                                           lambda key: {})
-            object_state['somevalue']['key'] = 'value'
+
+            dict = {}
+            dict['key'] = 'value'
+            object_state['somevalue'] = dict
+            object_state['somevalue']['someotherkey'] = 'thatshouldntsave'
             event.set()
 
         topic_consumer_earliest.on_stream_received = on_stream_received_handler

--- a/src/PythonClient/tests/quixstreams/unittests/state/test_localfilestorage.py
+++ b/src/PythonClient/tests/quixstreams/unittests/state/test_localfilestorage.py
@@ -4,6 +4,9 @@ import unittest
 from src.quixstreams.state.statevalue import StateValue
 from src.quixstreams.state.localfilestorage import LocalFileStorage
 
+#from src.quixstreams.logging import Logging, LogLevel
+#Logging.update_factory(LogLevel.Trace)
+
 
 class LocalFileStorageTests(unittest.TestCase):
 

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.6.0"
-informal_version = "0.5.6.0-dev3"
-nuget_version = "0.5.6.0-dev3"
+informal_version = "0.5.6.0-dev4"
+nuget_version = "0.5.6.0-dev4"
 
 
 def updatecsproj(projfilepath):

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.6.0"
-informal_version = "0.5.6.0-dev4"
-nuget_version = "0.5.6.0-dev4"
+informal_version = "0.5.6.0-dev5"
+nuget_version = "0.5.6.0-dev5"
 
 
 def updatecsproj(projfilepath):

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.6.0"
-informal_version = "0.5.6.0-dev2"
-nuget_version = "0.5.6.0-dev2"
+informal_version = "0.5.6.0-dev3"
+nuget_version = "0.5.6.0-dev3"
 
 
 def updatecsproj(projfilepath):

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.6.0"
-informal_version = "0.5.6.0-dev5"
-nuget_version = "0.5.6.0-dev5"
+informal_version = "0.5.6.0-dev6"
+nuget_version = "0.5.6.0-dev6"
 
 
 def updatecsproj(projfilepath):

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.6.0"
-informal_version = "0.5.6.0-dev6"
-nuget_version = "0.5.6.0-dev6"
+informal_version = "0.5.6.0-dev7"
+nuget_version = "0.5.6.0-dev7"
 
 
 def updatecsproj(projfilepath):

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.6.0"
-informal_version = "0.5.6.0"
-nuget_version = "0.5.6.0"
+informal_version = "0.5.6.0-dev8"
+nuget_version = "0.5.6.0-dev8"
 
 
 def updatecsproj(projfilepath):

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.6.0"
-informal_version = "0.5.6.0-dev8"
-nuget_version = "0.5.6.0-dev8"
+informal_version = "0.5.6.0"
+nuget_version = "0.5.6.0"
 
 
 def updatecsproj(projfilepath):

--- a/src/builds/csharp/nuget/build_nugets.py
+++ b/src/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.5.6.0"
-informal_version = "0.5.6.0-dev7"
-nuget_version = "0.5.6.0-dev7"
+informal_version = "0.5.6.0"
+nuget_version = "0.5.6.0"
 
 
 def updatecsproj(projfilepath):


### PR DESCRIPTION
- References are only saved on set, not on flush. Required to avoid excessive serialisation or IO
- Added logging capability
- FileStorage now writes to a temp file and moves to original location (framework dependent how). Should provide better resiliency in case app crashes
- Set version to 0.5.6