### PR TITLE
Fix RocksDB does not retry opening if it's locked by another process

### DIFF
--- a/docs/api-reference/application.md
+++ b/docs/api-reference/application.md
@@ -10,7 +10,7 @@
 class Application()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L43)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L43)
 
 The main Application class.
 
@@ -78,7 +78,7 @@ def __init__(broker_address: str,
              loglevel: Optional[LogLevel] = "INFO")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L82)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L82)
 
 
 <br>
@@ -155,7 +155,7 @@ def Quix(cls,
          auto_create_topics: bool = True) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L188)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L188)
 
 Initialize an Application to work with Quix platform,
 
@@ -266,7 +266,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L334)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L334)
 
 Create a topic definition.
 
@@ -325,7 +325,7 @@ Its name will be overridden by this method's 'name' param.
 def dataframe(topic: Topic) -> StreamingDataFrame
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L400)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L400)
 
 A simple helper method that generates a `StreamingDataFrame`, which is used
 
@@ -375,7 +375,7 @@ to be used as an input topic.
 def stop()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L436)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L436)
 
 Stop the internal poll loop and the message processing.
 
@@ -395,7 +395,7 @@ To otherwise stop an application, either send a `SIGTERM` to the process
 def get_producer() -> Producer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L448)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L448)
 
 Create and return a pre-configured Producer instance.
 The Producer is initialized with params passed to Application.
@@ -430,7 +430,7 @@ with app.get_producer() as producer:
 def get_consumer() -> Consumer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L484)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L484)
 
 Create and return a pre-configured Consumer instance.
 The Consumer is initialized with params passed to Application.
@@ -475,7 +475,7 @@ with app.get_consumer() as consumer:
 def clear_state()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L533)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L533)
 
 Clear the state of the application.
 
@@ -489,7 +489,7 @@ Clear the state of the application.
 def run(dataframe: StreamingDataFrame)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L562)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L562)
 
 Start processing data from Kafka using provided `StreamingDataFrame`
 
@@ -533,7 +533,7 @@ app.run(dataframe=df)
 class State(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L102)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L102)
 
 Primary interface for working with key-value state data from `StreamingDataFrame`
 
@@ -547,7 +547,7 @@ Primary interface for working with key-value state data from `StreamingDataFrame
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L107)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L107)
 
 Get the value for key if key is present in the state, else default
 
@@ -574,7 +574,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L116)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L116)
 
 Set value for the key.
 
@@ -595,7 +595,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L123)
 
 Delete value for the key.
 
@@ -617,7 +617,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L131)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L131)
 
 Check if the key exists in state.
 

--- a/docs/api-reference/dataframe.md
+++ b/docs/api-reference/dataframe.md
@@ -10,7 +10,7 @@
 class StreamingDataFrame(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L29)
 
 `StreamingDataFrame` is the main object you will use for ETL work.
 
@@ -74,7 +74,7 @@ def apply(func: Union[DataFrameFunc, DataFrameStatefulFunc],
           expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L99)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L99)
 
 Apply a function to transform the value and return a new value.
 
@@ -122,7 +122,7 @@ def update(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L142)
 
 Apply a function to mutate value in-place or to perform a side effect
 
@@ -170,7 +170,7 @@ def filter(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L181)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L181)
 
 Filter value using provided function.
 
@@ -218,7 +218,7 @@ of type `State` to perform stateful operations.
 def contains(key: str) -> StreamingSeries
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L234)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L234)
 
 Check if the key is present in the Row value.
 
@@ -258,7 +258,7 @@ def to_topic(topic: Topic,
              key: Optional[Callable[[object], object]] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L257)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L257)
 
 Produce current value to a topic. You can optionally specify a new key.
 
@@ -306,7 +306,7 @@ By default, the current message key will be used.
 def compose() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L296)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L296)
 
 Compose all functions of this StreamingDataFrame into one big closure.
 
@@ -349,7 +349,7 @@ and returns a result of StreamingDataFrame
 def test(value: object, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L326)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L326)
 
 A shorthand to test `StreamingDataFrame` with provided value
 
@@ -384,7 +384,7 @@ def tumbling_window(
                                  timedelta]] = 0) -> TumblingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L344)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L344)
 
 Create a tumbling window transformation on this StreamingDataFrame.
 
@@ -461,7 +461,7 @@ def hopping_window(
                                  timedelta]] = 0) -> HoppingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L409)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L409)
 
 Create a hopping window transformation on this StreamingDataFrame.
 
@@ -477,6 +477,9 @@ The time windows always use the current event time.
 <br>
 ***Example Snippet:***
 
+
+<br>
+***Example Snippet:***
 ```python
 
 app = Application()
@@ -547,7 +550,7 @@ like `sum`, `count`, etc. and applied to the StreamingDataFrame.
 class StreamingSeries(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L16)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L16)
 
 `StreamingSeries` are typically generated by `StreamingDataframes` when getting
 elements from, or performing certain operations on, a `StreamingDataframe`,
@@ -613,7 +616,7 @@ sdf = sdf[["column_a"] & (sdf["new_sum_field"] >= 10)]
 def from_func(cls, func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L76)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L76)
 
 Create a StreamingSeries from a function.
 
@@ -641,7 +644,7 @@ instance of `StreamingSeries`
 def apply(func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L90)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L90)
 
 Add a callable to the execution list for this series.
 
@@ -694,7 +697,7 @@ def compose(allow_filters: bool = True,
             allow_updates: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L124)
 
 Compose all functions of this StreamingSeries into one big closure.
 
@@ -754,7 +757,7 @@ and returns a result of `StreamingSeries`
 def test(value: Any, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L171)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L171)
 
 A shorthand to test `StreamingSeries` with provided value
 
@@ -786,7 +789,7 @@ result of `StreamingSeries`
 def isin(other: Container) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L202)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L202)
 
 Check if series value is in "other".
 
@@ -831,7 +834,7 @@ new StreamingSeries
 def contains(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L229)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L229)
 
 Check if series value contains "other"
 
@@ -876,7 +879,7 @@ new StreamingSeries
 def is_(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L254)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L254)
 
 Check if series value refers to the same object as `other`
 
@@ -918,7 +921,7 @@ new StreamingSeries
 def isnot(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L277)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L277)
 
 Check if series value does not refer to the same object as `other`
 
@@ -961,7 +964,7 @@ new StreamingSeries
 def isnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L301)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L301)
 
 Check if series value is None.
 
@@ -998,7 +1001,7 @@ new StreamingSeries
 def notnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L324)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L324)
 
 Check if series value is not None.
 
@@ -1035,7 +1038,7 @@ new StreamingSeries
 def abs() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L347)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L347)
 
 Get absolute value of the series value.
 
@@ -1073,7 +1076,7 @@ new StreamingSeries
 def set_message_context(context: Optional[MessageContext])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/context.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/context.py#L22)
 
 Set a MessageContext for the current message in the given `contextvars.Context`
 
@@ -1116,7 +1119,7 @@ sdf = sdf.update(lambda value: alter_context(value))
 def message_context() -> MessageContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/context.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/context.py#L53)
 
 Get a MessageContext for the current message, which houses most of the message
 
@@ -1157,7 +1160,7 @@ instance of `MessageContext`
 def message_key() -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/context.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/context.py#L84)
 
 Get the current message's key.
 

--- a/docs/api-reference/quix-platform-api.md
+++ b/docs/api-reference/quix-platform-api.md
@@ -10,7 +10,7 @@
 class QuixPortalApiService()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/api.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/api.py#L14)
 
 A light wrapper around the Quix Portal Api. If used in the Quix Platform, it will
 use that workspaces auth token and portal endpoint, else you must provide it.
@@ -36,7 +36,7 @@ See the swagger documentation for more info about the endpoints.
 class TopicCreationConfigs()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L54)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L54)
 
 <a id="quixstreams.platforms.quix.config.TopicCreationConfigs.name"></a>
 
@@ -54,7 +54,7 @@ Required when not created by a Quix App.
 class QuixKafkaConfigsBuilder()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L63)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L63)
 
 Retrieves all the necessary information from the Quix API and builds all the
 objects required to connect a confluent-kafka client to the Quix Platform.
@@ -80,7 +80,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
              workspace_cert_path: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L79)
 
 
 <br>
@@ -100,7 +100,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
 def append_workspace_id(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L169)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L169)
 
 Add the workspace ID to a given string, typically a topic or consumer group id
 
@@ -127,7 +127,7 @@ def search_for_workspace(
         workspace_name_or_id: Optional[str] = None) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L178)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L178)
 
 Search for a workspace given an expected workspace name or id.
 
@@ -153,7 +153,7 @@ the workspace data dict if search success, else None
 def get_workspace_info(known_workspace_topic: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L201)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L201)
 
 Queries for workspace data from the Quix API, regardless of instance cache,
 
@@ -175,7 +175,7 @@ and updates instance attributes from query result.
 def search_workspace_for_topic(workspace_id: str, topic: str) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L228)
 
 Search through all the topics in the given workspace id to see if there is a
 
@@ -204,7 +204,7 @@ the workspace_id if success, else None
 def search_for_topic_workspace(topic: str) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L244)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L244)
 
 Find what workspace a topic belongs to.
 
@@ -233,7 +233,7 @@ workspace data dict if topic search success, else None
 def get_workspace_ssl_cert(extract_to_folder: Optional[Path] = None) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L265)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L265)
 
 Gets and extracts zipped certificate from the API to provided folder.
 
@@ -262,7 +262,7 @@ def create_topics(topics: Iterable[TopicCreationConfigs],
                   finalize_timeout_seconds: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L328)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L328)
 
 Create topics in a Quix cluster.
 
@@ -284,7 +284,7 @@ marked as "Ready" (and thus ready to produce to/consume from).
 def confirm_topics_exist(topics: Iterable[Union[Topic, TopicCreationConfigs]])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L374)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L374)
 
 Confirm whether the desired set of topics exists in the Quix workspace.
 
@@ -304,7 +304,7 @@ Confirm whether the desired set of topics exists in the Quix workspace.
 def get_confluent_broker_config(known_topic: Optional[str] = None) -> dict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L414)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L414)
 
 Get the full client config dictionary required to authenticate a confluent-kafka
 
