### PR TITLE
add ability for Column class to access nested fields

### DIFF
--- a/src/StreamingDataFrames/streamingdataframes/dataframe/column.py
+++ b/src/StreamingDataFrames/streamingdataframes/dataframe/column.py
@@ -1,7 +1,7 @@
 import operator
 from typing import Optional, Any, Callable, Container
 
-from typing_extensions import Self, TypeAlias
+from typing_extensions import Self, TypeAlias, Union
 
 from ..models import Row
 
@@ -25,6 +25,9 @@ class Column:
     ):
         self.col_name = col_name
         self._eval_func = _eval_func if _eval_func else lambda row: row[self.col_name]
+
+    def __getitem__(self, item: Union[str, int]) -> Self:
+        return self.__class__(_eval_func=lambda x: self.eval(x)[item])
 
     def _operation(self, other: Any, op: Callable[[Any, Any], Any]) -> Self:
         return self.__class__(

--- a/src/StreamingDataFrames/tests/test_dataframes/test_dataframe/test_column.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_dataframe/test_column.py
@@ -286,13 +286,20 @@ class TestColumn:
         assert Column("x").isnot(other).eval(row) == expected
 
     @pytest.mark.parametrize(
-        "nested_item", [110, "a_string", {"another": "dict"}, ["a", "list"]]
+        "nested_item",
+        [
+            {2: 110},
+            {2: "a_string"},
+            {2: {"another": "dict"}},
+            {2: ["a", "list"]},
+            ["item", "in", "this", "list"],
+        ],
     )
     def test__get_item__(self, row_factory, nested_item):
-        msg_value = row_factory({"x": {"y": {"z": nested_item}}, "k": 0})
-        result = Column("x")["y"]["z"]
+        msg_value = row_factory({"x": {"y": nested_item}, "k": 0})
+        result = Column("x")["y"][2]
         assert isinstance(result, Column)
-        assert result.eval(msg_value) == nested_item
+        assert result.eval(msg_value) == nested_item[2]
 
     def test_get_item_with_apply(self, row_factory):
         msg_value = row_factory({"x": {"y": {"z": 110}}, "k": 0})

--- a/src/StreamingDataFrames/tests/test_dataframes/test_dataframe/test_column.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_dataframe/test_column.py
@@ -284,3 +284,24 @@ class TestColumn:
     def test_isnot(self, row_factory, value, other, expected):
         row = row_factory(value)
         assert Column("x").isnot(other).eval(row) == expected
+
+    @pytest.mark.parametrize(
+        "nested_item", [110, "a_string", {"another": "dict"}, ["a", "list"]]
+    )
+    def test__get_item__(self, row_factory, nested_item):
+        msg_value = row_factory({"x": {"y": {"z": nested_item}}, "k": 0})
+        result = Column("x")["y"]["z"]
+        assert isinstance(result, Column)
+        assert result.eval(msg_value) == nested_item
+
+    def test_get_item_with_apply(self, row_factory):
+        msg_value = row_factory({"x": {"y": {"z": 110}}, "k": 0})
+        result = Column("x")["y"]["z"].apply(lambda v: v + 10)
+        assert isinstance(result, Column)
+        assert result.eval(msg_value) == 120
+
+    def test_get_item_with_op(self, row_factory):
+        msg_value = row_factory({"x": {"y": 10}, "j": {"k": 5}})
+        result = Column("x")["y"] + Column("j")["k"]
+        assert isinstance(result, Column)
+        assert result.eval(msg_value) == 15

--- a/src/StreamingDataFrames/tests/test_dataframes/test_dataframe/test_dataframe.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_dataframe/test_dataframe.py
@@ -72,6 +72,15 @@ class TestDataframeProcess:
         expected = row_factory({"x": 1, "y": 2, "new": 9})
         assert dataframe.process(row).value == expected.value
 
+    def test_setitem_from_a_nested_column(
+        self, dataframe_factory, row_factory, row_plus_n_func
+    ):
+        dataframe = dataframe_factory()
+        dataframe["a"] = dataframe["x"]["y"]
+        row = row_factory({"x": {"y": 1, "z": "banana"}})
+        expected = row_factory({"x": {"y": 1, "z": "banana"}, "a": 1})
+        assert dataframe.process(row).value == expected.value
+
     def test_column_subset(self, dataframe_factory, row_factory):
         dataframe = dataframe_factory()
         dataframe = dataframe[["x", "y"]]


### PR DESCRIPTION
Added ability for `dataframe` `Columns` to access nested fields or indexes with typical bracket notation:

```
row_data = {"level_0": {"level_1": 10}}

sdf = app.dataframe()
sdf["new_col"] = sdf["level_0"]["level_1"]
sdf = sdf[sdf["level_0"]["level_1"] > 1]
```

Placeholder MR to the column-comparator branch until that's merged.