### PR TITLE
auto-create topics

### DIFF
--- a/src/StreamingDataFrames/streamingdataframes/app.py
+++ b/src/StreamingDataFrames/streamingdataframes/app.py
@@ -250,6 +250,10 @@ class Application:
         app.set_quix_config_builder(quix_config_builder)
         return app
 
+    @property
+    def is_quix_app(self):
+        return self._quix_config_builder is not None
+
     def topic(
         self,
         name: str,
@@ -273,7 +277,7 @@ class Application:
         :param creation_configs: settings for topic creation, if needed
         :return: `Topic` object
         """
-        if self._quix_config_builder is not None:
+        if self.is_quix_app:
             # This Application object was created via `.Quix()` method.
             # Quix platform's workspace id is used as topic prefix.
             name = self._quix_config_builder.append_workspace_id(name)
@@ -324,7 +328,7 @@ class Application:
 
         :param dataframe: instance of `StreamingDataFrame`
         """
-        if self._quix_config_builder:
+        if self.is_quix_app:
             logger.debug("Performing Quix-Specific runtime setup...")
             topics = chain(dataframe.topics_in.values(), dataframe.topics_out.values())
             if self._quix_config_builder.app_auto_create_topics:

--- a/src/StreamingDataFrames/streamingdataframes/app.py
+++ b/src/StreamingDataFrames/streamingdataframes/app.py
@@ -162,7 +162,7 @@ class Application:
         consumer_poll_timeout: float = 1.0,
         producer_poll_timeout: float = 0.0,
         quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None,
-        auto_create_topics: bool = False,
+        auto_create_topics: bool = True,
     ) -> Self:
         """
         Initialize an Application to work with Quix platform,

--- a/src/StreamingDataFrames/streamingdataframes/models/__init__.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/__init__.py
@@ -1,4 +1,5 @@
-from .topics import *
 from .rows import *
 from .serializers import *
 from .timestamps import *
+from .topics import *
+from .types import *

--- a/src/StreamingDataFrames/streamingdataframes/models/topics.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/topics.py
@@ -24,19 +24,7 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
-__all__ = (
-    "TopicCreationConfigs",
-    "Topic",
-)
-
-
-class TopicCreationConfigs:
-    def __init__(
-        self, num_partitions: int, replication_factor: int, optionals: dict = None
-    ):
-        self.num_partitions = num_partitions
-        self.replication_factor = replication_factor
-        self.optionals = optionals or {}
+__all__ = ("Topic",)
 
 
 class Topic:
@@ -47,7 +35,6 @@ class Topic:
         key_deserializer: Optional[Deserializer] = BytesDeserializer(),
         value_serializer: Optional[Serializer] = None,
         key_serializer: Optional[Serializer] = BytesSerializer(),
-        creation_configs: Optional[TopicCreationConfigs] = None,
     ):
         """
         A definition of Topic.
@@ -57,14 +44,12 @@ class Topic:
         :param key_deserializer: a deserializer for keys
         :param value_serializer: a serializer for values
         :param key_serializer: a serializer for keys
-        :param creation_configs: settings for topic creation, if needed
         """
         self._name = name
         self._key_serializer = key_serializer
         self._key_deserializer = key_deserializer
         self._value_serializer = value_serializer
         self._value_deserializer = value_deserializer
-        self.creation_configs = creation_configs
 
     @property
     def name(self) -> str:

--- a/src/StreamingDataFrames/streamingdataframes/models/topics.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/topics.py
@@ -1,4 +1,5 @@
 import logging
+
 from typing import Union, List, Mapping, Optional
 
 from .messages import KafkaMessage
@@ -23,6 +24,20 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
+__all__ = (
+    "TopicCreationConfigs",
+    "Topic",
+)
+
+
+class TopicCreationConfigs:
+    def __init__(
+        self, num_partitions: int, replication_factor: int, optionals: dict = None
+    ):
+        self.num_partitions = num_partitions
+        self.replication_factor = replication_factor
+        self.optionals = optionals or {}
+
 
 class Topic:
     def __init__(
@@ -32,6 +47,7 @@ class Topic:
         key_deserializer: Optional[Deserializer] = BytesDeserializer(),
         value_serializer: Optional[Serializer] = None,
         key_serializer: Optional[Serializer] = BytesSerializer(),
+        creation_configs: Optional[TopicCreationConfigs] = None,
     ):
         """
         A definition of Topic.