@@ -339,7 +339,7 @@ def get_confluent_client_configs(
 ) -> Tuple[dict, List[str], Optional[str]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L457)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L457)
 
 Get all the values you need in order to use a confluent_kafka-based client
 
@@ -376,7 +376,7 @@ and consumer group name
 class QuixEnvironment()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L7)
 
 Class to access various Quix platform environment settings
 
@@ -391,7 +391,7 @@ Class to access various Quix platform environment settings
 def state_management_enabled() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L19)
 
 Check whether "State management" is enabled for the current deployment
 
@@ -412,7 +412,7 @@ True if state management is enabled, otherwise False
 def deployment_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L27)
 
 Return current Quix deployment id.
 
@@ -436,7 +436,7 @@ deployment id or None
 def workspace_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L39)
 
 Return Quix workspace id if set
 
@@ -457,7 +457,7 @@ workspace id or None
 def portal_api() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L47)
 
 Return Quix Portal API url if set
 
@@ -478,7 +478,7 @@ portal API URL or None
 def sdk_token() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L56)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L56)
 
 Return Quix SDK token if set
 
@@ -499,7 +499,7 @@ sdk token or None
 def state_dir() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L64)
 
 Return application state directory on Quix.
 

--- a/docs/api-reference/quixstreams.md
+++ b/docs/api-reference/quixstreams.md
@@ -14,7 +14,7 @@
 def configure_logging(loglevel: Optional[LogLevel]) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/logging.py#L24)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/logging.py#L24)
 
 Configure "quixstreams" logger.
 
@@ -52,7 +52,7 @@ True if logging config has been updated, otherwise False.
 class TopicCreationConfigs()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L54)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L54)
 
 <a id="quixstreams.platforms.quix.config.TopicCreationConfigs.name"></a>
 
@@ -68,7 +68,7 @@ Required when not created by a Quix App.
 class QuixKafkaConfigsBuilder()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L63)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L63)
 
 Retrieves all the necessary information from the Quix API and builds all the
 objects required to connect a confluent-kafka client to the Quix Platform.
@@ -92,7 +92,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
              workspace_cert_path: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L79)
 
 **Arguments**:
 
@@ -108,7 +108,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
 def append_workspace_id(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L169)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L169)
 
 Add the workspace ID to a given string, typically a topic or consumer group id
 
@@ -129,7 +129,7 @@ def search_for_workspace(
         workspace_name_or_id: Optional[str] = None) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L178)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L178)
 
 Search for a workspace given an expected workspace name or id.
 
@@ -149,7 +149,7 @@ the workspace data dict if search success, else None
 def get_workspace_info(known_workspace_topic: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L201)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L201)
 
 Queries for workspace data from the Quix API, regardless of instance cache,
 
@@ -167,7 +167,7 @@ and updates instance attributes from query result.
 def search_workspace_for_topic(workspace_id: str, topic: str) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L228)
 
 Search through all the topics in the given workspace id to see if there is a
 
@@ -190,7 +190,7 @@ the workspace_id if success, else None
 def search_for_topic_workspace(topic: str) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L244)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L244)
 
 Find what workspace a topic belongs to.
 
@@ -213,7 +213,7 @@ workspace data dict if topic search success, else None
 def get_workspace_ssl_cert(extract_to_folder: Optional[Path] = None) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L265)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L265)
 
 Gets and extracts zipped certificate from the API to provided folder.
 
@@ -236,7 +236,7 @@ def create_topics(topics: Iterable[TopicCreationConfigs],
                   finalize_timeout_seconds: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L328)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L328)
 
 Create topics in a Quix cluster.
 
@@ -254,7 +254,7 @@ marked as "Ready" (and thus ready to produce to/consume from).
 def confirm_topics_exist(topics: Iterable[Union[Topic, TopicCreationConfigs]])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L374)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L374)
 
 Confirm whether the desired set of topics exists in the Quix workspace.
 
@@ -270,7 +270,7 @@ Confirm whether the desired set of topics exists in the Quix workspace.
 def get_confluent_broker_config(known_topic: Optional[str] = None) -> dict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L414)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L414)
 
 Get the full client config dictionary required to authenticate a confluent-kafka
 
@@ -299,7 +299,7 @@ def get_confluent_client_configs(
 ) -> Tuple[dict, List[str], Optional[str]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/config.py#L457)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/config.py#L457)
 
 Get all the values you need in order to use a confluent_kafka-based client
 
@@ -332,7 +332,7 @@ and consumer group name
 class QuixEnvironment()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L7)
 
 Class to access various Quix platform environment settings
 
@@ -345,7 +345,7 @@ Class to access various Quix platform environment settings
 def state_management_enabled() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L19)
 
 Check whether "State management" is enabled for the current deployment
 
@@ -362,7 +362,7 @@ True if state management is enabled, otherwise False
 def deployment_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L27)
 
 Return current Quix deployment id.
 
@@ -382,7 +382,7 @@ deployment id or None
 def workspace_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L39)
 
 Return Quix workspace id if set
 
@@ -399,7 +399,7 @@ workspace id or None
 def portal_api() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L47)
 
 Return Quix Portal API url if set
 
@@ -416,7 +416,7 @@ portal API URL or None
 def sdk_token() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L56)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L56)
 
 Return Quix SDK token if set
 
@@ -433,7 +433,7 @@ sdk token or None
 def state_dir() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/env.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/env.py#L64)
 
 Return application state directory on Quix.
 
@@ -453,7 +453,7 @@ path to state dir
 def check_state_management_enabled()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/checks.py#L11)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/checks.py#L11)
 
 Check if State Management feature is enabled for the current deployment on
 Quix platform.
@@ -467,7 +467,7 @@ If it's disabled, the exception will be raised.
 def check_state_dir(state_dir: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/checks.py#L28)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/checks.py#L28)
 
 Check if Application "state_dir" matches the state dir on Quix platform.
 
@@ -493,7 +493,7 @@ If it doesn't match, the warning will be logged.
 class QuixPortalApiService()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/platforms/quix/api.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/platforms/quix/api.py#L14)
 
 A light wrapper around the Quix Portal Api. If used in the Quix Platform, it will
 use that workspaces auth token and portal endpoint, else you must provide it.
@@ -518,7 +518,7 @@ See the swagger documentation for more info about the endpoints.
 class StreamingDataFrame(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L29)
 
 `StreamingDataFrame` is the main object you will use for ETL work.
 
@@ -574,7 +574,7 @@ def apply(func: Union[DataFrameFunc, DataFrameStatefulFunc],
           expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L99)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L99)
 
 Apply a function to transform the value and return a new value.
 
@@ -616,7 +616,7 @@ def update(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L142)
 
 Apply a function to mutate value in-place or to perform a side effect
 
@@ -658,7 +658,7 @@ def filter(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L181)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L181)
 
 Filter value using provided function.
 
@@ -700,7 +700,7 @@ of type `State` to perform stateful operations.
 def contains(key: str) -> StreamingSeries
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L234)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L234)
 
 Check if the key is present in the Row value.
 
@@ -732,7 +732,7 @@ def to_topic(topic: Topic,
              key: Optional[Callable[[object], object]] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L257)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L257)
 
 Produce current value to a topic. You can optionally specify a new key.
 
@@ -774,7 +774,7 @@ By default, the current message key will be used.
 def compose() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L296)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L296)
 
 Compose all functions of this StreamingDataFrame into one big closure.
 
@@ -811,7 +811,7 @@ and returns a result of StreamingDataFrame
 def test(value: object, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L326)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L326)
 
 A shorthand to test `StreamingDataFrame` with provided value
 
@@ -840,7 +840,7 @@ def tumbling_window(
                                  timedelta]] = 0) -> TumblingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L344)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L344)
 
 Create a tumbling window transformation on this StreamingDataFrame.
 
@@ -909,7 +909,7 @@ def hopping_window(
                                  timedelta]] = 0) -> HoppingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/dataframe.py#L409)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/dataframe.py#L409)
 
 Create a hopping window transformation on this StreamingDataFrame.
 
@@ -923,6 +923,7 @@ The time windows always use the current event time.
 
 Example Snippet:
 
