### PR TITLE
create interface to access row context from sdf

### DIFF
--- a/src/StreamingDataFrames/quixstreams/dataframe/column.py
+++ b/src/StreamingDataFrames/quixstreams/dataframe/column.py
@@ -1,12 +1,11 @@
 import operator
-from typing import Optional, Any, Callable, Container
+from copy import deepcopy
 
+from typing import Optional, Any, Callable, Container
 from typing_extensions import Self, TypeAlias, Union
 
 from ..models import Row, MessageContext
 from ..models.context import BaseMessageContext
-
-from copy import deepcopy
 
 ColumnApplier: TypeAlias = Callable[[Any, MessageContext], Any]
 

--- a/src/StreamingDataFrames/quixstreams/dataframe/column.py
+++ b/src/StreamingDataFrames/quixstreams/dataframe/column.py
@@ -4,6 +4,9 @@ from typing import Optional, Any, Callable, Container
 from typing_extensions import Self, TypeAlias, Union
 
 from ..models import Row, MessageContext
+from ..models.context import BaseMessageContext
+
+from copy import deepcopy
 
 ColumnApplier: TypeAlias = Callable[[Any, MessageContext], Any]
 
@@ -138,3 +141,17 @@ class Column:
 
     def __invert__(self) -> Self:
         return self.__class__(_eval_func=lambda x: invert(self.eval(x)))
+
+
+class ColumnContext(BaseMessageContext):
+    def __getattribute__(self, item):
+        def _getattr(row):
+            r = getattr(row, item)
+            if item == "headers":
+                if isinstance(row.headers, dict):
+                    return deepcopy(r)
+            elif item == "timestamp":
+                return deepcopy(r)
+            return r
+
+        return Column(_eval_func=_getattr)

--- a/src/StreamingDataFrames/quixstreams/dataframe/column.py
+++ b/src/StreamingDataFrames/quixstreams/dataframe/column.py
@@ -143,8 +143,8 @@ class Column:
 
 
 class ColumnContext(BaseMessageContext):
-    def __getattribute__(self, item):
-        def _getattr(row):
+    def __getattribute__(self, item) -> Column:
+        def _getattr(row) -> Any:
             r = getattr(row, item)
             if item == "headers":
                 if isinstance(row.headers, dict):

--- a/src/StreamingDataFrames/quixstreams/dataframe/dataframe.py
+++ b/src/StreamingDataFrames/quixstreams/dataframe/dataframe.py
@@ -3,7 +3,7 @@ from typing import Optional, Callable, Union, List, Mapping, Any
 
 from typing_extensions import Self, TypeAlias
 
-from .column import Column
+from .column import Column, ColumnContext
 from .exceptions import InvalidApplyResultType
 from .pipeline import Pipeline
 from ..models import Row, Topic, MessageContext
@@ -194,6 +194,10 @@ class StreamingDataFrame:
                 topic, row, key=key(row.value, row.context) if key else None
             )
         )
+
+    @property
+    def context(self) -> ColumnContext:
+        return ColumnContext()
 
     @property
     def id(self) -> str:

--- a/src/StreamingDataFrames/quixstreams/models/context.py
+++ b/src/StreamingDataFrames/quixstreams/models/context.py
@@ -1,17 +1,17 @@
 from typing import Any, Optional, Union, Mapping
+from typing_extensions import Protocol
 
 from .messages import MessageHeadersTuples
 from .timestamps import MessageTimestamp
 
 
-class BaseMessageContext:
+class BaseMessageContext(Protocol):
     """
-    An object with Kafka message properties.
+    Base Object for inheriting methods for ColumnContext.
 
-    It is made pseudo-immutable (i.e. public attributes don't have setters), and
-    it should not be mutated during message processing.
+    It allows skipping slot assignment and providing auto-complete.
 
-    All params are optional to accommodate ColumnContext access to its methods.
+    Methods will also work as defaults for its subclasses.
     """
 
     __slots__ = (
@@ -25,28 +25,6 @@ class BaseMessageContext:
         "_latency",
         "_leader_epoch",
     )
-
-    def __init__(
-        self,
-        topic: Optional[str] = None,
-        partition: Optional[int] = None,
-        offset: Optional[int] = None,
-        size: Optional[int] = None,
-        timestamp: Optional[MessageTimestamp] = None,
-        key: Optional[Any] = None,
-        headers: Optional[Union[Mapping, MessageHeadersTuples]] = None,
-        latency: Optional[float] = None,
-        leader_epoch: Optional[int] = None,
-    ):
-        self._topic = topic
-        self._partition = partition
-        self._offset = offset
-        self._size = size
-        self._timestamp = timestamp
-        self._key = key
-        self._headers = headers
-        self._latency = latency
-        self._leader_epoch = leader_epoch
 
     @property
     def topic(self) -> str:
@@ -87,7 +65,10 @@ class BaseMessageContext:
 
 class MessageContext(BaseMessageContext):
     """
-    Enforces the existence of certain values when used in real time.
+    An object with Kafka message properties.
+
+    It is made pseudo-immutable (i.e. public attributes don't have setters), and
+    it should not be mutated during message processing.
     """
 
     def __init__(
@@ -102,14 +83,12 @@ class MessageContext(BaseMessageContext):
         latency: Optional[float] = None,
         leader_epoch: Optional[int] = None,
     ):
