### PR TITLE
Add sdf.contains() method to check if column exists in a message

### DIFF
--- a/src/StreamingDataFrames/quixstreams/dataframe/dataframe.py
+++ b/src/StreamingDataFrames/quixstreams/dataframe/dataframe.py
@@ -238,10 +238,10 @@ class StreamingDataFrame:
     @staticmethod
     def contains(key: str) -> Column:
         """
-        Returns a Column configured to assess whether a specified key is present in rows.
+        Check if the key is present in the Row value.
 
-        :param key: A string representing the column name to check for in each row.
-        :return: A Column object configured to evaluate the presence of a column.
+        :param key: a column name to check.
+        :returns: a Column object that evaluates to True if the key is present or False otherwise.
 
         Example:
             >>> df = StreamingDataframe()

--- a/src/StreamingDataFrames/quixstreams/dataframe/dataframe.py
+++ b/src/StreamingDataFrames/quixstreams/dataframe/dataframe.py
@@ -235,6 +235,22 @@ class StreamingDataFrame:
     def producer(self, producer: RowProducerProto):
         self._real_producer = producer
 
+    @staticmethod
+    def contains(key: str) -> Column:
+        """
+        Returns a Column configured to assess whether a specified key is present in rows.
+
+        :param key: A string representing the column name to check for in each row.
+        :return: A Column object configured to evaluate the presence of a column.
+
+        Example:
+            >>> df = StreamingDataframe()
+            >>> sdf['has_column'] = sdf.contains('column_x')
+            # This would add a new column 'has_column' which contains boolean values
+            # indicating the presence of 'column_x' in each row.
+        """
+        return Column(_eval_func=lambda row: key in row.keys())
+
     def __setitem__(self, key: str, value: Any):
         self._apply(lambda row: setitem(key, value, row))
 

--- a/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -155,7 +155,9 @@ class TestDataframeProcess:
         row = row_factory({"x": 1, "y": 2})
         assert dataframe.process(row).value == row.value
 
-    def test_compound_inequality_filter_is_filtered(self, dataframe_factory, row_factory):
+    def test_compound_inequality_filter_is_filtered(
+        self, dataframe_factory, row_factory
+    ):
         dataframe = dataframe_factory()
         dataframe = dataframe[(dataframe["x"] >= 0) & (dataframe["y"] < 0)]
         row = row_factory({"x": 1, "y": 2})
@@ -163,19 +165,25 @@ class TestDataframeProcess:
 
     def test_contains_on_existing_column(self, dataframe_factory, row_factory):
         dataframe = dataframe_factory()
-        dataframe['has_column'] = dataframe.contains('x')
+        dataframe["has_column"] = dataframe.contains("x")
         row = row_factory({"x": 1})
-        assert dataframe.process(row).value == row_factory({"x": 1, "has_column": True}).value
+        assert (
+            dataframe.process(row).value
+            == row_factory({"x": 1, "has_column": True}).value
+        )
 
     def test_contains_on_missing_column(self, dataframe_factory, row_factory):
         dataframe = dataframe_factory()
-        dataframe['has_column'] = dataframe.contains('wrong_column')
+        dataframe["has_column"] = dataframe.contains("wrong_column")
         row = row_factory({"x": 1})
-        assert dataframe.process(row).value == row_factory({"x": 1, "has_column": False}).value
+        assert (
+            dataframe.process(row).value
+            == row_factory({"x": 1, "has_column": False}).value
+        )
 
     def test_contains_as_filter(self, dataframe_factory, row_factory):
         dataframe = dataframe_factory()
-        dataframe = dataframe[dataframe.contains('x')]
+        dataframe = dataframe[dataframe.contains("x")]
 
         valid_row = row_factory({"x": 1, "y": 2})
         valid_result = dataframe.process(valid_row)

--- a/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -155,13 +155,34 @@ class TestDataframeProcess:
         row = row_factory({"x": 1, "y": 2})
         assert dataframe.process(row).value == row.value
 
-    def test_compound_inequality_filter_is_filtered(
-        self, dataframe_factory, row_factory
-    ):
+    def test_compound_inequality_filter_is_filtered(self, dataframe_factory, row_factory):
         dataframe = dataframe_factory()
         dataframe = dataframe[(dataframe["x"] >= 0) & (dataframe["y"] < 0)]
         row = row_factory({"x": 1, "y": 2})
         assert dataframe.process(row) is None
+
+    def test_contains_on_existing_column(self, dataframe_factory, row_factory):
+        dataframe = dataframe_factory()
+        dataframe['has_column'] = dataframe.contains('x')
+        row = row_factory({"x": 1})
+        assert dataframe.process(row).value == row_factory({"x": 1, "has_column": True}).value
+
+    def test_contains_on_missing_column(self, dataframe_factory, row_factory):
+        dataframe = dataframe_factory()
+        dataframe['has_column'] = dataframe.contains('wrong_column')
+        row = row_factory({"x": 1})
+        assert dataframe.process(row).value == row_factory({"x": 1, "has_column": False}).value
+
+    def test_contains_as_filter(self, dataframe_factory, row_factory):
+        dataframe = dataframe_factory()
+        dataframe = dataframe[dataframe.contains('x')]
+
+        valid_row = row_factory({"x": 1, "y": 2})
+        valid_result = dataframe.process(valid_row)
+        assert valid_result is not None and valid_result.value == valid_row.value
+
+        invalid_row = row_factory({"y": 2})
+        assert dataframe.process(invalid_row) is None
 
 
 class TestDataframeKafka:

--- a/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -78,14 +78,14 @@ class TestDataframeProcess:
     def test_setitem_column_with_operations(self, dataframe_factory, row_factory):
         dataframe = dataframe_factory()
         dataframe["new"] = (
-            dataframe["x"] + dataframe["y"].apply(lambda v, ctx: v + 5) + 1
+                dataframe["x"] + dataframe["y"].apply(lambda v, ctx: v + 5) + 1
         )
         row = row_factory({"x": 1, "y": 2})
         expected = row_factory({"x": 1, "y": 2, "new": 9})
         assert dataframe.process(row).value == expected.value
 
     def test_setitem_from_a_nested_column(
-        self, dataframe_factory, row_factory, row_plus_n_func
+            self, dataframe_factory, row_factory, row_plus_n_func
     ):
         dataframe = dataframe_factory()
         dataframe["a"] = dataframe["x"]["y"]
@@ -101,7 +101,7 @@ class TestDataframeProcess:
         assert dataframe.process(row).value == expected.value
 
     def test_column_subset_with_funcs(
-        self, dataframe_factory, row_factory, row_plus_n_func
+            self, dataframe_factory, row_factory, row_plus_n_func
     ):
         dataframe = dataframe_factory()
         dataframe = dataframe[["x", "y"]].apply(row_plus_n_func(n=5))
@@ -128,7 +128,7 @@ class TestDataframeProcess:
         assert dataframe.process(row).value == row.value
 
     def test_inequality_filter_with_operation_is_filtered(
-        self, dataframe_factory, row_factory
+            self, dataframe_factory, row_factory
     ):
         dataframe = dataframe_factory()
         dataframe = dataframe[(dataframe["x"] - dataframe["y"]) > 0]
@@ -142,7 +142,7 @@ class TestDataframeProcess:
         assert dataframe.process(row).value == row.value
 
     def test_inequality_filtering_with_apply_is_filtered(
-        self, dataframe_factory, row_factory
+            self, dataframe_factory, row_factory
     ):
         dataframe = dataframe_factory()
         dataframe = dataframe[dataframe["x"].apply(lambda v, ctx: v - 10) >= 0]
@@ -187,12 +187,12 @@ class TestDataframeProcess:
 
 class TestDataframeKafka:
     def test_to_topic(
-        self,
-        dataframe_factory,
-        row_consumer_factory,
-        row_producer_factory,
-        row_factory,
-        topic_json_serdes_factory,
+            self,
+            dataframe_factory,
+            row_consumer_factory,
+            row_producer_factory,
+            row_factory,
+            topic_json_serdes_factory,
     ):
         topic = topic_json_serdes_factory()
         producer = row_producer_factory()
@@ -222,12 +222,12 @@ class TestDataframeKafka:
         assert row_to_produce.value == consumed_row.value
 
     def test_to_topic_custom_key(
-        self,
-        dataframe_factory,
-        row_consumer_factory,
-        row_producer_factory,
-        row_factory,
-        topic_json_serdes_factory,
+            self,
+            dataframe_factory,
+            row_consumer_factory,
+            row_producer_factory,
+            row_factory,
+            topic_json_serdes_factory,
     ):
         topic = topic_json_serdes_factory()
         producer = row_producer_factory()
@@ -256,12 +256,12 @@ class TestDataframeKafka:
         assert consumed_row.key == row_to_produce.value["x"].encode()
 
     def test_to_topic_multiple_topics_out(
-        self,
-        dataframe_factory,
-        row_consumer_factory,
-        row_producer_factory,
-        row_factory,
-        topic_json_serdes_factory,
+            self,
+            dataframe_factory,
+            row_consumer_factory,
+            row_producer_factory,
+            row_factory,
+            topic_json_serdes_factory,
     ):
         topic_0 = topic_json_serdes_factory()
         topic_1 = topic_json_serdes_factory()
@@ -336,7 +336,7 @@ class TestDataframeStateful:
         result = None
         for row in rows:
             with state_manager.start_store_transaction(
-                topic=row.topic, partition=row.partition, offset=row.offset
+                    topic=row.topic, partition=row.partition, offset=row.offset
             ):
                 result = sdf.process(row)
 

--- a/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/src/StreamingDataFrames/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -78,14 +78,14 @@ class TestDataframeProcess:
     def test_setitem_column_with_operations(self, dataframe_factory, row_factory):
         dataframe = dataframe_factory()
         dataframe["new"] = (
-                dataframe["x"] + dataframe["y"].apply(lambda v, ctx: v + 5) + 1
+            dataframe["x"] + dataframe["y"].apply(lambda v, ctx: v + 5) + 1
         )
         row = row_factory({"x": 1, "y": 2})
         expected = row_factory({"x": 1, "y": 2, "new": 9})
         assert dataframe.process(row).value == expected.value
 
     def test_setitem_from_a_nested_column(
-            self, dataframe_factory, row_factory, row_plus_n_func
+        self, dataframe_factory, row_factory, row_plus_n_func
     ):
         dataframe = dataframe_factory()
         dataframe["a"] = dataframe["x"]["y"]
@@ -101,7 +101,7 @@ class TestDataframeProcess:
         assert dataframe.process(row).value == expected.value
 
     def test_column_subset_with_funcs(
-            self, dataframe_factory, row_factory, row_plus_n_func
+        self, dataframe_factory, row_factory, row_plus_n_func
     ):
         dataframe = dataframe_factory()
         dataframe = dataframe[["x", "y"]].apply(row_plus_n_func(n=5))
@@ -128,7 +128,7 @@ class TestDataframeProcess:
         assert dataframe.process(row).value == row.value
 
     def test_inequality_filter_with_operation_is_filtered(
-            self, dataframe_factory, row_factory
+        self, dataframe_factory, row_factory
     ):
         dataframe = dataframe_factory()
         dataframe = dataframe[(dataframe["x"] - dataframe["y"]) > 0]
@@ -142,7 +142,7 @@ class TestDataframeProcess:
         assert dataframe.process(row).value == row.value
 
     def test_inequality_filtering_with_apply_is_filtered(
-            self, dataframe_factory, row_factory
+        self, dataframe_factory, row_factory
     ):
         dataframe = dataframe_factory()
         dataframe = dataframe[dataframe["x"].apply(lambda v, ctx: v - 10) >= 0]
@@ -187,12 +187,12 @@ class TestDataframeProcess:
 
 class TestDataframeKafka:
     def test_to_topic(
-            self,
-            dataframe_factory,
-            row_consumer_factory,
-            row_producer_factory,
-            row_factory,
-            topic_json_serdes_factory,
+        self,
+        dataframe_factory,
+        row_consumer_factory,
+        row_producer_factory,
+        row_factory,
+        topic_json_serdes_factory,
     ):
         topic = topic_json_serdes_factory()
         producer = row_producer_factory()
@@ -222,12 +222,12 @@ class TestDataframeKafka:
         assert row_to_produce.value == consumed_row.value
 
     def test_to_topic_custom_key(
-            self,
-            dataframe_factory,
-            row_consumer_factory,
-            row_producer_factory,
-            row_factory,
-            topic_json_serdes_factory,
+        self,
+        dataframe_factory,
+        row_consumer_factory,
+        row_producer_factory,
+        row_factory,
+        topic_json_serdes_factory,
     ):
         topic = topic_json_serdes_factory()
         producer = row_producer_factory()
@@ -256,12 +256,12 @@ class TestDataframeKafka:
         assert consumed_row.key == row_to_produce.value["x"].encode()
 
     def test_to_topic_multiple_topics_out(
-            self,
-            dataframe_factory,
-            row_consumer_factory,
-            row_producer_factory,
-            row_factory,
-            topic_json_serdes_factory,
+        self,
+        dataframe_factory,
+        row_consumer_factory,
+        row_producer_factory,
+        row_factory,
+        topic_json_serdes_factory,
     ):
         topic_0 = topic_json_serdes_factory()
         topic_1 = topic_json_serdes_factory()
@@ -336,7 +336,7 @@ class TestDataframeStateful:
         result = None
         for row in rows:
             with state_manager.start_store_transaction(
-                    topic=row.topic, partition=row.partition, offset=row.offset
+                topic=row.topic, partition=row.partition, offset=row.offset
             ):
                 result = sdf.process(row)
 


### PR DESCRIPTION
## Why?
Currently there's no way to check if the key exists in a message in SDF

## What?
Add sdf.contains("key") method that can be passed to SDF as a filter.

Usage: 

```python
# Add a new column 'has_column' that will contain either True or False whether a 'column_x' exists or not in a message
sdf['has_column'] = sdf.contains('column_x')
```
or

```python
# Filter out messages that don't contain 'column_x'
sdf[sdf.contains('column_x')]
```