+Example Snippet:
 ```python
 
 app = Application()
@@ -989,7 +990,7 @@ like `sum`, `count`, etc. and applied to the StreamingDataFrame.
 class StreamingSeries(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L16)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L16)
 
 `StreamingSeries` are typically generated by `StreamingDataframes` when getting
 elements from, or performing certain operations on, a `StreamingDataframe`,
@@ -1047,7 +1048,7 @@ sdf = sdf[["column_a"] & (sdf["new_sum_field"] >= 10)]
 def from_func(cls, func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L76)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L76)
 
 Create a StreamingSeries from a function.
 
@@ -1069,7 +1070,7 @@ instance of `StreamingSeries`
 def apply(func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L90)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L90)
 
 Add a callable to the execution list for this series.
 
@@ -1114,7 +1115,7 @@ def compose(allow_filters: bool = True,
             allow_updates: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L124)
 
 Compose all functions of this StreamingSeries into one big closure.
 
@@ -1166,7 +1167,7 @@ and returns a result of `StreamingSeries`
 def test(value: Any, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L171)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L171)
 
 A shorthand to test `StreamingSeries` with provided value
 
@@ -1192,7 +1193,7 @@ result of `StreamingSeries`
 def isin(other: Container) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L202)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L202)
 
 Check if series value is in "other".
 
@@ -1229,7 +1230,7 @@ new StreamingSeries
 def contains(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L229)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L229)
 
 Check if series value contains "other"
 
@@ -1266,7 +1267,7 @@ new StreamingSeries
 def is_(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L254)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L254)
 
 Check if series value refers to the same object as `other`
 
@@ -1300,7 +1301,7 @@ new StreamingSeries
 def isnot(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L277)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L277)
 
 Check if series value does not refer to the same object as `other`
 
@@ -1335,7 +1336,7 @@ new StreamingSeries
 def isnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L301)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L301)
 
 Check if series value is None.
 
@@ -1366,7 +1367,7 @@ new StreamingSeries
 def notnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L324)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L324)
 
 Check if series value is not None.
 
@@ -1397,7 +1398,7 @@ new StreamingSeries
 def abs() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/series.py#L347)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/series.py#L347)
 
 Get absolute value of the series value.
 
@@ -1433,7 +1434,7 @@ new StreamingSeries
 def ensure_milliseconds(delta: Union[int, timedelta]) -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/utils.py#L5)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/utils.py#L5)
 
 Convert timedelta to milliseconds.
 
@@ -1461,7 +1462,7 @@ timedelta value in milliseconds as `int`
 class FixedTimeWindowDefinition(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/definitions.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/definitions.py#L20)
 
 <a id="quixstreams.dataframe.windows.definitions.FixedTimeWindowDefinition.sum"></a>
 
@@ -1471,7 +1472,7 @@ class FixedTimeWindowDefinition(abc.ABC)
 def sum() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/definitions.py#L68)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/definitions.py#L68)
 
 Configure the window to aggregate data by summing up values within
 
@@ -1489,7 +1490,7 @@ an instance of `FixedTimeWindow` configured to perform sum aggregation.
 def count() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/definitions.py#L95)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/definitions.py#L95)
 
 Configure the window to aggregate data by counting the number of values
 
@@ -1507,7 +1508,7 @@ an instance of `FixedTimeWindow` configured to perform record count.
 def mean() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/definitions.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/definitions.py#L122)
 
 Configure the window to aggregate data by calculating the mean of the values
 
@@ -1527,7 +1528,7 @@ def reduce(reducer: Callable[[Any, Any], Any],
            initializer: Callable[[Any], Any]) -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/definitions.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/definitions.py#L153)
 
 Configure the window to perform a custom aggregation using `reducer`
 
@@ -1576,7 +1577,7 @@ A window configured to perform custom reduce aggregation on the data.
 def max() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/definitions.py#L213)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/definitions.py#L213)
 
 Configure a window to aggregate the maximum value within each window period.
 
@@ -1593,7 +1594,7 @@ value within each window period.
 def min() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/definitions.py#L242)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/definitions.py#L242)
 
 Configure a window to aggregate the minimum value within each window period.
 
@@ -1618,7 +1619,7 @@ value within each window period.
 class FixedTimeWindow()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/time_based.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/time_based.py#L29)
 
 <a id="quixstreams.dataframe.windows.time_based.FixedTimeWindow.final"></a>
 
@@ -1628,7 +1629,7 @@ class FixedTimeWindow()
 def final(expand: bool = True) -> "StreamingDataFrame"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/time_based.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/time_based.py#L92)
 
 Apply the window aggregation and return results only when the windows are
 
@@ -1666,7 +1667,7 @@ Default - `True`
 def current(expand: bool = True) -> "StreamingDataFrame"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/time_based.py#L129)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/time_based.py#L129)
 
 Apply the window transformation to the StreamingDataFrame to return results
 
@@ -1704,7 +1705,7 @@ def get_window_ranges(timestamp_ms: int,
                       step_ms: Optional[int] = None) -> List[Tuple[int, int]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/dataframe/windows/base.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/dataframe/windows/base.py#L22)
 
 Get a list of window ranges for the given timestamp.
 
@@ -1734,7 +1735,7 @@ a list of (<start>, <end>) tuples
 class RowProducer(Producer, RowProducerProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/rowproducer.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/rowproducer.py#L25)
 
 A producer class that is capable of serializing Rows to bytes and send them to Kafka.
 
@@ -1772,7 +1773,7 @@ def produce_row(row: Row,
                 timestamp: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/rowproducer.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/rowproducer.py#L66)
 
 Serialize Row to bytes according to the Topic serialization settings
 
@@ -1796,7 +1797,7 @@ If this method fails, it will trigger the provided "on_error" callback.
 def poll(timeout: float = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/rowproducer.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/rowproducer.py#L103)
 
 Polls the producer for events and calls `on_delivery` callbacks.
 
@@ -1818,7 +1819,7 @@ If poll fails, it will trigger the provided "on_error" callback
 class StreamFunction(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/functions.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/functions.py#L27)
 
 A base class for all the streaming operations in Quix Streams.
 
@@ -1836,7 +1837,7 @@ It provides two methods that return closures to be called on the input values:
 def func() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/functions.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/functions.py#L44)
 
 The original function
 
@@ -1849,7 +1850,7 @@ The original function
 def get_executor() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/functions.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/functions.py#L51)
 
 Returns a wrapper to be called on a single value.
 
@@ -1862,7 +1863,7 @@ Returns a wrapper to be called on a single value.
 def get_executor_expanded() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/functions.py#L57)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/functions.py#L57)
 
 Returns a wrapper to be called on a list of expanded values.
 
@@ -1874,7 +1875,7 @@ Returns a wrapper to be called on a list of expanded values.
 class ApplyFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/functions.py#L63)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/functions.py#L63)
 
 Wrap a function into "Apply" function.
 
@@ -1889,7 +1890,7 @@ and its result will always be passed downstream.
 class ApplyExpandFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/functions.py#L86)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/functions.py#L86)
 
 Wrap a function into "Apply" function and expand the returned iterable
 into separate values downstream.
@@ -1905,7 +1906,7 @@ If the returned value is not `Iterable`, `TypeError` will be raised.
 class FilterFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/functions.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/functions.py#L115)
 
 Wraps a function into a "Filter" function.
 The result of a Filter function is interpreted as boolean.
@@ -1921,7 +1922,7 @@ value is filtered out.
 class UpdateFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/functions.py#L147)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/functions.py#L147)
 
 Wrap a function into an "Update" function.
 
@@ -1941,7 +1942,7 @@ def compose(functions: List[StreamFunction],
             allow_expands: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/functions.py#L176)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/functions.py#L176)
 
 Composes a list of functions and its parents into a single
 
@@ -1975,7 +1976,7 @@ def composer(outer_func: StreamCallable,
              inner_func: StreamCallable) -> Callable[[T], R]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/functions.py#L226)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/functions.py#L226)
 
 A function that wraps two other functions into a closure.
 
@@ -2001,7 +2002,7 @@ a function with one argument (value)
 class Stream()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/stream.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/stream.py#L22)
 
 <a id="quixstreams.core.stream.stream.Stream.__init__"></a>
 
@@ -2012,7 +2013,7 @@ def __init__(func: Optional[StreamFunction] = None,
              parent: Optional[Self] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/stream.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/stream.py#L23)
 
 A base class for all streaming operations.
 
@@ -2055,7 +2056,7 @@ Default - "Apply(lambda v: v)".
 def add_filter(func: Callable[[T], R]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/stream.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/stream.py#L79)
 
 Add a function to filter values from the Stream.
 
@@ -2079,7 +2080,7 @@ a new `Stream` derived from the current one
 def add_apply(func: Callable[[T], R], expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/stream.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/stream.py#L92)
 
 Add an "apply" function to the Stream.
 
@@ -2105,7 +2106,7 @@ a new `Stream` derived from the current one
 def add_update(func: Callable[[T], object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/stream.py#L109)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/stream.py#L109)
 
 Add an "update" function to the Stream, that will mutate the input value.
 
@@ -2128,7 +2129,7 @@ a new Stream derived from the current one
 def diff(other: "Stream") -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/stream.py#L121)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/stream.py#L121)
 
 Takes the difference between Streams `self` and `other` based on their last
 
@@ -2160,7 +2161,7 @@ new `Stream` instance including all the Streams from the diff
 def tree() -> List[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/stream.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/stream.py#L150)
 
 Return a list of all parent Streams including the node itself.
 
@@ -2180,7 +2181,7 @@ def compose(allow_filters: bool = True,
             allow_expands: bool = True) -> Callable[[T], R]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/core/stream/stream.py#L164)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/core/stream/stream.py#L164)
 
 Compose a list of functions from this `Stream` and its parents into one
 
@@ -2222,7 +2223,7 @@ the stream has functions with "expand=True" in the tree. Default - True.
 def dumps(value: Any) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/utils/json.py#L8)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/utils/json.py#L8)
 
 Serialize to JSON using `orjson` package.
 
@@ -2242,7 +2243,7 @@ bytes
 def loads(value: bytes) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/utils/json.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/utils/json.py#L18)
 
 Deserialize from JSON using `orjson` package.
 
@@ -2274,7 +2275,7 @@ object
 class TimestampType(enum.IntEnum)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/timestamps.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/timestamps.py#L9)
 
 <a id="quixstreams.models.timestamps.TimestampType.TIMESTAMP_NOT_AVAILABLE"></a>
 
@@ -2302,7 +2303,7 @@ broker receive time
 class MessageTimestamp()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/timestamps.py#L15)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/timestamps.py#L15)
 
 Represents a timestamp of incoming Kafka message.
 
@@ -2318,7 +2319,7 @@ it should not be mutated during message processing.
 def create(cls, timestamp_type: int, milliseconds: int) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/timestamps.py#L42)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/timestamps.py#L42)
 
 Create a Timestamp object based on data
 
@@ -2355,7 +2356,7 @@ Timestamp object
 class MessageContext()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/messagecontext.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/messagecontext.py#L7)
 
 An object with Kafka message properties.
 
@@ -2374,7 +2375,7 @@ it should not be mutated during message processing.
 class ConfluentKafkaMessageProto(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/types.py#L10)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/types.py#L10)
 
 An interface of `confluent_kafka.Message`.
 
@@ -2399,7 +2400,7 @@ see https://github.com/confluentinc/confluent-kafka-python/issues/1535.
 class IgnoreMessage(exceptions.QuixException)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/exceptions.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/exceptions.py#L51)
 
 Raise this exception from Deserializer.__call__ in order to ignore the processing
 of the particular message.
@@ -2416,7 +2417,7 @@ of the particular message.
 class QuixDeserializer(JSONDeserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L70)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L70)
 
 Handles Deserialization for any Quix-formatted topic.
 
@@ -2431,7 +2432,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L77)
 
 **Arguments**:
 
@@ -2449,7 +2450,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L97)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L97)
 
 Each Quix message might contain data for multiple Rows.
 This property informs the downstream processors about that, so they can
@@ -2464,7 +2465,7 @@ def deserialize(model_key: str, value: Union[List[Mapping],
                                              Mapping]) -> Iterable[Mapping]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L150)
 
 Deserialization function for particular data types (Timeseries or EventData).
 
@@ -2485,7 +2486,7 @@ Iterable of dicts
 class QuixSerializer(JSONSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L268)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L268)
 
 <a id="quixstreams.models.serializers.quix.QuixSerializer.__init__"></a>
 
@@ -2496,7 +2497,7 @@ def __init__(as_legacy: bool = True,
              dumps: Callable[[Any], Union[str, bytes]] = default_dumps)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L272)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L272)
 
 Serializer that returns data in json format.
 
@@ -2514,7 +2515,7 @@ Default - :py:func:`quixstreams.utils.json.dumps`
 class QuixTimeseriesSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L315)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L315)
 
 Serialize data to JSON formatted according to Quix Timeseries format.
 
@@ -2546,7 +2547,7 @@ Output:
 class QuixEventsSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L403)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L403)
 
 Serialize data to JSON formatted according to Quix EventData format.
 The input value is expected to be a dictionary with the following keys:
@@ -2587,7 +2588,7 @@ Output:
 class BytesDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L44)
 
 A deserializer to bypass bytes without any changes
 
@@ -2599,7 +2600,7 @@ A deserializer to bypass bytes without any changes
 class BytesSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L55)
 
 A serializer to bypass bytes without any changes
 
@@ -2611,7 +2612,7 @@ A serializer to bypass bytes without any changes
 class StringDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L64)
 
 <a id="quixstreams.models.serializers.simple_types.StringDeserializer.__init__"></a>
 
@@ -2621,7 +2622,7 @@ class StringDeserializer(Deserializer)
 def __init__(column_name: Optional[str] = None, codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L65)
 
 Deserializes bytes to strings using the specified encoding.
 
@@ -2638,7 +2639,7 @@ A wrapper around `confluent_kafka.serialization.StringDeserializer`.
 class IntegerDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L84)
 
 Deserializes bytes to integers.
 
@@ -2652,7 +2653,7 @@ A wrapper around `confluent_kafka.serialization.IntegerDeserializer`.
 class DoubleDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L103)
 
 Deserializes float to IEEE 764 binary64.
 
@@ -2666,7 +2667,7 @@ A wrapper around `confluent_kafka.serialization.DoubleDeserializer`.
 class StringSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L122)
 
 <a id="quixstreams.models.serializers.simple_types.StringSerializer.__init__"></a>
 
@@ -2676,7 +2677,7 @@ class StringSerializer(Serializer)
 def __init__(codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L123)
 
 Serializes strings to bytes using the specified encoding.
 
@@ -2692,7 +2693,7 @@ Serializes strings to bytes using the specified encoding.
 class IntegerSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L135)
 
 Serializes integers to bytes
 
@@ -2704,7 +2705,7 @@ Serializes integers to bytes
 class DoubleSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L148)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L148)
 
 Serializes floats to bytes
 
@@ -2720,7 +2721,7 @@ Serializes floats to bytes
 class JSONSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/json.py#L13)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/json.py#L13)
 
 <a id="quixstreams.models.serializers.json.JSONSerializer.__init__"></a>
 
@@ -2730,7 +2731,7 @@ class JSONSerializer(Serializer)
 def __init__(dumps: Callable[[Any], Union[str, bytes]] = default_dumps)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/json.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/json.py#L14)
 
 Serializer that returns data in json format.
 
@@ -2747,7 +2748,7 @@ Default - :py:func:`quixstreams.utils.json.dumps`
 class JSONDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/json.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/json.py#L35)
 
 <a id="quixstreams.models.serializers.json.JSONDeserializer.__init__"></a>
 
@@ -2758,7 +2759,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/json.py#L36)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/json.py#L36)
 
 Deserializer that parses data from JSON
 
@@ -2781,7 +2782,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 class SerializationContext()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/base.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/base.py#L22)
 
 Provides additional context for message serialization/deserialization.
 
@@ -2795,7 +2796,7 @@ Every `Serializer` and `Deserializer` receives an instance of `SerializationCont
 def to_confluent_ctx(field: MessageField) -> _SerializationContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/base.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/base.py#L35)
 
 Convert `SerializationContext` to `confluent_kafka.SerializationContext`
 
