### PR TITLE
Enable message split by default

### DIFF
--- a/src/CsharpClient/QuixStreams.Kafka.Transport/SerDes/PackageSerializationMode.cs
+++ b/src/CsharpClient/QuixStreams.Kafka.Transport/SerDes/PackageSerializationMode.cs
@@ -36,8 +36,8 @@ namespace QuixStreams.Kafka.Transport.SerDes
 
         /// <summary>
         /// Whether message split is enabled.
-        /// Disabled by default
+        /// Enabled by default
         /// </summary>
-        public static bool EnableMessageSplit { get; set; } = false;
+        public static bool EnableMessageSplit { get; set; } = true;
     }
 }


### PR DESCRIPTION
* If the message needs no splitting, it stays as is
* If the message needs splitting, SDF won't be able to parse it but also wouldn't see it with it disabled.