### PR TITLE
corrected handling of message timestamp

### DIFF
--- a/src/StreamingDataFrames/streamingdataframes/models/serializers/base.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/serializers/base.py
@@ -7,6 +7,7 @@ from confluent_kafka.serialization import (
 )
 
 from ..types import MessageHeadersTuples, MessageHeadersMapping
+from ..timestamps import MessageTimestamp
 
 __all__ = (
     "SerializationContext",
@@ -22,11 +23,17 @@ class SerializationContext:
     Every `Serializer` and `Deserializer` receives an instance of `SerializationContext`
     """
 
-    __slots__ = ("topic", "headers")
+    __slots__ = ("topic", "headers", "timestamp")
 
-    def __init__(self, topic: str, headers: Optional[MessageHeadersTuples] = None):
+    def __init__(
+        self,
+        topic: str,
+        headers: Optional[MessageHeadersTuples] = None,
+        timestamp: Optional[MessageTimestamp] = None,
+    ):
         self.topic = topic
         self.headers = headers
+        self.timestamp = timestamp  # used only by Quix Serializers
 
     def to_confluent_ctx(self, field: MessageField) -> _SerializationContext:
         """

--- a/src/StreamingDataFrames/streamingdataframes/models/serializers/base.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/serializers/base.py
@@ -7,7 +7,6 @@ from confluent_kafka.serialization import (
 )
 
 from ..types import MessageHeadersTuples, MessageHeadersMapping
-from ..timestamps import MessageTimestamp
 
 __all__ = (
     "SerializationContext",
@@ -23,17 +22,15 @@ class SerializationContext:
     Every `Serializer` and `Deserializer` receives an instance of `SerializationContext`
     """
 
-    __slots__ = ("topic", "headers", "timestamp")
+    __slots__ = ("topic", "headers")
 
     def __init__(
         self,
         topic: str,
         headers: Optional[MessageHeadersTuples] = None,
-        timestamp: Optional[MessageTimestamp] = None,
     ):
         self.topic = topic
         self.headers = headers
-        self.timestamp = timestamp  # used only by Quix Serializers
 
     def to_confluent_ctx(self, field: MessageField) -> _SerializationContext:
         """

--- a/src/StreamingDataFrames/streamingdataframes/models/serializers/base.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/serializers/base.py
@@ -24,11 +24,7 @@ class SerializationContext:
 
     __slots__ = ("topic", "headers")
 
-    def __init__(
-        self,
-        topic: str,
-        headers: Optional[MessageHeadersTuples] = None,
-    ):
+    def __init__(self, topic: str, headers: Optional[MessageHeadersTuples] = None):
         self.topic = topic
         self.headers = headers
 

--- a/src/StreamingDataFrames/streamingdataframes/models/serializers/quix.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/serializers/quix.py
@@ -1,13 +1,10 @@
 import base64
-import logging
 from typing import List, Mapping, Iterable, Optional, Union, Tuple, Any, Callable
 
 from .base import SerializationContext
 from .exceptions import SerializationError, IgnoreMessage
 from .json import JSONDeserializer, JSONSerializer
 from ..types import MessageHeadersMapping
-
-logger = logging.getLogger(__name__)
 
 Q_SPLITMESSAGEID_NAME = "__Q_SplitMessageId"
 

--- a/src/StreamingDataFrames/streamingdataframes/models/serializers/quix.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/serializers/quix.py
@@ -350,9 +350,7 @@ class QuixTimeseriesSerializer(QuixSerializer):
         QCodecId.HEADER_NAME: QCodecId.JSON_TYPED,
     }
 
-    def __call__(
-        self, value: Mapping, ctx: SerializationContext, timestamp_ns: int = None
-    ) -> Union[str, bytes]:
+    def __call__(self, value: Mapping, ctx: SerializationContext) -> Union[str, bytes]:
         if not isinstance(value, Mapping):
             raise SerializationError(f"Expected Mapping, got {type(value)}")
         result = {
@@ -397,7 +395,7 @@ class QuixTimeseriesSerializer(QuixSerializer):
         # if not provided one directly or from current message.
         if not is_empty:
             result["Timestamps"].append(
-                timestamp_ns or value.get(Q_TIMESTAMP_KEY) or time.time_ns()
+                value.get(Q_TIMESTAMP_KEY) or ctx.timestamp.milliseconds
             )
 
         return self._to_json(result)
@@ -439,9 +437,7 @@ class QuixEventsSerializer(QuixSerializer):
         QCodecId.HEADER_NAME: QCodecId.JSON_TYPED,
     }
 
-    def __call__(
-        self, value: Mapping, ctx: SerializationContext, timestamp_ns: int = None
-    ) -> Union[str, bytes]:
+    def __call__(self, value: Mapping, ctx: SerializationContext) -> Union[str, bytes]:
         if not isinstance(value, Mapping):
             raise SerializationError(f"Expected Mapping, got {type(value)}")
 
@@ -466,9 +462,7 @@ class QuixEventsSerializer(QuixSerializer):
             "Id": event_id,
             "Value": event_value,
             "Tags": tags,
-            Q_TIMESTAMP_KEY: timestamp_ns
-            or value.get(Q_TIMESTAMP_KEY)
-            or time.time_ns(),
+            Q_TIMESTAMP_KEY: value.get(Q_TIMESTAMP_KEY) or ctx.timestamp.milliseconds,
         }
 
         return self._to_json(result)