@@ -2817,7 +2818,7 @@ instance of `confluent_kafka.serialization.SerializationContext`
 class Deserializer(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/base.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/base.py#L47)
 
 <a id="quixstreams.models.serializers.base.Deserializer.__init__"></a>
 
@@ -2827,7 +2828,7 @@ class Deserializer(abc.ABC)
 def __init__(column_name: Optional[str] = None, *args, **kwargs)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/base.py#L48)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/base.py#L48)
 
 A base class for all Deserializers
 
@@ -2845,7 +2846,7 @@ dictionary with `column_name` as a key.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/base.py#L58)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/base.py#L58)
 
 Return True if the deserialized message should be considered as Iterable
 and each item in it should be processed as a separate message.
@@ -2858,7 +2859,7 @@ and each item in it should be processed as a separate message.
 class Serializer(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/base.py#L75)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/base.py#L75)
 
 A base class for all Serializers
 
@@ -2871,7 +2872,7 @@ A base class for all Serializers
 def extra_headers() -> MessageHeadersMapping
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/base.py#L81)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/base.py#L81)
 
 Informs producer to set additional headers
 
@@ -2896,7 +2897,7 @@ dict with headers
 class Topic()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/topics.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/topics.py#L64)
 
 A representation of a Kafka topic and its expected data format via
 designated key and value serializers/deserializers.
@@ -2919,7 +2920,7 @@ def __init__(
         timestamp_extractor: Optional[TimestampExtractor] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/topics.py#L74)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/topics.py#L74)
 
 Can specify serialization that should be used when consuming/producing
 
@@ -2975,7 +2976,7 @@ topic = Topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/topics.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/topics.py#L135)
 
 Topic name
 
@@ -2987,7 +2988,7 @@ Topic name
 def row_serialize(row: Row, key: Optional[Any] = None) -> KafkaMessage
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/topics.py#L141)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/topics.py#L141)
 
 Serialize Row to a Kafka message structure
 
@@ -3009,7 +3010,7 @@ def row_deserialize(
         message: ConfluentKafkaMessageProto) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/topics.py#L164)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/topics.py#L164)
 
 Deserialize incoming Kafka message to a Row.
 
@@ -3037,7 +3038,7 @@ Row, list of Rows or None if the message is ignored.
 class Row()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/rows.py#L11)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/rows.py#L11)
 
 Row is a dict-like interface on top of the message data + some Kafka props
 
@@ -3049,7 +3050,7 @@ Row is a dict-like interface on top of the message data + some Kafka props
 def keys() -> KeysView
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/rows.py#L73)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/rows.py#L73)
 
 Also allows unpacking row.value via **row
 
@@ -3061,7 +3062,7 @@ Also allows unpacking row.value via **row
 def clone(value: dict) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/rows.py#L85)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/rows.py#L85)
 
 Manually clone the Row; doing it this way is much faster than doing a deepcopy
 on the entire Row object.
@@ -3082,7 +3083,7 @@ on the entire Row object.
 class WindowedRocksDBStorePartition(RocksDBStorePartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/partition.py#L21)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/partition.py#L21)
 
 A base class to access windowed state in RocksDB.
 
@@ -3095,9 +3096,6 @@ stores the expiration index to delete expired windows.
 
 - `path`: an absolute path to the RocksDB folder
 - `options`: RocksDB options. If `None`, the default options will be used.
-- `open_max_retries`: number of times to retry opening the database
-if it's locked by another process. To disable retrying, pass 0.
-- `open_retry_backoff`: number of seconds to wait between each retry.
 
 <a id="quixstreams.state.rocksdb.windowed.transaction"></a>
 
@@ -3111,7 +3109,7 @@ if it's locked by another process. To disable retrying, pass 0.
 class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/transaction.py#L16)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/transaction.py#L16)
 
 <a id="quixstreams.state.rocksdb.windowed.transaction.WindowedRocksDBPartitionTransaction.expire_windows"></a>
 
@@ -3122,7 +3120,7 @@ def expire_windows(duration_ms: int,
                    grace_ms: int = 0) -> List[Tuple[Tuple[int, int], Any]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/transaction.py#L74)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/transaction.py#L74)
 
 Get a list of expired windows from RocksDB considering latest timestamp,
 
@@ -3160,7 +3158,7 @@ sorted list of tuples in format `((start, end), value)`
 def parse_window_key(key: bytes) -> Tuple[bytes, int, int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/serialization.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/serialization.py#L12)
 
 Parse the window key from Rocksdb into (message_key, start, end) structure.
 
@@ -3183,7 +3181,7 @@ a tuple with message key, start timestamp, end timestamp
 def encode_window_key(start_ms: int, end_ms: int) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/serialization.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/serialization.py#L39)
 
 Encode window start and end timestamps into bytes of the following format:
 
@@ -3208,7 +3206,7 @@ window timestamps as bytes
 def encode_window_prefix(prefix: bytes, start_ms: int) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/serialization.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/serialization.py#L53)
 
 Encode window prefix and start time to iterate over keys in RocksDB
 
@@ -3236,7 +3234,7 @@ bytes
 class WindowedTransactionState(WindowedState)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/state.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/state.py#L9)
 
 <a id="quixstreams.state.rocksdb.windowed.state.WindowedTransactionState.__init__"></a>
 
@@ -3246,7 +3244,7 @@ class WindowedTransactionState(WindowedState)
 def __init__(transaction: "WindowedRocksDBPartitionTransaction")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/state.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/state.py#L12)
 
 A windowed state to be provided into `StreamingDataFrame` window functions.
 
@@ -3264,7 +3262,7 @@ def get_window(start_ms: int,
                default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/state.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/state.py#L20)
 
 Get the value of the window defined by `start` and `end` timestamps
 
@@ -3288,7 +3286,7 @@ value or None if the key is not found and `default` is not provided
 def update_window(start_ms: int, end_ms: int, value: Any, timestamp_ms: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/state.py#L36)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/state.py#L36)
 
 Set a value for the window.
 
@@ -3310,7 +3308,7 @@ using the provided `timestamp`.
 def get_latest_timestamp() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/state.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/state.py#L53)
 
 Get the latest observed timestamp for the current state partition.
 
@@ -3330,7 +3328,7 @@ def expire_windows(duration_ms: int,
                    grace_ms: int = 0) -> List[Tuple[Tuple[int, int], Any]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/windowed/state.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/windowed/state.py#L65)
 
 Get a list of expired windows from RocksDB considering the current
 latest timestamp, window duration and grace period.
@@ -3352,14 +3350,18 @@ calling this method multiple times will yield different results for the same
 class RocksDBOptions(RocksDBOptionsType)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/options.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/options.py#L25)
 
-Common RocksDB database options.
+RocksDB database options.
 
-Please see `rocksdict.Options` for a complete description of each option.
+**Arguments**:
 
-To provide extra options that are not presented in this class, feel free
-to override it and specify the additional values.
+- `dumps`: function to dump data to JSON
+- `loads`: function to load data from JSON
+- `open_max_retries`: number of times to retry opening the database
+if it's locked by another process. To disable retrying, pass 0
+- `open_retry_backoff`: number of seconds to wait between each retry.
+Please see `rocksdict.Options` for a complete description of other options.
 
 <a id="quixstreams.state.rocksdb.options.RocksDBOptions.write_buffer_size"></a>
 
@@ -3393,7 +3395,7 @@ to override it and specify the additional values.
 def to_options() -> rocksdict.Options
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/options.py#L48)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/options.py#L53)
 
 Convert parameters to `rocksdict.Options`
 
@@ -3413,7 +3415,7 @@ instance of `rocksdict.Options`
 class RocksDBStore(Store)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/store.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/store.py#L18)
 
 <a id="quixstreams.state.rocksdb.store.RocksDBStore.__init__"></a>
 
@@ -3423,12 +3425,10 @@ class RocksDBStore(Store)
 def __init__(name: str,
              topic: str,
              base_dir: str,
-             options: Optional[RocksDBOptionsType] = None,
-             open_max_retries: int = 10,
-             open_retry_backoff: float = 3.0)
+             options: Optional[RocksDBOptionsType] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/store.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/store.py#L19)
 
 RocksDB-based state store.
 
@@ -3441,9 +3441,6 @@ partitions' transactions.
 - `topic`: a topic name for this store
 - `base_dir`: path to a directory with the state
 - `options`: RocksDB options. If `None`, the default options will be used.
-- `open_max_retries`: number of times to retry opening the database
-if it's locked by another process. To disable retrying, pass 0.
-- `open_retry_backoff`: number of seconds to wait between each retry.
 
 <a id="quixstreams.state.rocksdb.store.RocksDBStore.topic"></a>
 
@@ -3454,7 +3451,7 @@ if it's locked by another process. To disable retrying, pass 0.
 def topic() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/store.py#L52)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/store.py#L45)
 
 Store topic name
 
@@ -3467,7 +3464,7 @@ Store topic name
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/store.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/store.py#L52)
 
 Store name
 
@@ -3480,7 +3477,7 @@ Store name
 def partitions() -> Dict[int, RocksDBStorePartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/store.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/store.py#L59)
 
 Mapping of assigned store partitions
 
@@ -3492,7 +3489,7 @@ Mapping of assigned store partitions
 def assign_partition(partition: int) -> RocksDBStorePartition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/store.py#L80)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/store.py#L68)
 
 Open and assign store partition.
 
@@ -3515,7 +3512,7 @@ instance of`RocksDBStorePartition`
 def revoke_partition(partition: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/store.py#L110)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/store.py#L98)
 
 Revoke and close the assigned store partition.
 
@@ -3533,7 +3530,7 @@ If the partition is not assigned, it will log the message and return.
 def start_partition_transaction(partition: int) -> RocksDBPartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/store.py#L131)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/store.py#L119)
 
 Start a new partition transaction.
 
@@ -3556,7 +3553,7 @@ instance of `RocksDBPartitionTransaction`
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/store.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/store.py#L141)
 
 Close the store and revoke all assigned partitions
 
@@ -3572,7 +3569,7 @@ Close the store and revoke all assigned partitions
 class RocksDBStorePartition(StorePartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L47)
 
 A base class to access state in RocksDB.
 
@@ -3584,15 +3581,12 @@ Responsibilities:
  3. Flushing WriteBatches to the RocksDB
 
 It opens the RocksDB on `__init__`. If the db is locked by another process,
-it will retry according to `open_max_retries` and `open_retry_backoff`.
+it will retry according to `open_max_retries` and `open_retry_backoff` options.
 
 **Arguments**:
 
 - `path`: an absolute path to the RocksDB folder
 - `options`: RocksDB options. If `None`, the default options will be used.
-- `open_max_retries`: number of times to retry opening the database
-if it's locked by another process. To disable retrying, pass 0.
-- `open_retry_backoff`: number of seconds to wait between each retry.
 
 <a id="quixstreams.state.rocksdb.partition.RocksDBStorePartition.begin"></a>
 
@@ -3602,7 +3596,7 @@ if it's locked by another process. To disable retrying, pass 0.
 def begin() -> "RocksDBPartitionTransaction"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L85)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L80)
 
 Create a new `RocksDBTransaction` object.
 
@@ -3620,7 +3614,7 @@ an instance of `RocksDBTransaction`
 def write(batch: WriteBatch)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L96)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L91)
 
 Write `WriteBatch` to RocksDB
 
@@ -3638,7 +3632,7 @@ def get(key: bytes,
         cf_name: str = "default") -> Union[None, bytes, Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L98)
 
 Get a key from RocksDB.
 
@@ -3660,7 +3654,7 @@ a value if the key is present in the DB. Otherwise, `default`
 def exists(key: bytes, cf_name: str = "default") -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L117)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L112)
 
 Check if a key is present in the DB.
 
@@ -3681,7 +3675,7 @@ Check if a key is present in the DB.
 def get_processed_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L128)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L123)
 
 Get last processed offset for the given partition
 
@@ -3697,7 +3691,7 @@ offset or `None` if there's no processed offset yet
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L140)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L135)
 
 Close the underlying RocksDB
 
@@ -3710,7 +3704,7 @@ Close the underlying RocksDB
 def path() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L148)
 
 Absolute path to RocksDB database folder
 
