### PR TITLE
Quix legacy SERDES support for SDF

### DIFF
--- a/src/StreamingDataFrames/streamingdataframes/models/serializers/__init__.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/serializers/__init__.py
@@ -16,6 +16,5 @@ from .quix import (
     QuixLegacyEventsSerializer,
     QuixTimeseriesSerializer,
     QuixLegacyTimeseriesSerializer,
-    QuixTimeseriesDeserializer,
-    QuixEventsDeserializer,
+    QuixDeserializer,
 )

--- a/src/StreamingDataFrames/streamingdataframes/models/serializers/__init__.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/serializers/__init__.py
@@ -13,7 +13,9 @@ from .exceptions import *
 from .json import JSONSerializer, JSONDeserializer
 from .quix import (
     QuixEventsSerializer,
+    QuixLegacyEventsSerializer,
     QuixTimeseriesSerializer,
+    QuixLegacyTimeseriesSerializer,
     QuixTimeseriesDeserializer,
     QuixEventsDeserializer,
 )

--- a/src/StreamingDataFrames/streamingdataframes/models/serializers/__init__.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/serializers/__init__.py
@@ -13,8 +13,6 @@ from .exceptions import *
 from .json import JSONSerializer, JSONDeserializer
 from .quix import (
     QuixEventsSerializer,
-    QuixLegacyEventsSerializer,
     QuixTimeseriesSerializer,
-    QuixLegacyTimeseriesSerializer,
     QuixDeserializer,
 )

--- a/src/StreamingDataFrames/streamingdataframes/models/serializers/json.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/serializers/json.py
@@ -19,7 +19,7 @@ class JSONSerializer(Serializer):
         :param dumps_kwargs: a dict with keyword arguments for `dumps()` function.
         """
         self._dumps = dumps
-        self._dumps_kwargs = dumps_kwargs or {}
+        self._dumps_kwargs = {"separators": (",", ":"), **(dumps_kwargs or {})}
 
     def __call__(self, value: Any, ctx: SerializationContext) -> Union[str, bytes]:
         return self._to_json(value)

--- a/src/StreamingDataFrames/streamingdataframes/models/serializers/json.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/serializers/json.py
@@ -10,7 +10,7 @@ __all__ = ("JSONSerializer", "JSONDeserializer")
 class JSONSerializer(Serializer):
     def __init__(
         self,
-        dumps: Callable[[Any, None], Union[str, bytes]] = json.dumps,
+        dumps: Optional[Callable[[Any, None], Union[str, bytes]]] = None,
         dumps_kwargs: Optional[Mapping] = None,
     ):
         """
@@ -18,7 +18,7 @@ class JSONSerializer(Serializer):
         :param dumps: a function to serialize objects to json. Default - `json.dumps`
         :param dumps_kwargs: a dict with keyword arguments for `dumps()` function.
         """
-        self._dumps = dumps
+        self._dumps = dumps or json.dumps
         self._dumps_kwargs = {"separators": (",", ":"), **(dumps_kwargs or {})}
 
     def __call__(self, value: Any, ctx: SerializationContext) -> Union[str, bytes]:
@@ -35,9 +35,9 @@ class JSONDeserializer(Deserializer):
     def __init__(
         self,
         column_name: Optional[str] = None,
-        loads: Callable[
-            [Union[str, bytes, bytearray], None], Union[List, Mapping]
-        ] = json.loads,
+        loads: Optional[
+            Callable[[Union[str, bytes, bytearray], None], Union[List, Mapping]]
+        ] = None,
         loads_kwargs: Optional[Mapping] = None,
     ):
         """