@@ -41,12 +57,14 @@ class Topic:
         :param key_deserializer: a deserializer for keys
         :param value_serializer: a serializer for values
         :param key_serializer: a serializer for keys
+        :param creation_configs: settings for topic creation, if needed
         """
         self._name = name
         self._key_serializer = key_serializer
         self._key_deserializer = key_deserializer
         self._value_serializer = value_serializer
         self._value_deserializer = value_deserializer
+        self.creation_configs = creation_configs
 
     @property
     def name(self) -> str:

--- a/src/StreamingDataFrames/streamingdataframes/platforms/quix/api.py
+++ b/src/StreamingDataFrames/streamingdataframes/platforms/quix/api.py
@@ -123,20 +123,20 @@ class QuixPortalApiService:
     def post_topic(
         self,
         topic_name: str,
+        topic_partitions: int,
+        topic_rep_factor: int,
+        topic_ret_minutes: int,
+        topic_ret_bytes: int,
         workspace_id: Optional[str] = None,
-        topic_partitions: Optional[int] = None,
-        topic_rep_factor: Optional[int] = None,
-        topic_ret_minutes: Optional[int] = None,
-        topic_ret_bytes: Optional[int] = None,
     ) -> dict:
         workspace_id = workspace_id or self.default_workspace_id
         d = {
             "name": topic_name,
             "configuration": {
-                "partitions": topic_partitions or 2,
-                "replicationFactor": topic_rep_factor or 2,
-                "retentionInMinutes": topic_ret_minutes or 10080,
-                "retentionInBytes": topic_ret_bytes or 52428800,
+                "partitions": topic_partitions,
+                "replicationFactor": topic_rep_factor,
+                "retentionInMinutes": topic_ret_minutes,
+                "retentionInBytes": topic_ret_bytes,
             },
         }
         return self.session.post(f"/{workspace_id}/topics", json=d).json()

--- a/src/StreamingDataFrames/streamingdataframes/platforms/quix/api.py
+++ b/src/StreamingDataFrames/streamingdataframes/platforms/quix/api.py
@@ -57,8 +57,9 @@ class QuixPortalApiService:
             super().__init__()
 
         def request(self, method, url, **kwargs):
+            timeout = kwargs.pop("timeout", 10)
             return super().request(
-                method, urljoin(base=self.url_base, url=url), **kwargs
+                method, urljoin(base=self.url_base, url=url), timeout=timeout, **kwargs
             )
 
     @property

--- a/src/StreamingDataFrames/streamingdataframes/platforms/quix/config.py
+++ b/src/StreamingDataFrames/streamingdataframes/platforms/quix/config.py
@@ -23,11 +23,11 @@ __all__ = (
 
 @dataclasses.dataclass
 class TopicCreationConfigs:
-    name: str
-    num_partitions: Optional[int] = None
-    replication_factor: Optional[int] = None
-    retention_bytes: Optional[int] = None
-    retention_minutes: Optional[int] = None
+    name: Optional[str] = None  # Required when not created by a Quix App.
+    num_partitions: int = 2
+    replication_factor: int = 2
+    retention_bytes: int = 52428800
+    retention_minutes: int = 10080
     optionals: Optional[Mapping] = None
 
 
@@ -82,7 +82,7 @@ class QuixKafkaConfigsBuilder:
         # since this is slowly building up.
         # Application.Quix only
         self.app_auto_create_topics: bool = True
-        self.create_topic_configs: Dict[str:TopicCreationConfigs] = {}
+        self.create_topic_configs: Dict[str, TopicCreationConfigs] = {}
 
     class NoWorkspaceFound(QuixException):
         ...
@@ -105,15 +105,6 @@ class QuixKafkaConfigsBuilder:
             "password": "sasl.password",
         }
         values = {"ScramSha256": "SCRAM-SHA-256", "SaslSsl": "SASL_SSL"}
-
-    @dataclasses.dataclass
-    class TopicCreationConfigs:
-        name: Optional[str] = None  # Required when not created by a Quix App.
-        num_partitions: Optional[int] = None
-        replication_factor: Optional[int] = None
-        retention_bytes: Optional[int] = None
-        retention_minutes: Optional[int] = None
-        optionals: Optional[Mapping] = None
 
     @property
     def workspace_id(self) -> str:

--- a/src/StreamingDataFrames/streamingdataframes/platforms/quix/config.py
+++ b/src/StreamingDataFrames/streamingdataframes/platforms/quix/config.py
@@ -63,7 +63,7 @@ class QuixKafkaConfigsBuilder:
         self._quix_broker_config = None
         self._quix_broker_settings = None
         self._workspace_meta = None
-        self.app_auto_create_topics: bool = False  # Used by Application.Quix only
+        self.app_auto_create_topics: Optional[bool] = None  # Application.Quix only
 
     class NoWorkspaceFound(QuixException):
         ...

--- a/src/StreamingDataFrames/tests/test_dataframes/fixtures.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/fixtures.py
@@ -275,7 +275,7 @@ def quix_app_factory(random_consumer_group):
         on_producer_error: Optional[ProducerErrorCallback] = None,
         on_processing_error: Optional[ProcessingErrorCallback] = None,
         on_message_processed: Optional[MessageProcessedCallback] = None,
-        auto_create_topics: bool = False,
+        auto_create_topics: bool = True,
     ) -> Application:
         workspace_id = "my_ws"
         cfg_builder = create_autospec(QuixKafkaConfigsBuilder)

--- a/src/StreamingDataFrames/tests/test_dataframes/fixtures.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/fixtures.py
@@ -281,6 +281,7 @@ def quix_app_factory(random_consumer_group):
         cfg_builder = create_autospec(QuixKafkaConfigsBuilder)
         cfg_builder._workspace_id = workspace_id
         cfg_builder.workspace_id = workspace_id
+        cfg_builder.create_topic_configs = {}
         cfg_builder.append_workspace_id.side_effect = lambda s: f"{workspace_id}-{s}"
 
         return Application.Quix(

--- a/src/StreamingDataFrames/tests/test_dataframes/fixtures.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/fixtures.py
@@ -1,9 +1,10 @@
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional
+from unittest.mock import create_autospec
 
 import pytest
 from confluent_kafka.admin import AdminClient, NewTopic, NewPartitions
+from typing import Optional
 
 from streamingdataframes.app import Application, MessageProcessedCallback
 from streamingdataframes.error_callbacks import (
@@ -27,6 +28,7 @@ from streamingdataframes.models.timestamps import (
     MessageTimestamp,
 )
 from streamingdataframes.models.topics import Topic
+from streamingdataframes.platforms.quix import QuixKafkaConfigsBuilder
 from streamingdataframes.rowconsumer import RowConsumer
 from streamingdataframes.rowproducer import RowProducer
 
@@ -258,6 +260,40 @@ def app_factory(kafka_container, random_consumer_group):
             on_processing_error=on_processing_error,
             on_message_processed=on_message_processed,
             state_dir=state_dir,
+        )
+
+    return factory
+
+
+@pytest.fixture()
+def quix_app_factory(random_consumer_group):
+    def factory(
+        auto_offset_reset: AutoOffsetReset = "latest",
+        consumer_extra_config: Optional[dict] = None,
+        producer_extra_config: Optional[dict] = None,
+        on_consumer_error: Optional[ConsumerErrorCallback] = None,
+        on_producer_error: Optional[ProducerErrorCallback] = None,
+        on_processing_error: Optional[ProcessingErrorCallback] = None,
+        on_message_processed: Optional[MessageProcessedCallback] = None,
+        auto_create_topics: bool = False,
+    ) -> Application:
+        workspace_id = "my_ws"
+        cfg_builder = create_autospec(QuixKafkaConfigsBuilder)
+        cfg_builder._workspace_id = workspace_id
+        cfg_builder.workspace_id = workspace_id
+        cfg_builder.append_workspace_id.side_effect = lambda s: f"{workspace_id}-{s}"
+
+        return Application.Quix(
+            random_consumer_group,
+            quix_config_builder=cfg_builder,
+            auto_offset_reset=auto_offset_reset,
+            consumer_extra_config=consumer_extra_config,
+            producer_extra_config=producer_extra_config,
+            on_consumer_error=on_consumer_error,
+            on_producer_error=on_producer_error,
+            on_processing_error=on_processing_error,
+            on_message_processed=on_message_processed,
+            auto_create_topics=auto_create_topics,
         )
 
     return factory

--- a/src/StreamingDataFrames/tests/test_dataframes/test_app.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_app.py
@@ -384,10 +384,8 @@ class TestQuixApplication:
         """
         app = quix_app_factory(auto_create_topics=False)
 