@@ -3727,7 +3721,7 @@ file path
 def destroy(cls, path: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L161)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L156)
 
 Delete underlying RocksDB database
 
@@ -3745,7 +3739,7 @@ The database must be closed first.
 def get_column_family_handle(cf_name: str) -> ColumnFamily
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L171)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L166)
 
 Get a column family handle to pass to it WriteBatch.
 
@@ -3768,7 +3762,7 @@ instance of `rocksdict.ColumnFamily`
 def get_column_family(cf_name: str) -> Rdict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L187)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L182)
 
 Get a column family instance.
 
@@ -3790,7 +3784,7 @@ instance of `rocksdict.Rdict` for the given column family
 class RocksDBPartitionTransaction(PartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L314)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L309)
 
 A transaction class to perform simple key-value operations like
 
@@ -3837,7 +3831,7 @@ the underlying RocksDB
 def with_prefix(prefix: Any = b"") -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L383)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L378)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -3867,7 +3861,7 @@ def get(key: Any,
         cf_name: str = "default") -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L412)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L407)
 
 Get a key from the store.
 
@@ -3896,7 +3890,7 @@ value or `default`
 def set(key: Any, value: Any, cf_name: str = "default")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L447)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L442)
 
 Set a key to the store.
 
@@ -3917,7 +3911,7 @@ It first updates the key in the update cache.
 def delete(key: Any, cf_name: str = "default")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L472)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L467)
 
 Delete a key from the store.
 
@@ -3937,7 +3931,7 @@ It first deletes the key from the update cache.
 def exists(key: Any, cf_name: str = "default") -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L495)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L490)
 
 Check if a key exists in the store.
 
@@ -3961,7 +3955,7 @@ It first looks up the key in the update cache.
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L517)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L512)
 
 Check if the transaction is completed.
 
@@ -3983,7 +3977,7 @@ The completed transaction should not be re-used.
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L531)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L526)
 
 Check if the transaction has failed.
 
@@ -4003,7 +3997,7 @@ and
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/rocksdb/partition.py#L543)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/rocksdb/partition.py#L538)
 
 Flush the recent updates to the database and empty the update cache.
 
@@ -4057,7 +4051,7 @@ cannot be used anymore.
 class Store(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L9)
 
 Abstract state store.
 
@@ -4073,7 +4067,7 @@ partitions' transactions.
 def topic() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L18)
 
 Topic name
 
@@ -4086,7 +4080,7 @@ Topic name
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L24)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L24)
 
 Store name
 
@@ -4099,7 +4093,7 @@ Store name
 def partitions() -> Dict[int, "StorePartition"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L30)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L30)
 
 Mapping of assigned store partitions
 
@@ -4115,7 +4109,7 @@ dict of "{partition: <StorePartition>}"
 def assign_partition(partition: int) -> "StorePartition"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L37)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L37)
 
 Assign new store partition
 
@@ -4135,7 +4129,7 @@ instance of `StorePartition`
 def revoke_partition(partition: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L46)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L46)
 
 Revoke assigned store partition
 
@@ -4152,7 +4146,7 @@ def start_partition_transaction(
         partition: int) -> Optional["PartitionTransaction"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L55)
 
 Start a new partition transaction.
 
@@ -4174,7 +4168,7 @@ instance of `PartitionTransaction`
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L66)
 
 Close store and revoke all store partitions
 
@@ -4186,7 +4180,7 @@ Close store and revoke all store partitions
 class StorePartition(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L78)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L78)
 
 A base class to access state in the underlying storage.
 It represents a single instance of some storage (e.g. a single database for
@@ -4201,7 +4195,7 @@ the persistent storage).
 def path() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L87)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L87)
 
 Absolute path to RocksDB database folder
 
@@ -4213,7 +4207,7 @@ Absolute path to RocksDB database folder
 def begin() -> "PartitionTransaction"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L93)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L93)
 
 State new `PartitionTransaction`
 
@@ -4225,7 +4219,7 @@ State new `PartitionTransaction`
 class State(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L102)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L102)
 
 Primary interface for working with key-value state data from `StreamingDataFrame`
 