--- a/src/StreamingDataFrames/streamingdataframes/models/topics.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/topics.py
@@ -64,9 +64,7 @@ class Topic:
         :param row: Row to serialize
         :return: KafkaMessage object with serialized values
         """
-        ctx = SerializationContext(
-            topic=self.name, headers=row.headers, timestamp=row.timestamp
-        )
+        ctx = SerializationContext(topic=self.name, headers=row.headers)
         if self._key_serializer is None:
             raise SerializerIsNotProvidedError(
                 f'Key serializer is not provided for topic "{self.name}"'

--- a/src/StreamingDataFrames/streamingdataframes/models/topics.py
+++ b/src/StreamingDataFrames/streamingdataframes/models/topics.py
@@ -64,7 +64,9 @@ class Topic:
         :param row: Row to serialize
         :return: KafkaMessage object with serialized values
         """
-        ctx = SerializationContext(topic=row.topic, headers=row.headers)
+        ctx = SerializationContext(
+            topic=self.name, headers=row.headers, timestamp=row.timestamp
+        )
         if self._key_serializer is None:
             raise SerializerIsNotProvidedError(
                 f'Key serializer is not provided for topic "{self.name}"'

--- a/src/StreamingDataFrames/tests/test_dataframes/test_models/fixtures.py
+++ b/src/StreamingDataFrames/tests/test_dataframes/test_models/fixtures.py
@@ -15,6 +15,7 @@ def quix_timeseries_factory():
         numeric: Mapping[str, List[Union[int, float, None]]] = None,
         strings: Mapping[str, List[Union[str, None]]] = None,
         tags: Mapping[str, List[Union[str, None]]] = None,
+        timestamps: List[int] = None,
         model_key: str = "TimeseriesData",
         codec_id: str = "JT",
         as_legacy: bool = False,
@@ -38,9 +39,11 @@ def quix_timeseries_factory():
                 length = max(length, len(values))
                 if length != len(values):
                     raise ValueError("Parameters must be of the same length")
+        if timestamps and len(timestamps) != length:
+            raise ValueError("Parameters must be of the same length")
 
         value = {
-            "Timestamps": [time.time_ns() for _ in range(length)],
+            "Timestamps": timestamps or [time.time_ns() for _ in range(length)],
             "StringValues": strings,
             "NumericValues": numeric,
             "BinaryValues": binary,


### PR DESCRIPTION
Adjusted how timestamps are handled with Quix SERDES.

- No longer use the hidden field `Q__Timestamp`
  - `Timestamp` is now placed in the row message body
- Timestamps are propagated where possible
  - When producing, uses the `Timestamp` value in the message OR (if missing) the consumed message Kafka timestamp to populate the respective outbound message Quix `Timestamp` field