-        topic_in_0 = app.topic("topic_in_0")
-        topic_in_1 = app.topic("topic_in_1")
-        topic_out_0 = app.topic("topic_out_0")
-        topic_out_1 = app.topic("topic_out_1")
+        topic_in_0, topic_in_1 = app.topic("topic_in_0"), app.topic("topic_in_1")
+        topic_out_0, topic_out_1 = app.topic("topic_out_0"), app.topic("topic_out_1")
 
         sdf = app.dataframe(topics_in=[topic_in_0, topic_in_1])
         sdf.to_topic(topic_out_0)

--- a/src/StreamingDataFrames/tests/test_dataframes/test_platforms/test_quix/test_api.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_platforms/test_quix/test_api.py
@@ -2,10 +2,17 @@ import zipfile
 from io import BytesIO
 from unittest.mock import create_autospec
 
+import pytest
+
 from streamingdataframes.platforms.quix.api import QuixPortalApiService
 
 
 class TestApi:
+    def test_no_workspace_id_provided(self):
+        api = QuixPortalApiService(portal_api="http://portal.com", auth_token="token")
+        with pytest.raises(api.UndefinedQuixWorkspaceId):
+            api.get_topics()
+
     def test_get_workspace_certificate(self):
         zip_in_mem = BytesIO()
         with zipfile.ZipFile(zip_in_mem, "a", zipfile.ZIP_DEFLATED, False) as zip_file:


### PR DESCRIPTION
Topics are now allowed be auto-created when using the Quix Platform (via `Application.Quix()`) when calling `.run()`.

Since auto-creating topics is not a valid option for non-Quix apps, the variable is stored by the `QuixKafkaConfigsBuilder`, and is set by the `Application.Quix(auto_create_topics=BOOL)` (default=`True`)

If True, create any missing topics, ignoring existing. There is a brief period we must wait for them to be finalized.
If False, validate that the expected topics exist, else raise an exception.

The topics referenced are whatever topics are defined on the SDF, both `input_topics` and `output_topics`. 

For topic configuration, a new class `TopicCreationConfigs` was added, which `Topic.creation_configs` now optionally references (and can be handed at init via `creation_configs`). These are basically all the broker-level settings you could normally provide Kafka during topic creation. Any non-required configuration settings are handled with `TopicCreationConfigs.optionals`...which is almost all of them except partitions and rep factor.

There is some other general cleanup, mostly around the API wrapper.