-        super().__init__(
-            topic=topic,
-            partition=partition,
-            offset=offset,
-            size=size,
-            timestamp=timestamp,
-            key=key,
-            headers=headers,
-            latency=latency,
-            leader_epoch=leader_epoch,
-        )
+        self._topic = topic
+        self._partition = partition
+        self._offset = offset
+        self._size = size
+        self._timestamp = timestamp
+        self._key = key
+        self._headers = headers
+        self._latency = latency
+        self._leader_epoch = leader_epoch

--- a/src/StreamingDataFrames/quixstreams/models/context.py
+++ b/src/StreamingDataFrames/quixstreams/models/context.py
@@ -4,12 +4,14 @@ from .messages import MessageHeadersTuples
 from .timestamps import MessageTimestamp
 
 
-class MessageContext:
+class BaseMessageContext:
     """
     An object with Kafka message properties.
 
     It is made pseudo-immutable (i.e. public attributes don't have setters), and
     it should not be mutated during message processing.
+
+    All params are optional to accommodate ColumnContext access to its methods.
     """
 
     __slots__ = (
@@ -26,11 +28,11 @@ class MessageContext:
 
     def __init__(
         self,
-        topic: str,
-        partition: int,
-        offset: int,
-        size: int,
-        timestamp: MessageTimestamp,
+        topic: Optional[str] = None,
+        partition: Optional[int] = None,
+        offset: Optional[int] = None,
+        size: Optional[int] = None,
+        timestamp: Optional[MessageTimestamp] = None,
         key: Optional[Any] = None,
         headers: Optional[Union[Mapping, MessageHeadersTuples]] = None,
         latency: Optional[float] = None,
@@ -81,3 +83,33 @@ class MessageContext:
     @property
     def leader_epoch(self) -> Optional[int]:
         return self._leader_epoch
+
+
+class MessageContext(BaseMessageContext):
+    """
+    Enforces the existence of certain values when used in real time.
+    """
+
+    def __init__(
+        self,
+        topic: str,
+        partition: int,
+        offset: int,
+        size: int,
+        timestamp: MessageTimestamp,
+        key: Optional[Any] = None,
+        headers: Optional[Union[Mapping, MessageHeadersTuples]] = None,
+        latency: Optional[float] = None,
+        leader_epoch: Optional[int] = None,
+    ):
+        super().__init__(
+            topic=topic,
+            partition=partition,
+            offset=offset,
+            size=size,
+            timestamp=timestamp,
+            key=key,
+            headers=headers,
+            latency=latency,
+            leader_epoch=leader_epoch,
+        )

--- a/src/StreamingDataFrames/quixstreams/models/context.py
+++ b/src/StreamingDataFrames/quixstreams/models/context.py
@@ -1,17 +1,12 @@
 from typing import Any, Optional, Union, Mapping
-from typing_extensions import Protocol
 
 from .messages import MessageHeadersTuples
 from .timestamps import MessageTimestamp
 
 
-class BaseMessageContext(Protocol):
+class BaseMessageContext:
     """
     Base Object for inheriting methods for ColumnContext.
-
-    It allows skipping slot assignment and providing auto-complete.
-
-    Methods will also work as defaults for its subclasses.
     """
 
     __slots__ = (

--- a/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_column.py
+++ b/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_column.py
@@ -1,6 +1,6 @@
 import pytest
 
-from quixstreams.dataframe.column import Column
+from quixstreams.dataframe.column import Column, ColumnContext
 
 
 class TestColumn:
@@ -326,3 +326,9 @@ class TestColumn:
         assert isinstance(result, Column)
         with pytest.raises(TypeError, match="bad operand type for abs()"):
             assert result.eval(row)
+
+
+class TestColumnContext:
+    def test_column_context(self, row_factory):
+        row = row_factory({"doesn't": "matter"})
+        assert ColumnContext().topic.eval(row) == row.context.topic

--- a/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -163,6 +163,13 @@ class TestDataframeProcess:
         row = row_factory({"x": 1, "y": 2})
         assert dataframe.process(row) is None
 
+    def test_column_context(self, dataframe_factory, row_factory):
+        dataframe = dataframe_factory()
+        dataframe["new_column"] = dataframe.context.topic + "-woo"
+        row = row_factory({"x": 1})
+        expected = row_factory({"x": 1, "new_column": f"{row.topic}{'-woo'}"})
+        assert dataframe.process(row).value == expected.value
+
 
 class TestDataframeKafka:
     def test_to_topic(


### PR DESCRIPTION
Adds a new attribute, `StreamingDataFrame.context`, which generates a object called `ColumnContext`.

`ColumnContext` is a very simple object that basically inherits from `MessageContext` and gives you access to its methods (auto-complete), returning a Column in its place when calling the `MessageContext` methods like `.key`, `.timestamp`, etc. 

It also clones the values where appropriate (timestamp, headers if dict)

So, end result could be something like  

```python
sdf["new_column"] = sdf.context.key + sdf["my_append_value"]
```

One thing to consider would be to not have it be a property, but a function i.e. context(), to better designate it's not some attribute of the dataframe itself, or name it "message_context" or something. I used the name `context` for consistency in naming from `.apply` and such, in case that wasn't obvious =)


<br><br>
An alternative approach would be to do something like this on the SDF for each item:

```python
@staticmethod
def context_key():
    return Column(_eval_func=lambda row: row.context.key)
```

but I thought the former was a lot cleaner overall in terms of using the same objects we already have.