@@ -49,7 +49,7 @@ class JSONDeserializer(Deserializer):
         :param loads_kwargs: dict with named arguments for `loads` function.
         """
         super().__init__(column_name=column_name)
-        self._loads = loads
+        self._loads = loads or json.loads
         self._loads_kwargs = loads_kwargs or {}
 
     def __call__(

--- a/src/StreamingDataFrames/tests/test_dataframes/test_models/fixtures.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_models/fixtures.py
@@ -17,6 +17,7 @@ def quix_timeseries_factory():
         tags: Mapping[str, List[Union[str, None]]] = None,
         model_key: str = "TimeseriesData",
         codec_id: str = "JT",
+        as_legacy: bool = False,
     ) -> ConfluentKafkaMessageStub:
         binary = binary or {}
         numeric = numeric or {}
@@ -45,9 +46,16 @@ def quix_timeseries_factory():
             "BinaryValues": binary,
             "TagValues": tags,
         }
+        # Note: Only legacy client uses S and E, so we just use 0 and 1 as placeholders
         message = ConfluentKafkaMessageStub(
-            value=json.dumps(value).encode(),
-            headers=[
+            value=json.dumps(
+                {"C": codec_id, "K": model_key, "V": value, "S": 0, "E": 1}
+                if as_legacy
+                else value
+            ).encode(),
+            headers=None
+            if as_legacy
+            else [
                 ("__Q_ModelKey", model_key.encode()),
                 ("__Q_CodecId", codec_id.encode()),
             ],
@@ -93,6 +101,7 @@ def quix_eventdata_factory():
         params: EventDataParams,
         model_key: str = "EventData",
         codec_id: str = "JT",
+        as_legacy: bool = False,
     ) -> ConfluentKafkaMessageStub:
         event = {
             "Timestamp": params.timestamp,
@@ -101,8 +110,14 @@ def quix_eventdata_factory():
             "Tags": params.tags,
         }
         message = ConfluentKafkaMessageStub(
-            value=json.dumps(event).encode(),
-            headers=[
+            value=json.dumps(
+                {"C": codec_id, "K": model_key, "V": event, "S": 0, "E": 1}
+                if as_legacy
+                else event
+            ).encode(),
+            headers=None
+            if as_legacy
+            else [
                 ("__Q_ModelKey", model_key.encode()),
                 ("__Q_CodecId", codec_id.encode()),
             ],
@@ -118,6 +133,7 @@ def quix_eventdata_list_factory():
         params: List[EventDataParams],
         model_key: str = "EventData[]",
         codec_id: str = "JT",
+        as_legacy: bool = False,
     ) -> ConfluentKafkaMessageStub:
         events = [
             {
@@ -129,8 +145,14 @@ def quix_eventdata_list_factory():
             for p in params
         ]
         message = ConfluentKafkaMessageStub(
-            value=json.dumps(events).encode(),
-            headers=[
+            value=json.dumps(
+                {"C": codec_id, "K": model_key, "V": events, "S": 0, "E": 1}
+                if as_legacy
+                else events
+            ).encode(),
+            headers=None
+            if as_legacy
+            else [
                 ("__Q_ModelKey", model_key.encode()),
                 ("__Q_CodecId", codec_id.encode()),
             ],

--- a/src/StreamingDataFrames/tests/test_dataframes/test_models/test_quix_serializers.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_models/test_quix_serializers.py
@@ -407,16 +407,18 @@ class TestQuixTimeseriesSerializer:
         c = "JT"
         k = "ParameterData"
         s = len("{" + f'"C":"{c}","K":"{k}","V":')
-        expected_value_str = json.dumps(expected_value, separators=(",", ":"))
+        expected_value_bytes = json.dumps(
+            expected_value, separators=(",", ":")
+        ).encode()
         expected = {
             "C": c,
             "K": k,
             "V": expected_value,
             "S": s,
-            "E": s + len(expected_value_str),
+            "E": s + len(expected_value_bytes),
         }
         assert json.loads(serialized) == expected
-        assert serialized[expected["S"] : expected["E"]] == expected_value_str
+        assert serialized[expected["S"] : expected["E"]] == expected_value_bytes
 
     @pytest.mark.parametrize(
         "value",
@@ -464,7 +466,7 @@ class TestQuixTimeseriesSerializer:
         c = "JT"
         k = "ParameterData"
         s = len("{" + f'"C":"{c}","K":"{k}","V":')
-        expected_value_str = json.dumps(expected_value, separators=(",", ":"))
+        expected_value_str = json.dumps(expected_value, separators=(",", ":")).encode()
         expected = {
             "C": c,
             "K": k,
@@ -525,17 +527,19 @@ class TestQuixEventsSerializer:
         c = "JT"
         k = "EventData"
         s = len("{" + f'"C":"{c}","K":"{k}","V":')
-        expected_value_str = json.dumps(expected_value, separators=(",", ":"))
+        expected_value_bytes = json.dumps(
+            expected_value, separators=(",", ":")
+        ).encode()
         expected = {
             "C": c,
             "K": k,
             "V": expected_value,
             "S": s,
-            "E": s + len(expected_value_str),
+            "E": s + len(expected_value_bytes),
         }
         serialized = serializer(value, timestamp_ns=timestamp_ns, ctx=ctx)
         assert json.loads(serialized) == expected
-        assert serialized[expected["S"] : expected["E"]] == expected_value_str
+        assert serialized[expected["S"] : expected["E"]] == expected_value_bytes
 
     @pytest.mark.parametrize("as_legacy", [True, False])
     @pytest.mark.parametrize("value", [0, "", object(), [], (), set()])

--- a/src/StreamingDataFrames/tests/test_dataframes/test_models/test_serializers.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_models/test_serializers.py
@@ -32,8 +32,8 @@ class TestSerializers:
             (StringSerializer(), "abc", b"abc"),
             (StringSerializer(codec="cp1251"), "abc", "abc".encode("cp1251")),
             (BytesSerializer(), b"abc", b"abc"),
-            (JSONSerializer(), {"a": 123}, '{"a": 123}'),
-            (JSONSerializer(), [1, 2, 3], "[1, 2, 3]"),
+            (JSONSerializer(), {"a": 123}, '{"a":123}'),
+            (JSONSerializer(), [1, 2, 3], "[1,2,3]"),
         ],
     )
     def test_serialize_success(self, serializer: Serializer, value, expected):

--- a/src/StreamingDataFrames/tests/test_dataframes/test_models/test_topics.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_models/test_topics.py
@@ -199,7 +199,7 @@ class TestTopic:
                 b"key",
                 {"field": "value"},
                 b"key",
-                '{"field": "value"}',
+                '{"field":"value"}',
             ),
         ],
     )

--- a/src/StreamingDataFrames/tests/test_dataframes/test_models/utils.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_models/utils.py
@@ -27,7 +27,7 @@ class ConfluentKafkaMessageStub:
         timestamp: Tuple[int, int] = (1, 123),
         key: bytes = None,
         value: bytes = None,
-        headers: List[Tuple[str, bytes]] = None,
+        headers: Optional[List[Tuple[str, bytes]]] = None,
         latency: float = None,
         leader_epoch: int = None,
     ):
@@ -37,7 +37,7 @@ class ConfluentKafkaMessageStub:
         self._timestamp = timestamp
         self._key = key
         self._value = value
-        self._headers = headers or []
+        self._headers = headers
         self._latency = latency
         self._leader_epoch = leader_epoch
 


### PR DESCRIPTION
# Legacy Quix SerDes additions
Added/changed several things around serdes to accomodate parsing of Quix legacy (aka pre-header) formats (`quixstreams` <0.6.0) in a fully backwards-compatible manner.

## Quix Deserialization 
- Deserialization now has one universal class, `QuixDeserialzer`
  - other Quix deserializer classes removed/consolidated
- You can now handle multiple quix message types upon consume instead of just 1
  - Includes `EventData`, `EventData[]`,  and`TimeSeries`/`ParameterData` 
  - Ignore list remains the same
  - If your app needs access to different messages in different formats, you will need to do some sort of conversion with SDF manually to properly convert them to the same data structure post-deserialization
- Legacy formats of `ParameterData`, `EventData`, and `EventData[]` are now supported (<0.6.0) and fully backwards-compatible
  - "Split" messages remain NOT supported
  - Messages with multiple "rows" (lists of entries) are still parsed/handled as individual rows (just like the current SDF format).
  
  
## Quix Serialization
- Added two new "Legacy" serializers, `QuixLegacyTimeseriesSerializer` and `QuixLegacyEventSerializer`
