### PR TITLE
Don't set `ssl.endpoint.identification.algorithm` by default for Quix apps

### DIFF
--- a/quixstreams/platforms/quix/config.py
+++ b/quixstreams/platforms/quix/config.py
@@ -475,7 +475,6 @@ class QuixKafkaConfigsBuilder:
                 param_value = _QUIX_SASL_MECHANISM_MAP[param_value]
             cfg_out[rdkafka_param_name] = param_value
 
-        cfg_out["ssl.endpoint.identification.algorithm"] = "none"
         # Specify SSL certificate if it's provided for the broker
         ssl_cert_path = self._set_workspace_cert()
         if ssl_cert_path is not None:

--- a/tests/test_quixstreams/test_app.py
+++ b/tests/test_quixstreams/test_app.py
@@ -426,7 +426,6 @@ class TestQuixApplication:
                 "sasl.username": "my-username",
                 "sasl.password": "my-password",
                 "ssl.ca.location": "/mock/dir/ca.cert",
-                "ssl.endpoint.identification.algorithm": "none",
             }
 
         cfg_builder = create_autospec(QuixKafkaConfigsBuilder)

--- a/tests/test_quixstreams/test_platforms/test_quix/test_config.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/test_config.py
@@ -440,7 +440,6 @@ class TestQuixKafkaConfigsBuilder:
             "sasl.username": "my-username",
             "sasl.password": "my-password",
             "ssl.ca.location": "/mock/dir/ca.cert",
-            "ssl.endpoint.identification.algorithm": "none",
             "connections.max.idle.ms": QUIX_CONNECTIONS_MAX_IDLE_MS,
             "metadata.max.age.ms": QUIX_METADATA_MAX_AGE_MS,
         }


### PR DESCRIPTION
Remove the line setting `ssl.endpoint.identification.algorithm` to "none" as its not required anymore and it could potentially reduce the security