@@ -4237,7 +4231,7 @@ Primary interface for working with key-value state data from `StreamingDataFrame
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L107)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L107)
 
 Get the value for key if key is present in the state, else default
 
@@ -4258,7 +4252,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L116)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L116)
 
 Set value for the key.
 
@@ -4275,7 +4269,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L123)
 
 Delete value for the key.
 
@@ -4293,7 +4287,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L131)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L131)
 
 Check if the key exists in state.
 
@@ -4313,7 +4307,7 @@ True if key exists, False otherwise
 class PartitionTransaction(State)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L139)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L139)
 
 A transaction class to perform simple key-value operations like
 "get", "set", "delete" and "exists" on a single storage partition.
@@ -4327,7 +4321,7 @@ A transaction class to perform simple key-value operations like
 def state() -> State
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L146)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L146)
 
 An instance of State to be provided to `StreamingDataFrame` functions
 
@@ -4341,7 +4335,7 @@ An instance of State to be provided to `StreamingDataFrame` functions
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L153)
 
 Return `True` if transaction failed to update data at some point.
 
@@ -4360,7 +4354,7 @@ bool
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L162)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L162)
 
 Return `True` if transaction is completed.
 
@@ -4378,7 +4372,7 @@ bool
 def with_prefix(prefix: Any = b"") -> Iterator[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L171)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L171)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -4401,7 +4395,7 @@ context maager
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L181)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L181)
 
 Flush the recent updates and last processed offset to the storage.
 
@@ -4417,7 +4411,7 @@ Flush the recent updates and last processed offset to the storage.
 class WindowedState(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L194)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L194)
 
 A windowed state to be provided into `StreamingDataFrame` window functions.
 
@@ -4431,7 +4425,7 @@ def get_window(start_ms: int,
                default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L199)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L199)
 
 Get the value of the window defined by `start` and `end` timestamps
 
@@ -4455,7 +4449,7 @@ value or None if the key is not found and `default` is not provided
 def update_window(start_ms: int, end_ms: int, value: Any, timestamp_ms: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L212)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L212)
 
 Set a value for the window.
 
@@ -4477,7 +4471,7 @@ using the provided `timestamp`.
 def get_latest_timestamp() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L225)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L225)
 
 Get the latest observed timestamp for the current state partition.
 
@@ -4496,7 +4490,7 @@ latest observed event timestamp in milliseconds
 def expire_windows(duration_ms: int, grace_ms: int = 0)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L235)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L235)
 
 Get a list of expired windows from RocksDB considering the current
 
@@ -4519,7 +4513,7 @@ calling this method multiple times will yield different results for the same
 class WindowedPartitionTransaction(WindowedState)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L249)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L249)
 
 <a id="quixstreams.state.types.WindowedPartitionTransaction.failed"></a>
 
@@ -4530,7 +4524,7 @@ class WindowedPartitionTransaction(WindowedState)
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L255)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L255)
 
 Return `True` if transaction failed to update data at some point.
 
@@ -4549,7 +4543,7 @@ bool
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L264)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L264)
 
 Return `True` if transaction is completed.
 
@@ -4567,7 +4561,7 @@ bool
 def with_prefix(prefix: Any = b"") -> Iterator[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L273)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L273)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -4590,7 +4584,7 @@ context maager
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/types.py#L283)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/types.py#L283)
 
 Flush the recent updates and last processed offset to the storage.
 
@@ -4614,7 +4608,7 @@ Flush the recent updates and last processed offset to the storage.
 class StateStoreManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L29)
 
 Class for managing state stores and partitions.
 
@@ -4632,7 +4626,7 @@ StateStoreManager is responsible for:
 def stores() -> Dict[str, Dict[str, Store]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L65)
 
 Map of registered state stores
 
@@ -4649,7 +4643,7 @@ def get_store(topic: str,
               store_name: str = _DEFAULT_STATE_STORE_NAME) -> Store
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L72)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L72)
 
 Get a store for given name and topic
 
@@ -4671,7 +4665,7 @@ def register_store(topic_name: str,
                    store_name: str = _DEFAULT_STATE_STORE_NAME)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L88)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L88)
 
 Register a state store to be managed by StateStoreManager.
 
@@ -4693,7 +4687,7 @@ Each store can be registered only once for each topic.
 def register_windowed_store(topic_name: str, store_name: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L111)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L111)
 
 Register a windowed state store to be managed by StateStoreManager.
 
@@ -4715,7 +4709,7 @@ Each window store can be registered only once for each topic.
 def clear_stores()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L134)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L134)
 
 Delete all state stores managed by StateStoreManager.
 
@@ -4727,7 +4721,7 @@ Delete all state stores managed by StateStoreManager.
 def on_partition_assign(tp: TopicPartition) -> List[StorePartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L149)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L149)
 
 Assign store partitions for each registered store for the given `TopicPartition`
 
@@ -4749,7 +4743,7 @@ list of assigned `StorePartition`
 def on_partition_revoke(tp: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L163)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L163)
 
 Revoke store partitions for each registered store for the given `TopicPartition`
 
@@ -4765,7 +4759,7 @@ Revoke store partitions for each registered store for the given `TopicPartition`
 def on_partition_lost(tp: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L172)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L172)
 
 Revoke and close store partitions for each registered store for the given
 
@@ -4783,7 +4777,7 @@ Revoke and close store partitions for each registered store for the given
 def init()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L182)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L182)
 
 Initialize `StateStoreManager` and create a store directory
 
@@ -4796,7 +4790,7 @@ Initialize `StateStoreManager` and create a store directory
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L189)
 
 Close all registered stores
 
@@ -4809,7 +4803,7 @@ def get_store_transaction(
         store_name: str = _DEFAULT_STATE_STORE_NAME) -> PartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L197)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L197)
 
 Get active `PartitionTransaction` for the store
 
@@ -4827,7 +4821,7 @@ def start_store_transaction(topic: str, partition: int,
                             offset: int) -> Iterator["_MultiStoreTransaction"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/manager.py#L212)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/manager.py#L212)
 
 Starting the multi-store transaction for the Kafka message.
 
@@ -4856,7 +4850,7 @@ before the end of the current one will fail.
 class TransactionState(State)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/state.py#L6)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/state.py#L6)
 
 <a id="quixstreams.state.state.TransactionState.__init__"></a>
 
@@ -4866,7 +4860,7 @@ class TransactionState(State)
 def __init__(transaction: PartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/state.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/state.py#L9)
 
 Simple key-value state to be provided into `StreamingDataFrame` functions
 
@@ -4882,7 +4876,7 @@ Simple key-value state to be provided into `StreamingDataFrame` functions
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/state.py#L17)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/state.py#L17)
 
 Get the value for key if key is present in the state, else default
 
@@ -4903,7 +4897,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/state.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/state.py#L27)
 
 Set value for the key.
 
@@ -4920,7 +4914,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/state.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/state.py#L35)
 
 Delete value for the key.
 
@@ -4938,7 +4932,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/state/state.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/state/state.py#L44)
 
 Check if the key exists in state.
 
@@ -4966,7 +4960,7 @@ True if key exists, False otherwise
 class PartitionAssignmentError(QuixException)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/exceptions/assignment.py#L6)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/exceptions/assignment.py#L6)
 
 Error happened during partition rebalancing.
 Raised from `on_assign`, `on_revoke` and `on_lost` callbacks
@@ -4987,7 +4981,7 @@ Raised from `on_assign`, `on_revoke` and `on_lost` callbacks
 def set_message_context(context: Optional[MessageContext])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/context.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/context.py#L22)
 
 Set a MessageContext for the current message in the given `contextvars.Context`
 
@@ -5024,7 +5018,7 @@ sdf = sdf.update(lambda value: alter_context(value))
 def message_context() -> MessageContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/context.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/context.py#L53)
 
 Get a MessageContext for the current message, which houses most of the message
 
@@ -5059,7 +5053,7 @@ instance of `MessageContext`
 def message_key() -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/context.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/context.py#L84)
 
 Get the current message's key.
 
@@ -5095,7 +5089,7 @@ a deserialized message key
 class Producer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/producer.py#L58)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/producer.py#L58)
 
 <a id="quixstreams.kafka.producer.Producer.__init__"></a>
 
@@ -5107,7 +5101,7 @@ def __init__(broker_address: str,
              extra_config: dict = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/producer.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/producer.py#L59)
 
 A wrapper around `confluent_kafka.Producer`.
 
@@ -5143,7 +5137,7 @@ def produce(topic: str,
             buffer_error_max_tries: int = 3)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/producer.py#L98)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/producer.py#L98)
 
 Produce message to topic.
 
@@ -5172,7 +5166,7 @@ Pass `0` to not retry after `BufferError`.
 def poll(timeout: float = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/producer.py#L156)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/producer.py#L156)
 
 Polls the producer for events and calls `on_delivery` callbacks.
 
@@ -5188,7 +5182,7 @@ Polls the producer for events and calls `on_delivery` callbacks.
 def flush(timeout: float = None) -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/producer.py#L163)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/producer.py#L163)
 
 Wait for all messages in the Producer queue to be delivered.
 
@@ -5212,7 +5206,7 @@ number of messages delivered
 class Consumer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L66)
 
 <a id="quixstreams.kafka.consumer.Consumer.__init__"></a>
 
@@ -5229,7 +5223,7 @@ def __init__(broker_address: str,
              extra_config: Optional[dict] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L67)
 
 A wrapper around `confluent_kafka.Consumer`.
 
@@ -5267,7 +5261,7 @@ Note: values passed as arguments override values in `extra_config`.
 def poll(timeout: float = None) -> Optional[Message]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L124)
 
 Consumes a single message, calls callbacks and returns events.
 
@@ -5302,7 +5296,7 @@ def subscribe(topics: List[str],
               on_lost: Optional[RebalancingCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L143)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L143)
 
 Set subscription to supplied list of topics
 
@@ -5340,7 +5334,7 @@ for example, may fail.
 def unsubscribe()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L237)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L237)
 
 Remove current subscription.
 
@@ -5358,7 +5352,7 @@ def store_offsets(message: Optional[Message] = None,
                   offsets: List[TopicPartition] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L245)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L245)
 
 .. py:function:: store_offsets([message=None], [offsets=None])
 
@@ -5389,7 +5383,7 @@ def commit(message: Message = None,
            asynchronous: bool = True) -> Optional[List[TopicPartition]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L279)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L279)
 
 Commit a message or a list of offsets.
 
@@ -5423,7 +5417,7 @@ def committed(partitions: List[TopicPartition],
               timeout: float = None) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L319)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L319)
 
 .. py:function:: committed(partitions, [timeout=None])
 
@@ -5453,7 +5447,7 @@ def get_watermark_offsets(partition: TopicPartition,
                           cached: bool = False) -> Tuple[int, int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L339)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L339)
 
 Retrieve low and high offsets for the specified partition.
 
@@ -5485,7 +5479,7 @@ def list_topics(topic: Optional[str] = None,
                 timeout: float = -1) -> ClusterMetadata
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L365)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L365)
 
 .. py:function:: list_topics([topic=None], [timeout=-1])
 
@@ -5514,7 +5508,7 @@ or -1 for infinite timeout.
 def memberid() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L386)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L386)
 
 Return this client's broker-assigned group member id.
 
@@ -5535,7 +5529,7 @@ def offsets_for_times(partitions: List[TopicPartition],
                       timeout: float = None) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L399)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L399)
 
 Look up offsets by timestamp for the specified partitions.
 
@@ -5561,7 +5555,7 @@ last message in the partition, a value of -1 will be returned.
 def pause(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L427)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L427)
 
 Pause consumption for the provided list of partitions.
 
@@ -5581,7 +5575,7 @@ Pause consumption for the provided list of partitions.
 def resume(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L437)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L437)
 
 .. py:function:: resume(partitions)
 
@@ -5603,7 +5597,7 @@ Resume consumption for the provided list of partitions.
 def position(partitions: List[TopicPartition]) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L449)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L449)
 
 Retrieve current positions (offsets) for the specified partitions.
 
@@ -5630,7 +5624,7 @@ the last consumed message + 1.
 def seek(partition: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L463)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L463)
 
 Set consume position for partition to offset.
 
@@ -5658,7 +5652,7 @@ pass the offset in an `assign()` call.
 def assignment() -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L480)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L480)
 
 Returns the current partition assignment.
 
@@ -5679,7 +5673,7 @@ Returns the current partition assignment.
 def set_sasl_credentials(username: str, password: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L493)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L493)
 
 Sets the SASL credentials used for this client.
 These credentials will overwrite the old ones, and will be used the next
@@ -5696,7 +5690,7 @@ This method is applicable only to SASL PLAIN and SCRAM mechanisms.
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/kafka/consumer.py#L505)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/kafka/consumer.py#L505)
 
 Close down and terminate the Kafka Consumer.
 
@@ -5722,7 +5716,7 @@ see `poll()` for more info.
 class Application()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L43)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L43)
 
 The main Application class.
 
@@ -5784,7 +5778,7 @@ def __init__(broker_address: str,
              loglevel: Optional[LogLevel] = "INFO")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L82)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L82)
 
 **Arguments**:
 
@@ -5857,7 +5851,7 @@ def Quix(cls,
          auto_create_topics: bool = True) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L188)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L188)
 
 Initialize an Application to work with Quix platform,
 
@@ -5960,7 +5954,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L334)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L334)
 
 Create a topic definition.
 
@@ -6011,7 +6005,7 @@ Its name will be overridden by this method's 'name' param.
 def dataframe(topic: Topic) -> StreamingDataFrame
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L400)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L400)
 
 A simple helper method that generates a `StreamingDataFrame`, which is used
 
@@ -6053,7 +6047,7 @@ to be used as an input topic.
 def stop()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L436)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L436)
 
 Stop the internal poll loop and the message processing.
 
@@ -6071,7 +6065,7 @@ To otherwise stop an application, either send a `SIGTERM` to the process
 def get_producer() -> Producer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L448)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L448)
 
 Create and return a pre-configured Producer instance.
 The Producer is initialized with params passed to Application.
@@ -6102,7 +6096,7 @@ with app.get_producer() as producer:
 def get_consumer() -> Consumer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L484)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L484)
 
 Create and return a pre-configured Consumer instance.
 The Consumer is initialized with params passed to Application.
@@ -6143,7 +6137,7 @@ with app.get_consumer() as consumer:
 def clear_state()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L533)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L533)
 
 Clear the state of the application.
 
@@ -6155,7 +6149,7 @@ Clear the state of the application.
 def run(dataframe: StreamingDataFrame)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/app.py#L562)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/app.py#L562)
 
 Start processing data from Kafka using provided `StreamingDataFrame`
 
@@ -6195,7 +6189,7 @@ app.run(dataframe=df)
 class RowConsumer(Consumer, RowConsumerProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/rowconsumer.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/rowconsumer.py#L59)
 
 <a id="quixstreams.rowconsumer.RowConsumer.__init__"></a>
 
@@ -6213,7 +6207,7 @@ def __init__(broker_address: str,
              on_error: Optional[ConsumerErrorCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/rowconsumer.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/rowconsumer.py#L60)
 
 A consumer class that is capable of deserializing Kafka messages to Rows
 
@@ -6257,7 +6251,7 @@ def subscribe(topics: List[Topic],
               on_lost: Optional[RebalancingCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/rowconsumer.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/rowconsumer.py#L115)
 
 Set subscription to supplied list of topics.
 
@@ -6286,7 +6280,7 @@ for example, may fail.
 def poll_row(timeout: float = None) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/rowconsumer.py#L149)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/rowconsumer.py#L149)
 
 Consumes a single message and deserialize it to Row or a list of Rows.
 

--- a/docs/api-reference/topics-serdes.md
+++ b/docs/api-reference/topics-serdes.md
@@ -10,7 +10,7 @@
 class Topic()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/topics.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/topics.py#L64)
 
 A representation of a Kafka topic and its expected data format via
 designated key and value serializers/deserializers.
@@ -35,7 +35,7 @@ def __init__(
         timestamp_extractor: Optional[TimestampExtractor] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/topics.py#L74)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/topics.py#L74)
 
 Can specify serialization that should be used when consuming/producing
 
@@ -99,7 +99,7 @@ topic = Topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/topics.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/topics.py#L135)
 
 Topic name
 
@@ -113,7 +113,7 @@ Topic name
 def row_serialize(row: Row, key: Optional[Any] = None) -> KafkaMessage
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/topics.py#L141)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/topics.py#L141)
 
 Serialize Row to a Kafka message structure
 
@@ -141,7 +141,7 @@ def row_deserialize(
         message: ConfluentKafkaMessageProto) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/topics.py#L164)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/topics.py#L164)
 
 Deserialize incoming Kafka message to a Row.
 
@@ -169,7 +169,7 @@ Row, list of Rows or None if the message is ignored.
 class QuixDeserializer(JSONDeserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L70)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L70)
 
 Handles Deserialization for any Quix-formatted topic.
 
@@ -186,7 +186,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L77)
 
 
 <br>
@@ -208,7 +208,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L97)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L97)
 
 Each Quix message might contain data for multiple Rows.
 This property informs the downstream processors about that, so they can
@@ -225,7 +225,7 @@ def deserialize(model_key: str, value: Union[List[Mapping],
                                              Mapping]) -> Iterable[Mapping]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L150)
 
 Deserialization function for particular data types (Timeseries or EventData).
 
@@ -250,7 +250,7 @@ Iterable of dicts
 class QuixTimeseriesSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L315)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L315)
 
 Serialize data to JSON formatted according to Quix Timeseries format.
 
@@ -282,7 +282,7 @@ Output:
 class QuixEventsSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/quix.py#L403)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/quix.py#L403)
 
 Serialize data to JSON formatted according to Quix EventData format.
 The input value is expected to be a dictionary with the following keys:
@@ -323,7 +323,7 @@ Output:
 class BytesDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L44)
 
 A deserializer to bypass bytes without any changes
 
@@ -335,7 +335,7 @@ A deserializer to bypass bytes without any changes
 class BytesSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L55)
 
 A serializer to bypass bytes without any changes
 
@@ -347,7 +347,7 @@ A serializer to bypass bytes without any changes
 class StringDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L64)
 
 <a id="quixstreams.models.serializers.simple_types.StringDeserializer.__init__"></a>
 
@@ -359,7 +359,7 @@ class StringDeserializer(Deserializer)
 def __init__(column_name: Optional[str] = None, codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L65)
 
 Deserializes bytes to strings using the specified encoding.
 
@@ -378,7 +378,7 @@ A wrapper around `confluent_kafka.serialization.StringDeserializer`.
 class IntegerDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L84)
 
 Deserializes bytes to integers.
 
@@ -392,7 +392,7 @@ A wrapper around `confluent_kafka.serialization.IntegerDeserializer`.
 class DoubleDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L103)
 
 Deserializes float to IEEE 764 binary64.
 
@@ -406,7 +406,7 @@ A wrapper around `confluent_kafka.serialization.DoubleDeserializer`.
 class StringSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L122)
 
 <a id="quixstreams.models.serializers.simple_types.StringSerializer.__init__"></a>
 
@@ -418,7 +418,7 @@ class StringSerializer(Serializer)
 def __init__(codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L123)
 
 Serializes strings to bytes using the specified encoding.
 
@@ -436,7 +436,7 @@ Serializes strings to bytes using the specified encoding.
 class IntegerSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L135)
 
 Serializes integers to bytes
 
@@ -448,7 +448,7 @@ Serializes integers to bytes
 class DoubleSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/5ea02f7558e6dd73d58eb673f71bad48aaf23282/quixstreams/models/serializers/simple_types.py#L148)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/d487ba232924184a06a29208a62f151af810708a/quixstreams/models/serializers/simple_types.py#L148)
 
 Serializes floats to bytes
 

--- a/quixstreams/state/rocksdb/options.py
+++ b/quixstreams/state/rocksdb/options.py
@@ -24,12 +24,15 @@ COMPRESSION_TYPES: Mapping[CompressionType, DBCompressionType] = {
 @dataclasses.dataclass(frozen=True)
 class RocksDBOptions(RocksDBOptionsType):
     """
-    Common RocksDB database options.
+    RocksDB database options.
 
-    Please see `rocksdict.Options` for a complete description of each option.
+    :param dumps: function to dump data to JSON
+    :param loads: function to load data from JSON
+    :param open_max_retries: number of times to retry opening the database
+            if it's locked by another process. To disable retrying, pass 0
+    :param open_retry_backoff: number of seconds to wait between each retry.
 
-    To provide extra options that are not presented in this class, feel free
-    to override it and specify the additional values.
+    Please see `rocksdict.Options` for a complete description of other options.
     """
 
     write_buffer_size: int = 64 * 1024 * 1024  # 64MB
@@ -42,6 +45,8 @@ class RocksDBOptions(RocksDBOptionsType):
     db_log_dir: Optional[str] = None
     dumps: DumpsFunc = dumps
     loads: LoadsFunc = loads
+    open_max_retries: int = 10
+    open_retry_backoff: float = 3.0
 
     def to_options(self) -> rocksdict.Options:
         """

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -54,29 +54,24 @@ class RocksDBStorePartition(StorePartition):
      3. Flushing WriteBatches to the RocksDB
 
     It opens the RocksDB on `__init__`. If the db is locked by another process,
-    it will retry according to `open_max_retries` and `open_retry_backoff`.
+    it will retry according to `open_max_retries` and `open_retry_backoff` options.
 
     :param path: an absolute path to the RocksDB folder
     :param options: RocksDB options. If `None`, the default options will be used.
-    :param open_max_retries: number of times to retry opening the database
-        if it's locked by another process. To disable retrying, pass 0.
-    :param open_retry_backoff: number of seconds to wait between each retry.
     """
 
     def __init__(
         self,
         path: str,
         options: Optional[RocksDBOptionsType] = None,
-        open_max_retries: int = 10,
-        open_retry_backoff: float = 3.0,
     ):
         self._path = path
         self._options = options or RocksDBOptions()
         self._rocksdb_options = self._options.to_options()
         self._dumps = self._options.dumps
         self._loads = self._options.loads
-        self._open_max_retries = open_max_retries
-        self._open_retry_backoff = open_retry_backoff
+        self._open_max_retries = self._options.open_max_retries
+        self._open_retry_backoff = self._options.open_retry_backoff
         self._db = self._init_rocksdb()
         self._cf_cache = {}
         self._cf_handle_cache = {}
@@ -266,7 +261,7 @@ class RocksDBStorePartition(StorePartition):
                 )
                 return db
             except Exception as exc:
-                is_locked = str(exc).lower().startswith("io error: lock")
+                is_locked = str(exc).lower().startswith("io error")
                 if not is_locked:
                     raise
 

--- a/quixstreams/state/rocksdb/store.py
+++ b/quixstreams/state/rocksdb/store.py
@@ -22,8 +22,6 @@ class RocksDBStore(Store):
         topic: str,
         base_dir: str,
         options: Optional[RocksDBOptionsType] = None,
-        open_max_retries: int = 10,
-        open_retry_backoff: float = 3.0,
     ):
         """
         RocksDB-based state store.
@@ -35,9 +33,6 @@ class RocksDBStore(Store):
         :param topic: a topic name for this store
         :param base_dir: path to a directory with the state
         :param options: RocksDB options. If `None`, the default options will be used.
-        :param open_max_retries: number of times to retry opening the database
-            if it's locked by another process. To disable retrying, pass 0.
-        :param open_retry_backoff: number of seconds to wait between each retry.
         """
         self._name = name
         self._topic = topic
@@ -45,8 +40,6 @@ class RocksDBStore(Store):
         self._transactions: Dict[int, RocksDBPartitionTransaction] = {}
         self._partitions: Dict[int, RocksDBStorePartition] = {}
         self._options = options
-        self._open_max_retries = open_max_retries
-        self._open_retry_backoff = open_retry_backoff
 
     @property
     def topic(self) -> str:
@@ -70,12 +63,7 @@ class RocksDBStore(Store):
         return self._partitions
 
     def create_new_partition(self, path: str) -> RocksDBStorePartition:
-        return RocksDBStorePartition(
-            path=path,
-            options=self._options,
-            open_max_retries=self._open_max_retries,
-            open_retry_backoff=self._open_retry_backoff,
-        )
+        return RocksDBStorePartition(path=path, options=self._options)
 
     def assign_partition(self, partition: int) -> RocksDBStorePartition:
         """

--- a/quixstreams/state/rocksdb/types.py
+++ b/quixstreams/state/rocksdb/types.py
@@ -18,6 +18,8 @@ class RocksDBOptionsType(Protocol):
     db_log_dir: Optional[str]
     dumps: DumpsFunc
     loads: LoadsFunc
+    open_max_retries: int
+    open_retry_backoff: float
 
     def to_options(self) -> rocksdict.Options:
         ...

--- a/quixstreams/state/rocksdb/windowed/partition.py
+++ b/quixstreams/state/rocksdb/windowed/partition.py
@@ -28,24 +28,14 @@ class WindowedRocksDBStorePartition(RocksDBStorePartition):
 
     :param path: an absolute path to the RocksDB folder
     :param options: RocksDB options. If `None`, the default options will be used.
-    :param open_max_retries: number of times to retry opening the database
-        if it's locked by another process. To disable retrying, pass 0.
-    :param open_retry_backoff: number of seconds to wait between each retry.
     """
 
     def __init__(
         self,
         path: str,
         options: Optional[RocksDBOptionsType] = None,
-        open_max_retries: int = 10,
-        open_retry_backoff: float = 3.0,
     ):
-        super().__init__(
-            path=path,
-            options=options,
-            open_max_retries=open_max_retries,
-            open_retry_backoff=open_retry_backoff,
-        )
+        super().__init__(path=path, options=options)
         self._latest_timestamp_ms = self._get_latest_timestamp_from_db()
         self._expiration_index_cf_name = f"__expiration-index__"
         self._ensure_column_family(self._expiration_index_cf_name)

--- a/quixstreams/state/rocksdb/windowed/store.py
+++ b/quixstreams/state/rocksdb/windowed/store.py
@@ -13,24 +13,18 @@ class WindowedRocksDBStore(RocksDBStore):
         topic: str,
         base_dir: str,
         options: Optional[RocksDBOptionsType] = None,
-        open_max_retries: int = 10,
-        open_retry_backoff: float = 3.0,
     ):
         super().__init__(
             name=name,
             topic=topic,
             base_dir=base_dir,
             options=options,
-            open_max_retries=open_max_retries,
-            open_retry_backoff=open_retry_backoff,
         )
 
     def create_new_partition(self, path: str) -> WindowedRocksDBStorePartition:
         db_partition = WindowedRocksDBStorePartition(
             path=path,
             options=self._options,
-            open_max_retries=self._open_max_retries,
-            open_retry_backoff=self._open_retry_backoff,
         )
         return db_partition
 

--- a/tests/test_quixstreams/test_state/test_rocksdb/fixtures.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/fixtures.py
@@ -13,15 +13,12 @@ def rocksdb_partition_factory(tmp_path):
     def factory(
         name: str = "db",
         options: Optional[RocksDBOptions] = None,
-        open_max_retries: int = 0,
-        open_retry_backoff: float = 3.0,
     ) -> RocksDBStorePartition:
         path = (tmp_path / name).as_posix()
+        _options = options or RocksDBOptions(open_max_retries=0, open_retry_backoff=3.0)
         return RocksDBStorePartition(
             path,
-            options=options,
-            open_max_retries=open_max_retries,
-            open_retry_backoff=open_retry_backoff,
+            options=_options,
         )
 
     return factory

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_partition.py
@@ -61,7 +61,9 @@ class TestRocksDBStorePartition:
 
         executor.submit(_close_db)
 
-        rocksdb_partition_factory("db", open_max_retries=10, open_retry_backoff=1)
+        rocksdb_partition_factory(
+            "db", options=RocksDBOptions(open_max_retries=10, open_retry_backoff=1)
+        )
 
     def test_open_db_locked_no_retries_fails(self, rocksdb_partition_factory, executor):
         _ = rocksdb_partition_factory("db")

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_partition.py
@@ -65,6 +65,21 @@ class TestRocksDBStorePartition:
             "db", options=RocksDBOptions(open_max_retries=10, open_retry_backoff=1)
         )
 
+    def test_open_io_error_retries(self, rocksdb_partition_factory, executor):
+        err = Exception("io error")
+        patcher = patch.object(Rdict, "__init__", side_effect=err)
+        patcher.start()
+
+        def _close_db():
+            time.sleep(3)
+            patcher.stop()
+
+        executor.submit(_close_db)
+
+        rocksdb_partition_factory(
+            "db", options=RocksDBOptions(open_max_retries=10, open_retry_backoff=1)
+        )
+
     def test_open_db_locked_no_retries_fails(self, rocksdb_partition_factory, executor):
         _ = rocksdb_partition_factory("db")
 

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_partition.py
@@ -70,11 +70,11 @@ class TestRocksDBStorePartition:
         patcher = patch.object(Rdict, "__init__", side_effect=err)
         patcher.start()
 
-        def _close_db():
+        def _stop_raising_on_db_open():
             time.sleep(3)
             patcher.stop()
 
-        executor.submit(_close_db)
+        executor.submit(_stop_raising_on_db_open)
 
         rocksdb_partition_factory(
             "db", options=RocksDBOptions(open_max_retries=10, open_retry_backoff=1)

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_partition.py
@@ -69,7 +69,7 @@ class TestRocksDBStorePartition:
         _ = rocksdb_partition_factory("db")
 
         with pytest.raises(Exception):
-            rocksdb_partition_factory("db", open_max_retries=0)
+            rocksdb_partition_factory("db", options=RocksDBOptions(open_max_retries=0))
 
     def test_open_db_locked_retries_exhausted_fails(
         self, rocksdb_partition_factory, executor
@@ -77,7 +77,9 @@ class TestRocksDBStorePartition:
         _ = rocksdb_partition_factory("db")
 
         with pytest.raises(Exception):
-            rocksdb_partition_factory("db", open_max_retries=3, open_retry_backoff=1)
+            rocksdb_partition_factory(
+                "db", options=RocksDBOptions(open_max_retries=3, open_retry_backoff=1)
+            )
 
     def test_open_arbitrary_exception_fails(self, rocksdb_partition_factory):
         err = Exception("some exception")


### PR DESCRIPTION
### Problem
RocksDBStorePartition is supposed to retry opening the RocksDB instance if it's locked by another consumer.
E.g. when a consumer is kicked out of the group and still holds the state partition, another consumer will get this partition assigned and try to open the same DB.

Currently, it works only if you try to open the DB in the same process.
When another process is trying to open the same DB, it will fail with an exception without any retry.

### Solution
- Retry opening db on any error starting with "io error".
- Surface `open_max_retries` and `open_retry_backoff` to RocksDBOptions object so they are configurable by users on the Application level.