### PR TITLE
Adds README to table of contents

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ markdown_extensions:
       alternate_style: true
 
 nav:
+  - 'Introduction': '../quix-streams-intro.html'
   - Example Applications: example.md
   - Defining your Streaming Pipeline: streamingdataframe.md
   - Serialization: serialization.md


### PR DESCRIPTION
## Description

Uses the README as a landing page for the docs of this branch.

The nav points to a stub file, that will be changed for the latest README for this branch, when the docs are built.