### PR TITLE
Make env variable `Quix__Portal__Api` Optional

### DIFF
--- a/docs/api-reference/application.md
+++ b/docs/api-reference/application.md
@@ -10,7 +10,7 @@
 class Application()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L52)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L52)
 
 The main Application class.
 
@@ -80,7 +80,7 @@ def __init__(broker_address: str,
              topic_manager: Optional[TopicManager] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L91)
 
 
 <br>
@@ -161,7 +161,7 @@ def Quix(cls,
          topic_manager: Optional[QuixTopicManager] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L228)
 
 Initialize an Application to work with Quix platform,
 
@@ -273,7 +273,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L386)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L386)
 
 Create a topic definition.
 
@@ -354,7 +354,7 @@ topic = app.topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def dataframe(topic: Topic) -> StreamingDataFrame
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L466)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L466)
 
 A simple helper method that generates a `StreamingDataFrame`, which is used
 
@@ -404,7 +404,7 @@ to be used as an input topic.
 def stop()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L502)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L502)
 
 Stop the internal poll loop and the message processing.
 
@@ -424,7 +424,7 @@ To otherwise stop an application, either send a `SIGTERM` to the process
 def get_producer() -> Producer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L516)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L516)
 
 Create and return a pre-configured Producer instance.
 The Producer is initialized with params passed to Application.
@@ -459,7 +459,7 @@ with app.get_producer() as producer:
 def get_consumer() -> Consumer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L547)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L547)
 
 Create and return a pre-configured Consumer instance.
 The Consumer is initialized with params passed to Application.
@@ -504,7 +504,7 @@ with app.get_consumer() as consumer:
 def clear_state()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L591)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L591)
 
 Clear the state of the application.
 
@@ -518,7 +518,7 @@ Clear the state of the application.
 def run(dataframe: StreamingDataFrame)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L670)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L670)
 
 Start processing data from Kafka using provided `StreamingDataFrame`
 
@@ -562,7 +562,7 @@ app.run(dataframe=df)
 class State(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L149)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L149)
 
 Primary interface for working with key-value state data from `StreamingDataFrame`
 
@@ -576,7 +576,7 @@ Primary interface for working with key-value state data from `StreamingDataFrame
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L154)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L154)
 
 Get the value for key if key is present in the state, else default
 
@@ -603,7 +603,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L163)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L163)
 
 Set value for the key.
 
@@ -624,7 +624,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L170)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L170)
 
 Delete value for the key.
 
@@ -646,7 +646,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L178)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L178)
 
 Check if the key exists in state.
 

--- a/docs/api-reference/dataframe.md
+++ b/docs/api-reference/dataframe.md
@@ -10,7 +10,7 @@
 class StreamingDataFrame(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L29)
 
 `StreamingDataFrame` is the main object you will use for ETL work.
 
@@ -74,7 +74,7 @@ def apply(func: Union[DataFrameFunc, DataFrameStatefulFunc],
           expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L99)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L99)
 
 Apply a function to transform the value and return a new value.
 
@@ -122,7 +122,7 @@ def update(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L142)
 
 Apply a function to mutate value in-place or to perform a side effect
 
@@ -170,7 +170,7 @@ def filter(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L181)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L181)
 
 Filter value using provided function.
 
@@ -218,7 +218,7 @@ of type `State` to perform stateful operations.
 def contains(key: str) -> StreamingSeries
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L234)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L234)
 
 Check if the key is present in the Row value.
 
@@ -258,7 +258,7 @@ def to_topic(topic: Topic,
              key: Optional[Callable[[object], object]] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L257)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L257)
 
 Produce current value to a topic. You can optionally specify a new key.
 
@@ -306,7 +306,7 @@ By default, the current message key will be used.
 def compose() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L296)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L296)
 
 Compose all functions of this StreamingDataFrame into one big closure.
 
@@ -349,7 +349,7 @@ and returns a result of StreamingDataFrame
 def test(value: object, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L326)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L326)
 
 A shorthand to test `StreamingDataFrame` with provided value
 
@@ -383,7 +383,7 @@ def tumbling_window(duration_ms: Union[int, timedelta],
                     name: Optional[str] = None) -> TumblingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L344)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L344)
 
 Create a tumbling window transformation on this StreamingDataFrame.
 
@@ -461,7 +461,7 @@ def hopping_window(duration_ms: Union[int, timedelta],
                    name: Optional[str] = None) -> HoppingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L413)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L413)
 
 Create a hopping window transformation on this StreamingDataFrame.
 
@@ -552,7 +552,7 @@ like `sum`, `count`, etc. and applied to the StreamingDataFrame.
 class StreamingSeries(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L16)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L16)
 
 `StreamingSeries` are typically generated by `StreamingDataframes` when getting
 elements from, or performing certain operations on, a `StreamingDataframe`,
@@ -618,7 +618,7 @@ sdf = sdf[["column_a"] & (sdf["new_sum_field"] >= 10)]
 def from_func(cls, func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L76)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L76)
 
 Create a StreamingSeries from a function.
 
@@ -646,7 +646,7 @@ instance of `StreamingSeries`
 def apply(func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L90)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L90)
 
 Add a callable to the execution list for this series.
 
@@ -699,7 +699,7 @@ def compose(allow_filters: bool = True,
             allow_updates: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L124)
 
 Compose all functions of this StreamingSeries into one big closure.
 
@@ -759,7 +759,7 @@ and returns a result of `StreamingSeries`
 def test(value: Any, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L171)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L171)
 
 A shorthand to test `StreamingSeries` with provided value
 
@@ -791,7 +791,7 @@ result of `StreamingSeries`
 def isin(other: Container) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L202)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L202)
 
 Check if series value is in "other".
 
@@ -836,7 +836,7 @@ new StreamingSeries
 def contains(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L229)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L229)
 
 Check if series value contains "other"
 
@@ -881,7 +881,7 @@ new StreamingSeries
 def is_(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L254)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L254)
 
 Check if series value refers to the same object as `other`
 
@@ -923,7 +923,7 @@ new StreamingSeries
 def isnot(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L277)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L277)
 
 Check if series value does not refer to the same object as `other`
 
@@ -966,7 +966,7 @@ new StreamingSeries
 def isnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L301)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L301)
 
 Check if series value is None.
 
@@ -1003,7 +1003,7 @@ new StreamingSeries
 def notnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L324)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L324)
 
 Check if series value is not None.
 
@@ -1040,7 +1040,7 @@ new StreamingSeries
 def abs() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L347)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L347)
 
 Get absolute value of the series value.
 
@@ -1078,7 +1078,7 @@ new StreamingSeries
 def set_message_context(context: Optional[MessageContext])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L22)
 
 Set a MessageContext for the current message in the given `contextvars.Context`
 
@@ -1121,7 +1121,7 @@ sdf = sdf.update(lambda value: alter_context(value))
 def message_context() -> MessageContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L53)
 
 Get a MessageContext for the current message, which houses most of the message
 
@@ -1162,7 +1162,7 @@ instance of `MessageContext`
 def message_key() -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L84)
 
 Get the current message's key.
 

--- a/docs/api-reference/quix-platform-api.md
+++ b/docs/api-reference/quix-platform-api.md
@@ -10,7 +10,7 @@
 class QuixPortalApiService()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/api.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/api.py#L14)
 
 A light wrapper around the Quix Portal Api. If used in the Quix Platform, it will
 use that workspaces auth token and portal endpoint, else you must provide it.
@@ -34,7 +34,7 @@ def get_workspace_certificate(
         workspace_id: Optional[str] = None) -> Optional[bytes]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/api.py#L89)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/api.py#L89)
 
 Get a workspace TLS certificate if available.
 
@@ -65,7 +65,7 @@ certificate as bytes if present, or None
 class TopicCreationConfigs()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L51)
 
 <a id="quixstreams.platforms.quix.config.TopicCreationConfigs.name"></a>
 
@@ -85,7 +85,7 @@ Required when not created by a Quix App.
 def strip_workspace_id_prefix(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L60)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -114,7 +114,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L72)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L72)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -141,7 +141,7 @@ the string with workspace_id prepended
 class QuixKafkaConfigsBuilder()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L84)
 
 Retrieves all the necessary information from the Quix API and builds all the
 objects required to connect a confluent-kafka client to the Quix Platform.
@@ -167,7 +167,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
              workspace_cert_path: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L100)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L100)
 
 
 <br>
@@ -187,7 +187,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
 def strip_workspace_id_prefix(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L179)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L179)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -215,7 +215,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L189)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -244,7 +244,7 @@ def search_for_workspace(
         workspace_name_or_id: Optional[str] = None) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L199)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L199)
 
 Search for a workspace given an expected workspace name or id.
 
@@ -270,7 +270,7 @@ the workspace data dict if search success, else None
 def get_workspace_info(known_workspace_topic: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L222)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L222)
 
 Queries for workspace data from the Quix API, regardless of instance cache,
 
@@ -292,7 +292,7 @@ and updates instance attributes from query result.
 def search_workspace_for_topic(workspace_id: str, topic: str) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L249)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L249)
 
 Search through all the topics in the given workspace id to see if there is a
 
@@ -321,7 +321,7 @@ the workspace_id if success, else None
 def search_for_topic_workspace(topic: str) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L265)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L265)
 
 Find what workspace a topic belongs to.
 
@@ -351,7 +351,7 @@ def get_workspace_ssl_cert(
         extract_to_folder: Optional[Path] = None) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L286)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L286)
 
 Gets and extracts zipped certificate from the API to provided folder if the
 
@@ -382,7 +382,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout_seconds: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L363)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L363)
 
 Create topics in a Quix cluster.
 
@@ -404,7 +404,7 @@ marked as "Ready" (and thus ready to produce to/consume from).
 def confirm_topics_exist(topics: Union[List[Topic], List[str]])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L412)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L412)
 
 Confirm whether the desired set of topics exists in the Quix workspace.
 
@@ -424,7 +424,7 @@ Confirm whether the desired set of topics exists in the Quix workspace.
 def get_confluent_broker_config(known_topic: Optional[str] = None) -> dict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L452)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L452)
 
 Get the full client config dictionary required to authenticate a confluent-kafka
 
@@ -459,7 +459,7 @@ def get_confluent_client_configs(
 ) -> Tuple[dict, List[str], Optional[str]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L498)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L498)
 
 Get all the values you need in order to use a confluent_kafka-based client
 
@@ -496,7 +496,7 @@ and consumer group name
 class QuixEnvironment()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L7)
 
 Class to access various Quix platform environment settings
 
@@ -511,7 +511,7 @@ Class to access various Quix platform environment settings
 def state_management_enabled() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L19)
 
 Check whether "State management" is enabled for the current deployment
 
@@ -532,7 +532,7 @@ True if state management is enabled, otherwise False
 def deployment_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L27)
 
 Return current Quix deployment id.
 
@@ -556,7 +556,7 @@ deployment id or None
 def workspace_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L39)
 
 Return Quix workspace id if set
 
@@ -577,7 +577,7 @@ workspace id or None
 def portal_api() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L47)
 
 Return Quix Portal API url if set
 
@@ -598,7 +598,7 @@ portal API URL or None
 def sdk_token() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L56)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L56)
 
 Return Quix SDK token if set
 
@@ -619,7 +619,7 @@ sdk token or None
 def state_dir() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L64)
 
 Return application state directory on Quix.
 

--- a/docs/api-reference/quixstreams.md
+++ b/docs/api-reference/quixstreams.md
@@ -14,7 +14,7 @@
 def configure_logging(loglevel: Optional[LogLevel]) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/logging.py#L24)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/logging.py#L24)
 
 Configure "quixstreams" logger.
 
@@ -52,7 +52,7 @@ True if logging config has been updated, otherwise False.
 class TopicCreationConfigs()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L51)
 
 <a id="quixstreams.platforms.quix.config.TopicCreationConfigs.name"></a>
 
@@ -68,7 +68,7 @@ Required when not created by a Quix App.
 def strip_workspace_id_prefix(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L60)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -91,7 +91,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L72)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L72)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -114,7 +114,7 @@ the string with workspace_id prepended
 class QuixKafkaConfigsBuilder()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L84)
 
 Retrieves all the necessary information from the Quix API and builds all the
 objects required to connect a confluent-kafka client to the Quix Platform.
@@ -138,7 +138,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
              workspace_cert_path: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L100)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L100)
 
 **Arguments**:
 
@@ -154,7 +154,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
 def strip_workspace_id_prefix(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L179)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L179)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -176,7 +176,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L189)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -199,7 +199,7 @@ def search_for_workspace(
         workspace_name_or_id: Optional[str] = None) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L199)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L199)
 
 Search for a workspace given an expected workspace name or id.
 
@@ -219,7 +219,7 @@ the workspace data dict if search success, else None
 def get_workspace_info(known_workspace_topic: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L222)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L222)
 
 Queries for workspace data from the Quix API, regardless of instance cache,
 
@@ -237,7 +237,7 @@ and updates instance attributes from query result.
 def search_workspace_for_topic(workspace_id: str, topic: str) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L249)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L249)
 
 Search through all the topics in the given workspace id to see if there is a
 
@@ -260,7 +260,7 @@ the workspace_id if success, else None
 def search_for_topic_workspace(topic: str) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L265)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L265)
 
 Find what workspace a topic belongs to.
 
@@ -284,7 +284,7 @@ def get_workspace_ssl_cert(
         extract_to_folder: Optional[Path] = None) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L286)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L286)
 
 Gets and extracts zipped certificate from the API to provided folder if the
 
@@ -309,7 +309,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout_seconds: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L363)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L363)
 
 Create topics in a Quix cluster.
 
@@ -327,7 +327,7 @@ marked as "Ready" (and thus ready to produce to/consume from).
 def confirm_topics_exist(topics: Union[List[Topic], List[str]])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L412)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L412)
 
 Confirm whether the desired set of topics exists in the Quix workspace.
 
@@ -343,7 +343,7 @@ Confirm whether the desired set of topics exists in the Quix workspace.
 def get_confluent_broker_config(known_topic: Optional[str] = None) -> dict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L452)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L452)
 
 Get the full client config dictionary required to authenticate a confluent-kafka
 
@@ -372,7 +372,7 @@ def get_confluent_client_configs(
 ) -> Tuple[dict, List[str], Optional[str]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L498)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L498)
 
 Get all the values you need in order to use a confluent_kafka-based client
 
@@ -405,7 +405,7 @@ and consumer group name
 class QuixEnvironment()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L7)
 
 Class to access various Quix platform environment settings
 
@@ -418,7 +418,7 @@ Class to access various Quix platform environment settings
 def state_management_enabled() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L19)
 
 Check whether "State management" is enabled for the current deployment
 
@@ -435,7 +435,7 @@ True if state management is enabled, otherwise False
 def deployment_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L27)
 
 Return current Quix deployment id.
 
@@ -455,7 +455,7 @@ deployment id or None
 def workspace_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L39)
 
 Return Quix workspace id if set
 
@@ -472,7 +472,7 @@ workspace id or None
 def portal_api() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L47)
 
 Return Quix Portal API url if set
 
@@ -489,7 +489,7 @@ portal API URL or None
 def sdk_token() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L56)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L56)
 
 Return Quix SDK token if set
 
@@ -506,7 +506,7 @@ sdk token or None
 def state_dir() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L64)
 
 Return application state directory on Quix.
 
@@ -526,7 +526,7 @@ path to state dir
 def check_state_management_enabled()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/checks.py#L11)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/checks.py#L11)
 
 Check if State Management feature is enabled for the current deployment on
 Quix platform.
@@ -540,7 +540,7 @@ If it's disabled, the exception will be raised.
 def check_state_dir(state_dir: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/checks.py#L28)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/checks.py#L28)
 
 Check if Application "state_dir" matches the state dir on Quix platform.
 
@@ -566,7 +566,7 @@ If it doesn't match, the warning will be logged.
 class QuixPortalApiService()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/api.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/api.py#L14)
 
 A light wrapper around the Quix Portal Api. If used in the Quix Platform, it will
 use that workspaces auth token and portal endpoint, else you must provide it.
@@ -588,7 +588,7 @@ def get_workspace_certificate(
         workspace_id: Optional[str] = None) -> Optional[bytes]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/api.py#L89)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/api.py#L89)
 
 Get a workspace TLS certificate if available.
 
@@ -614,7 +614,7 @@ certificate as bytes if present, or None
 class QuixTopicManager(TopicManager)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/topic_manager.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/topic_manager.py#L9)
 
 The source of all topic management with quixstreams.
 
@@ -636,7 +636,7 @@ def __init__(topic_admin: TopicAdmin,
              quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/topic_manager.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/topic_manager.py#L29)
 
 **Arguments**:
 
@@ -657,7 +657,7 @@ generated for you.
 class StreamingDataFrame(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L29)
 
 `StreamingDataFrame` is the main object you will use for ETL work.
 
@@ -713,7 +713,7 @@ def apply(func: Union[DataFrameFunc, DataFrameStatefulFunc],
           expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L99)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L99)
 
 Apply a function to transform the value and return a new value.
 
@@ -755,7 +755,7 @@ def update(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L142)
 
 Apply a function to mutate value in-place or to perform a side effect
 
@@ -797,7 +797,7 @@ def filter(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L181)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L181)
 
 Filter value using provided function.
 
@@ -839,7 +839,7 @@ of type `State` to perform stateful operations.
 def contains(key: str) -> StreamingSeries
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L234)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L234)
 
 Check if the key is present in the Row value.
 
@@ -871,7 +871,7 @@ def to_topic(topic: Topic,
              key: Optional[Callable[[object], object]] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L257)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L257)
 
 Produce current value to a topic. You can optionally specify a new key.
 
@@ -913,7 +913,7 @@ By default, the current message key will be used.
 def compose() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L296)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L296)
 
 Compose all functions of this StreamingDataFrame into one big closure.
 
@@ -950,7 +950,7 @@ and returns a result of StreamingDataFrame
 def test(value: object, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L326)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L326)
 
 A shorthand to test `StreamingDataFrame` with provided value
 
@@ -978,7 +978,7 @@ def tumbling_window(duration_ms: Union[int, timedelta],
                     name: Optional[str] = None) -> TumblingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L344)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L344)
 
 Create a tumbling window transformation on this StreamingDataFrame.
 
@@ -1048,7 +1048,7 @@ def hopping_window(duration_ms: Union[int, timedelta],
                    name: Optional[str] = None) -> HoppingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L413)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L413)
 
 Create a hopping window transformation on this StreamingDataFrame.
 
@@ -1131,7 +1131,7 @@ like `sum`, `count`, etc. and applied to the StreamingDataFrame.
 class StreamingSeries(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L16)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L16)
 
 `StreamingSeries` are typically generated by `StreamingDataframes` when getting
 elements from, or performing certain operations on, a `StreamingDataframe`,
@@ -1189,7 +1189,7 @@ sdf = sdf[["column_a"] & (sdf["new_sum_field"] >= 10)]
 def from_func(cls, func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L76)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L76)
 
 Create a StreamingSeries from a function.
 
@@ -1211,7 +1211,7 @@ instance of `StreamingSeries`
 def apply(func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L90)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L90)
 
 Add a callable to the execution list for this series.
 
@@ -1256,7 +1256,7 @@ def compose(allow_filters: bool = True,
             allow_updates: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L124)
 
 Compose all functions of this StreamingSeries into one big closure.
 
@@ -1308,7 +1308,7 @@ and returns a result of `StreamingSeries`
 def test(value: Any, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L171)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L171)
 
 A shorthand to test `StreamingSeries` with provided value
 
@@ -1334,7 +1334,7 @@ result of `StreamingSeries`
 def isin(other: Container) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L202)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L202)
 
 Check if series value is in "other".
 
@@ -1371,7 +1371,7 @@ new StreamingSeries
 def contains(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L229)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L229)
 
 Check if series value contains "other"
 
@@ -1408,7 +1408,7 @@ new StreamingSeries
 def is_(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L254)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L254)
 
 Check if series value refers to the same object as `other`
 
@@ -1442,7 +1442,7 @@ new StreamingSeries
 def isnot(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L277)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L277)
 
 Check if series value does not refer to the same object as `other`
 
@@ -1477,7 +1477,7 @@ new StreamingSeries
 def isnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L301)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L301)
 
 Check if series value is None.
 
@@ -1508,7 +1508,7 @@ new StreamingSeries
 def notnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L324)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L324)
 
 Check if series value is not None.
 
@@ -1539,7 +1539,7 @@ new StreamingSeries
 def abs() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L347)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L347)
 
 Get absolute value of the series value.
 
@@ -1575,7 +1575,7 @@ new StreamingSeries
 def ensure_milliseconds(delta: Union[int, timedelta]) -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/utils.py#L5)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/utils.py#L5)
 
 Convert timedelta to milliseconds.
 
@@ -1603,7 +1603,7 @@ timedelta value in milliseconds as `int`
 class FixedTimeWindowDefinition(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L20)
 
 <a id="quixstreams.dataframe.windows.definitions.FixedTimeWindowDefinition.sum"></a>
 
@@ -1613,7 +1613,7 @@ class FixedTimeWindowDefinition(abc.ABC)
 def sum() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L68)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L68)
 
 Configure the window to aggregate data by summing up values within
 
@@ -1631,7 +1631,7 @@ an instance of `FixedTimeWindow` configured to perform sum aggregation.
 def count() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L95)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L95)
 
 Configure the window to aggregate data by counting the number of values
 
@@ -1649,7 +1649,7 @@ an instance of `FixedTimeWindow` configured to perform record count.
 def mean() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L122)
 
 Configure the window to aggregate data by calculating the mean of the values
 
@@ -1669,7 +1669,7 @@ def reduce(reducer: Callable[[Any, Any], Any],
            initializer: Callable[[Any], Any]) -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L153)
 
 Configure the window to perform a custom aggregation using `reducer`
 
@@ -1718,7 +1718,7 @@ A window configured to perform custom reduce aggregation on the data.
 def max() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L213)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L213)
 
 Configure a window to aggregate the maximum value within each window period.
 
@@ -1735,7 +1735,7 @@ value within each window period.
 def min() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L242)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L242)
 
 Configure a window to aggregate the minimum value within each window period.
 
@@ -1760,7 +1760,7 @@ value within each window period.
 class FixedTimeWindow()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/time_based.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/time_based.py#L29)
 
 <a id="quixstreams.dataframe.windows.time_based.FixedTimeWindow.final"></a>
 
@@ -1770,7 +1770,7 @@ class FixedTimeWindow()
 def final(expand: bool = True) -> "StreamingDataFrame"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/time_based.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/time_based.py#L92)
 
 Apply the window aggregation and return results only when the windows are
 
@@ -1808,7 +1808,7 @@ Default - `True`
 def current(expand: bool = True) -> "StreamingDataFrame"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/time_based.py#L129)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/time_based.py#L129)
 
 Apply the window transformation to the StreamingDataFrame to return results
 
@@ -1846,7 +1846,7 @@ def get_window_ranges(timestamp_ms: int,
                       step_ms: Optional[int] = None) -> List[Tuple[int, int]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/base.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/base.py#L22)
 
 Get a list of window ranges for the given timestamp.
 
@@ -1876,7 +1876,7 @@ a list of (<start>, <end>) tuples
 class RowProducer(Producer, RowProducerProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowproducer.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowproducer.py#L25)
 
 A producer class that is capable of serializing Rows to bytes and send them to Kafka.
 
@@ -1914,7 +1914,7 @@ def produce_row(row: Row,
                 timestamp: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowproducer.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowproducer.py#L66)
 
 Serialize Row to bytes according to the Topic serialization settings
 
@@ -1938,7 +1938,7 @@ If this method fails, it will trigger the provided "on_error" callback.
 def poll(timeout: float = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowproducer.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowproducer.py#L103)
 
 Polls the producer for events and calls `on_delivery` callbacks.
 
@@ -1960,7 +1960,7 @@ If poll fails, it will trigger the provided "on_error" callback
 class StreamFunction(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L27)
 
 A base class for all the streaming operations in Quix Streams.
 
@@ -1978,7 +1978,7 @@ It provides two methods that return closures to be called on the input values:
 def func() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L44)
 
 The original function
 
@@ -1991,7 +1991,7 @@ The original function
 def get_executor() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L51)
 
 Returns a wrapper to be called on a single value.
 
@@ -2004,7 +2004,7 @@ Returns a wrapper to be called on a single value.
 def get_executor_expanded() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L57)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L57)
 
 Returns a wrapper to be called on a list of expanded values.
 
@@ -2016,7 +2016,7 @@ Returns a wrapper to be called on a list of expanded values.
 class ApplyFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L63)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L63)
 
 Wrap a function into "Apply" function.
 
@@ -2031,7 +2031,7 @@ and its result will always be passed downstream.
 class ApplyExpandFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L86)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L86)
 
 Wrap a function into "Apply" function and expand the returned iterable
 into separate values downstream.
@@ -2047,7 +2047,7 @@ If the returned value is not `Iterable`, `TypeError` will be raised.
 class FilterFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L115)
 
 Wraps a function into a "Filter" function.
 The result of a Filter function is interpreted as boolean.
@@ -2063,7 +2063,7 @@ value is filtered out.
 class UpdateFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L147)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L147)
 
 Wrap a function into an "Update" function.
 
@@ -2083,7 +2083,7 @@ def compose(functions: List[StreamFunction],
             allow_expands: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L176)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L176)
 
 Composes a list of functions and its parents into a single
 
@@ -2117,7 +2117,7 @@ def composer(outer_func: StreamCallable,
              inner_func: StreamCallable) -> Callable[[T], R]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L226)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L226)
 
 A function that wraps two other functions into a closure.
 
@@ -2143,7 +2143,7 @@ a function with one argument (value)
 class Stream()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L22)
 
 <a id="quixstreams.core.stream.stream.Stream.__init__"></a>
 
@@ -2154,7 +2154,7 @@ def __init__(func: Optional[StreamFunction] = None,
              parent: Optional[Self] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L23)
 
 A base class for all streaming operations.
 
@@ -2197,7 +2197,7 @@ Default - "Apply(lambda v: v)".
 def add_filter(func: Callable[[T], R]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L79)
 
 Add a function to filter values from the Stream.
 
@@ -2221,7 +2221,7 @@ a new `Stream` derived from the current one
 def add_apply(func: Callable[[T], R], expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L92)
 
 Add an "apply" function to the Stream.
 
@@ -2247,7 +2247,7 @@ a new `Stream` derived from the current one
 def add_update(func: Callable[[T], object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L109)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L109)
 
 Add an "update" function to the Stream, that will mutate the input value.
 
@@ -2270,7 +2270,7 @@ a new Stream derived from the current one
 def diff(other: "Stream") -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L121)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L121)
 
 Takes the difference between Streams `self` and `other` based on their last
 
@@ -2302,7 +2302,7 @@ new `Stream` instance including all the Streams from the diff
 def tree() -> List[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L150)
 
 Return a list of all parent Streams including the node itself.
 
@@ -2322,7 +2322,7 @@ def compose(allow_filters: bool = True,
             allow_expands: bool = True) -> Callable[[T], R]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L164)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L164)
 
 Compose a list of functions from this `Stream` and its parents into one
 
@@ -2364,7 +2364,7 @@ the stream has functions with "expand=True" in the tree. Default - True.
 def dict_values(d: object) -> List
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/utils/dicts.py#L4)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/utils/dicts.py#L4)
 
 Recursively unpacks a set of nested dicts to get a flattened list of leaves,
 
@@ -2392,7 +2392,7 @@ a list with all the leaves of the various contained dicts
 def dumps(value: Any) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/utils/json.py#L8)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/utils/json.py#L8)
 
 Serialize to JSON using `orjson` package.
 
@@ -2412,7 +2412,7 @@ bytes
 def loads(value: bytes) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/utils/json.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/utils/json.py#L18)
 
 Deserialize from JSON using `orjson` package.
 
@@ -2444,7 +2444,7 @@ object
 class TimestampType(enum.IntEnum)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/timestamps.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/timestamps.py#L9)
 
 <a id="quixstreams.models.timestamps.TimestampType.TIMESTAMP_NOT_AVAILABLE"></a>
 
@@ -2472,7 +2472,7 @@ broker receive time
 class MessageTimestamp()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/timestamps.py#L15)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/timestamps.py#L15)
 
 Represents a timestamp of incoming Kafka message.
 
@@ -2488,7 +2488,7 @@ it should not be mutated during message processing.
 def create(cls, timestamp_type: int, milliseconds: int) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/timestamps.py#L42)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/timestamps.py#L42)
 
 Create a Timestamp object based on data
 
@@ -2525,7 +2525,7 @@ Timestamp object
 class MessageContext()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/messagecontext.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/messagecontext.py#L7)
 
 An object with Kafka message properties.
 
@@ -2544,7 +2544,7 @@ it should not be mutated during message processing.
 class ConfluentKafkaMessageProto(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/types.py#L10)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/types.py#L10)
 
 An interface of `confluent_kafka.Message`.
 
@@ -2569,7 +2569,7 @@ see https://github.com/confluentinc/confluent-kafka-python/issues/1535.
 class IgnoreMessage(exceptions.QuixException)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/exceptions.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/exceptions.py#L51)
 
 Raise this exception from Deserializer.__call__ in order to ignore the processing
 of the particular message.
@@ -2586,7 +2586,7 @@ of the particular message.
 class QuixDeserializer(JSONDeserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L70)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L70)
 
 Handles Deserialization for any Quix-formatted topic.
 
@@ -2601,7 +2601,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L77)
 
 **Arguments**:
 
@@ -2619,7 +2619,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L97)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L97)
 
 Each Quix message might contain data for multiple Rows.
 This property informs the downstream processors about that, so they can
@@ -2634,7 +2634,7 @@ def deserialize(model_key: str, value: Union[List[Mapping],
                                              Mapping]) -> Iterable[Mapping]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L150)
 
 Deserialization function for particular data types (Timeseries or EventData).
 
@@ -2655,7 +2655,7 @@ Iterable of dicts
 class QuixSerializer(JSONSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L268)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L268)
 
 <a id="quixstreams.models.serializers.quix.QuixSerializer.__init__"></a>
 
@@ -2666,7 +2666,7 @@ def __init__(as_legacy: bool = True,
              dumps: Callable[[Any], Union[str, bytes]] = default_dumps)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L272)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L272)
 
 Serializer that returns data in json format.
 
@@ -2684,7 +2684,7 @@ Default - :py:func:`quixstreams.utils.json.dumps`
 class QuixTimeseriesSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L315)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L315)
 
 Serialize data to JSON formatted according to Quix Timeseries format.
 
@@ -2716,7 +2716,7 @@ Output:
 class QuixEventsSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L403)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L403)
 
 Serialize data to JSON formatted according to Quix EventData format.
 The input value is expected to be a dictionary with the following keys:
@@ -2757,7 +2757,7 @@ Output:
 class BytesDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L44)
 
 A deserializer to bypass bytes without any changes
 
@@ -2769,7 +2769,7 @@ A deserializer to bypass bytes without any changes
 class BytesSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L55)
 
 A serializer to bypass bytes without any changes
 
@@ -2781,7 +2781,7 @@ A serializer to bypass bytes without any changes
 class StringDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L64)
 
 <a id="quixstreams.models.serializers.simple_types.StringDeserializer.__init__"></a>
 
@@ -2791,7 +2791,7 @@ class StringDeserializer(Deserializer)
 def __init__(column_name: Optional[str] = None, codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L65)
 
 Deserializes bytes to strings using the specified encoding.
 
@@ -2808,7 +2808,7 @@ A wrapper around `confluent_kafka.serialization.StringDeserializer`.
 class IntegerDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L84)
 
 Deserializes bytes to integers.
 
@@ -2822,7 +2822,7 @@ A wrapper around `confluent_kafka.serialization.IntegerDeserializer`.
 class DoubleDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L103)
 
 Deserializes float to IEEE 764 binary64.
 
@@ -2836,7 +2836,7 @@ A wrapper around `confluent_kafka.serialization.DoubleDeserializer`.
 class StringSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L122)
 
 <a id="quixstreams.models.serializers.simple_types.StringSerializer.__init__"></a>
 
@@ -2846,7 +2846,7 @@ class StringSerializer(Serializer)
 def __init__(codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L123)
 
 Serializes strings to bytes using the specified encoding.
 
@@ -2862,7 +2862,7 @@ Serializes strings to bytes using the specified encoding.
 class IntegerSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L135)
 
 Serializes integers to bytes
 
@@ -2874,7 +2874,7 @@ Serializes integers to bytes
 class DoubleSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L148)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L148)
 
 Serializes floats to bytes
 
@@ -2890,7 +2890,7 @@ Serializes floats to bytes
 class JSONSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/json.py#L13)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/json.py#L13)
 
 <a id="quixstreams.models.serializers.json.JSONSerializer.__init__"></a>
 
@@ -2900,7 +2900,7 @@ class JSONSerializer(Serializer)
 def __init__(dumps: Callable[[Any], Union[str, bytes]] = default_dumps)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/json.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/json.py#L14)
 
 Serializer that returns data in json format.
 
@@ -2917,7 +2917,7 @@ Default - :py:func:`quixstreams.utils.json.dumps`
 class JSONDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/json.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/json.py#L35)
 
 <a id="quixstreams.models.serializers.json.JSONDeserializer.__init__"></a>
 
@@ -2928,7 +2928,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/json.py#L36)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/json.py#L36)
 
 Deserializer that parses data from JSON
 
@@ -2951,7 +2951,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 class SerializationContext()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L22)
 
 Provides additional context for message serialization/deserialization.
 
@@ -2965,7 +2965,7 @@ Every `Serializer` and `Deserializer` receives an instance of `SerializationCont
 def to_confluent_ctx(field: MessageField) -> _SerializationContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L35)
 
 Convert `SerializationContext` to `confluent_kafka.SerializationContext`
 
@@ -2987,7 +2987,7 @@ instance of `confluent_kafka.serialization.SerializationContext`
 class Deserializer(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L47)
 
 <a id="quixstreams.models.serializers.base.Deserializer.__init__"></a>
 
@@ -2997,7 +2997,7 @@ class Deserializer(abc.ABC)
 def __init__(column_name: Optional[str] = None, *args, **kwargs)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L48)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L48)
 
 A base class for all Deserializers
 
@@ -3015,7 +3015,7 @@ dictionary with `column_name` as a key.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L58)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L58)
 
 Return True if the deserialized message should be considered as Iterable
 and each item in it should be processed as a separate message.
@@ -3028,7 +3028,7 @@ and each item in it should be processed as a separate message.
 class Serializer(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L75)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L75)
 
 A base class for all Serializers
 
@@ -3041,7 +3041,7 @@ A base class for all Serializers
 def extra_headers() -> MessageHeadersMapping
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L81)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L81)
 
 Informs producer to set additional headers
 
@@ -3070,7 +3070,7 @@ dict with headers
 class Row()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/rows.py#L11)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/rows.py#L11)
 
 Row is a dict-like interface on top of the message data + some Kafka props
 
@@ -3082,7 +3082,7 @@ Row is a dict-like interface on top of the message data + some Kafka props
 def keys() -> KeysView
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/rows.py#L73)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/rows.py#L73)
 
 Also allows unpacking row.value via **row
 
@@ -3094,7 +3094,7 @@ Also allows unpacking row.value via **row
 def clone(value: dict) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/rows.py#L85)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/rows.py#L85)
 
 Manually clone the Row; doing it this way is much faster than doing a deepcopy
 on the entire Row object.
@@ -3115,7 +3115,7 @@ on the entire Row object.
 def convert_topic_list(topics: List[Topic]) -> List[ConfluentTopic]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L23)
 
 Converts `Topic`s to `ConfluentTopic`s as required for Confluent's
 
@@ -3137,7 +3137,7 @@ list of confluent_kafka `ConfluentTopic`s
 class TopicAdmin()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L46)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L46)
 
 For performing "admin"-level operations on a Kafka cluster, mostly around topics.
 
@@ -3151,7 +3151,7 @@ Primarily used to create and inspect topic configurations.
 def __init__(broker_address: str, extra_config: Optional[Mapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L53)
 
 **Arguments**:
 
@@ -3166,7 +3166,7 @@ def __init__(broker_address: str, extra_config: Optional[Mapping] = None)
 def list_topics() -> Dict[str, ConfluentTopicMetadata]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L74)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L74)
 
 Get a list of topics and their metadata from a Kafka cluster
 
@@ -3182,7 +3182,7 @@ a dict of topic names and their metadata objects
 def inspect_topics(topic_names: List[str]) -> Dict[str, Optional[TopicConfig]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L83)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L83)
 
 A simplified way of getting the topic configurations of the provided topics
 
@@ -3206,7 +3206,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout: int = 60)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L152)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L152)
 
 Create the given list of topics and confirm they are ready.
 
@@ -3232,7 +3232,7 @@ fail (it ignores issues for a topic already existing).
 class TopicConfig()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L42)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L42)
 
 Represents all kafka-level configuration for a kafka topic.
 
@@ -3246,7 +3246,7 @@ Generally used by Topic and any topic creation procedures.
 class Topic()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L81)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L81)
 
 A representation of a Kafka topic and its expected data format via
 designated key and value serializers/deserializers.
@@ -3270,7 +3270,7 @@ def __init__(
         timestamp_extractor: Optional[TimestampExtractor] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L91)
 
 Can specify serialization that should be used when consuming/producing
 
@@ -3327,7 +3327,7 @@ topic = Topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L155)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L155)
 
 Topic name
 
@@ -3339,7 +3339,7 @@ Topic name
 def row_serialize(row: Row, key: Optional[Any] = None) -> KafkaMessage
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L165)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L165)
 
 Serialize Row to a Kafka message structure
 
@@ -3361,7 +3361,7 @@ def row_deserialize(
         message: ConfluentKafkaMessageProto) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L188)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L188)
 
 Deserialize incoming Kafka message to a Row.
 
@@ -3389,7 +3389,7 @@ Row, list of Rows or None if the message is ignored.
 def affirm_ready_for_create(topics: List[Topic])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L19)
 
 Validate a list of topics is ready for creation attempt
 
@@ -3405,7 +3405,7 @@ Validate a list of topics is ready for creation attempt
 class TopicManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L29)
 
 The source of all topic management with quixstreams.
 
@@ -3423,7 +3423,7 @@ See methods for details.
 def __init__(topic_admin: TopicAdmin, create_timeout: int = 60)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L48)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L48)
 
 **Arguments**:
 
@@ -3439,7 +3439,7 @@ def __init__(topic_admin: TopicAdmin, create_timeout: int = 60)
 def changelog_topics() -> Dict[str, Dict[str, Topic]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L71)
 
 Note: `Topic`s are the changelogs.
 
@@ -3455,7 +3455,7 @@ def topic_config(num_partitions: Optional[int] = None,
                  extra_config: Optional[dict] = None) -> TopicConfig
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L121)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L121)
 
 Convenience method for generating a `TopicConfig` with default settings
 
@@ -3483,7 +3483,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L142)
 
 A convenience method for generating a `Topic`. Will use default config options
 
@@ -3513,7 +3513,7 @@ def changelog_topic(topic_name: str, store_name: str,
                     consumer_group: str) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L191)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L191)
 
 Performs all the logic necessary to generate a changelog topic based on a
 
@@ -3552,7 +3552,7 @@ generate changelog topics. To turn off changelogs, init an Application with
 def create_topics(topics: List[Topic])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L262)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L262)
 
 Creates topics via an explicit list of provided `Topics`.
 
@@ -3571,7 +3571,7 @@ Exists as a way to manually specify what topics to create; otherwise,
 def create_all_topics()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L277)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L277)
 
 A convenience method to create all Topic objects stored on this TopicManager.
 
@@ -3583,7 +3583,7 @@ A convenience method to create all Topic objects stored on this TopicManager.
 def validate_all_topics()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L283)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L283)
 
 Validates all topics exist and changelogs have correct topic and rep factor.
 
@@ -3601,7 +3601,7 @@ Issues are pooled and raised as an Exception once inspections are complete.
 class WindowedRocksDBStore(RocksDBStore)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/store.py#L10)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/store.py#L10)
 
 RocksDB-based windowed state store.
 
@@ -3621,7 +3621,7 @@ def __init__(
         options: Optional[RocksDBOptionsType] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/store.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/store.py#L18)
 
 **Arguments**:
 
@@ -3644,7 +3644,7 @@ if using changelogs
 class WindowedRocksDBStorePartition(RocksDBStorePartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/partition.py#L24)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/partition.py#L24)
 
 A base class to access windowed state in RocksDB.
 
@@ -3674,7 +3674,7 @@ stores the expiration index to delete expired windows.
 class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/transaction.py#L21)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/transaction.py#L21)
 
 <a id="quixstreams.state.rocksdb.windowed.transaction.WindowedRocksDBPartitionTransaction.expire_windows"></a>
 
@@ -3685,7 +3685,7 @@ def expire_windows(duration_ms: int,
                    grace_ms: int = 0) -> List[Tuple[Tuple[int, int], Any]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/transaction.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/transaction.py#L79)
 
 Get a list of expired windows from RocksDB considering latest timestamp,
 
@@ -3723,7 +3723,7 @@ sorted list of tuples in format `((start, end), value)`
 def parse_window_key(key: bytes) -> Tuple[bytes, int, int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/serialization.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/serialization.py#L12)
 
 Parse the window key from Rocksdb into (message_key, start, end) structure.
 
@@ -3746,7 +3746,7 @@ a tuple with message key, start timestamp, end timestamp
 def encode_window_key(start_ms: int, end_ms: int) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/serialization.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/serialization.py#L39)
 
 Encode window start and end timestamps into bytes of the following format:
 
@@ -3771,7 +3771,7 @@ window timestamps as bytes
 def encode_window_prefix(prefix: bytes, start_ms: int) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/serialization.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/serialization.py#L53)
 
 Encode window prefix and start time to iterate over keys in RocksDB
 
@@ -3799,7 +3799,7 @@ bytes
 class WindowedTransactionState(WindowedState)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L9)
 
 <a id="quixstreams.state.rocksdb.windowed.state.WindowedTransactionState.__init__"></a>
 
@@ -3809,7 +3809,7 @@ class WindowedTransactionState(WindowedState)
 def __init__(transaction: "WindowedRocksDBPartitionTransaction")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L12)
 
 A windowed state to be provided into `StreamingDataFrame` window functions.
 
@@ -3827,7 +3827,7 @@ def get_window(start_ms: int,
                default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L20)
 
 Get the value of the window defined by `start` and `end` timestamps
 
@@ -3851,7 +3851,7 @@ value or None if the key is not found and `default` is not provided
 def update_window(start_ms: int, end_ms: int, value: Any, timestamp_ms: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L36)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L36)
 
 Set a value for the window.
 
@@ -3873,7 +3873,7 @@ using the provided `timestamp`.
 def get_latest_timestamp() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L53)
 
 Get the latest observed timestamp for the current state partition.
 
@@ -3893,7 +3893,7 @@ def expire_windows(duration_ms: int,
                    grace_ms: int = 0) -> List[Tuple[Tuple[int, int], Any]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L65)
 
 Get a list of expired windows from RocksDB considering the current
 latest timestamp, window duration and grace period.
@@ -3915,7 +3915,7 @@ calling this method multiple times will yield different results for the same
 class RocksDBOptions(RocksDBOptionsType)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/options.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/options.py#L25)
 
 RocksDB database options.
 
@@ -3960,7 +3960,7 @@ Please see `rocksdict.Options` for a complete description of other options.
 def to_options() -> rocksdict.Options
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/options.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/options.py#L53)
 
 Convert parameters to `rocksdict.Options`
 
@@ -3980,7 +3980,7 @@ instance of `rocksdict.Options`
 class RocksDBStore(Store)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L19)
 
 RocksDB-based state store.
 
@@ -4000,7 +4000,7 @@ def __init__(
         options: Optional[options_type] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L29)
 
 **Arguments**:
 
@@ -4020,7 +4020,7 @@ if using changelogs
 def topic() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L53)
 
 Store topic name
 
@@ -4033,7 +4033,7 @@ Store topic name
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L60)
 
 Store name
 
@@ -4046,7 +4046,7 @@ Store name
 def partitions() -> Dict[int, RocksDBStorePartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L67)
 
 Mapping of assigned store partitions
 
@@ -4058,7 +4058,7 @@ Mapping of assigned store partitions
 def assign_partition(partition: int) -> RocksDBStorePartition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L80)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L80)
 
 Open and assign store partition.
 
@@ -4081,7 +4081,7 @@ instance of`RocksDBStorePartition`
 def revoke_partition(partition: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L115)
 
 Revoke and close the assigned store partition.
 
@@ -4099,7 +4099,7 @@ If the partition is not assigned, it will log the message and return.
 def start_partition_transaction(partition: int) -> RocksDBPartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L136)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L136)
 
 Start a new partition transaction.
 
@@ -4122,7 +4122,7 @@ instance of `RocksDBPartitionTransaction`
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L158)
 
 Close the store and revoke all assigned partitions
 
@@ -4138,7 +4138,7 @@ Close the store and revoke all assigned partitions
 class RocksDBStorePartition(StorePartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L40)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L40)
 
 A base class to access state in RocksDB.
 
@@ -4166,7 +4166,7 @@ it will retry according to `open_max_retries` and `open_retry_backoff` options.
 def begin() -> RocksDBPartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L80)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L80)
 
 Create a new `RocksDBTransaction` object.
 
@@ -4185,7 +4185,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L106)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L106)
 
 Updates state from a given changelog message.
 
@@ -4201,7 +4201,7 @@ Updates state from a given changelog message.
 def set_changelog_offset(changelog_offset: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L130)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L130)
 
 Set the changelog offset based on a message (usually an "offset-only" message).
 
@@ -4221,7 +4221,7 @@ def produce_to_changelog(key: bytes,
                          headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L140)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L140)
 
 Produce a message to the StorePartitions respective changelog.
 
@@ -4233,7 +4233,7 @@ Produce a message to the StorePartitions respective changelog.
 def write(batch: WriteBatch)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L151)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L151)
 
 Write `WriteBatch` to RocksDB
 
@@ -4251,7 +4251,7 @@ def get(key: bytes,
         cf_name: str = "default") -> Union[None, bytes, Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L158)
 
 Get a key from RocksDB.
 
@@ -4273,7 +4273,7 @@ a value if the key is present in the DB. Otherwise, `default`
 def exists(key: bytes, cf_name: str = "default") -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L172)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L172)
 
 Check if a key is present in the DB.
 
@@ -4294,7 +4294,7 @@ Check if a key is present in the DB.
 def get_processed_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L183)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L183)
 
 Get last processed offset for the given partition
 
@@ -4310,7 +4310,7 @@ offset or `None` if there's no processed offset yet
 def get_changelog_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L195)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L195)
 
 Get offset that the changelog is up-to-date with.
 
@@ -4326,7 +4326,7 @@ offset or `None` if there's no processed offset yet
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L205)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L205)
 
 Close the underlying RocksDB
 
@@ -4339,7 +4339,7 @@ Close the underlying RocksDB
 def path() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L220)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L220)
 
 Absolute path to RocksDB database folder
 
@@ -4356,7 +4356,7 @@ file path
 def destroy(cls, path: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L228)
 
 Delete underlying RocksDB database
 
@@ -4374,7 +4374,7 @@ The database must be closed first.
 def get_column_family_handle(cf_name: str) -> ColumnFamily
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L238)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L238)
 
 Get a column family handle to pass to it WriteBatch.
 
@@ -4397,7 +4397,7 @@ instance of `rocksdict.ColumnFamily`
 def get_column_family(cf_name: str) -> Rdict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L259)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L259)
 
 Get a column family instance.
 
@@ -4427,7 +4427,7 @@ instance of `rocksdict.Rdict` for the given column family
 class RocksDBPartitionTransaction(PartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L71)
 
 A transaction class to perform simple key-value operations like
 "get", "set", "delete" and "exists" on a single RocksDB partition.
@@ -4466,7 +4466,7 @@ def __init__(partition: "RocksDBStorePartition", dumps: DumpsFunc,
              loads: LoadsFunc)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L114)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L114)
 
 **Arguments**:
 
@@ -4484,7 +4484,7 @@ the underlying RocksDB
 def with_prefix(prefix: Any = b"") -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L141)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L141)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -4514,7 +4514,7 @@ def get(key: Any,
         cf_name: str = "default") -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L170)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L170)
 
 Get a key from the store.
 
@@ -4543,7 +4543,7 @@ value or `default`
 def set(key: Any, value: Any, cf_name: str = "default")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L205)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L205)
 
 Set a key to the store.
 
@@ -4564,7 +4564,7 @@ It first updates the key in the update cache.
 def delete(key: Any, cf_name: str = "default")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L230)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L230)
 
 Delete a key from the store.
 
@@ -4584,7 +4584,7 @@ It first deletes the key from the update cache.
 def exists(key: Any, cf_name: str = "default") -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L253)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L253)
 
 Check if a key exists in the store.
 
@@ -4608,7 +4608,7 @@ It first looks up the key in the update cache.
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L275)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L275)
 
 Check if the transaction is completed.
 
@@ -4630,7 +4630,7 @@ The completed transaction should not be re-used.
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L289)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L289)
 
 Check if the transaction has failed.
 
@@ -4650,7 +4650,7 @@ and
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L318)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L318)
 
 Flush the recent updates to the database and empty the update cache.
 
@@ -4696,7 +4696,7 @@ cannot be used anymore.
 class RecoveryPartition()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L20)
 
 A changelog topic partition mapped to a respective `StorePartition` with helper
 methods to determine its current recovery status.
@@ -4712,7 +4712,7 @@ Since `StorePartition`s do recovery directly, it also handles recovery transacti
 def offset() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L41)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L41)
 
 Get the changelog offset from the underlying `StorePartition`.
 
@@ -4729,7 +4729,7 @@ changelog offset (int)
 def needs_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L50)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L50)
 
 Determine whether recovery is necessary for underlying `StorePartition`.
 
@@ -4742,7 +4742,7 @@ Determine whether recovery is necessary for underlying `StorePartition`.
 def needs_offset_update()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L59)
 
 Determine if an offset update is required.
 
@@ -4756,7 +4756,7 @@ Usually checked during assign if recovery was not required.
 def update_offset()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L67)
 
 Update only the changelog offset of a StorePartition.
 
@@ -4769,7 +4769,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L87)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L87)
 
 Recover the StorePartition using a message read from its respective changelog.
 
@@ -4785,7 +4785,7 @@ Recover the StorePartition using a message read from its respective changelog.
 def set_watermarks(lowwater: int, highwater: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L99)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L99)
 
 Set the changelog watermarks as gathered from Consumer.get_watermark_offsets()
 
@@ -4802,7 +4802,7 @@ Set the changelog watermarks as gathered from Consumer.get_watermark_offsets()
 class ChangelogProducerFactory()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L110)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L110)
 
 Generates ChangelogProducers, which produce changelog messages to a StorePartition.
 
@@ -4814,7 +4814,7 @@ Generates ChangelogProducers, which produce changelog messages to a StorePartiti
 def __init__(changelog_name: str, producer: RowProducer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L115)
 
 **Arguments**:
 
@@ -4833,7 +4833,7 @@ a ChangelogWriter instance
 def get_partition_producer(partition_num)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L125)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L125)
 
 Generate a ChangelogProducer for producing to a specific partition number
 
@@ -4851,7 +4851,7 @@ Generate a ChangelogProducer for producing to a specific partition number
 class ChangelogProducer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L137)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L137)
 
 Generated for a `StorePartition` to produce state changes to its respective
 kafka changelog partition.
@@ -4864,7 +4864,7 @@ kafka changelog partition.
 def __init__(changelog_name: str, partition_num: int, producer: RowProducer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L143)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L143)
 
 **Arguments**:
 
@@ -4882,7 +4882,7 @@ def produce(key: bytes,
             headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L153)
 
 Produce a message to a changelog topic partition.
 
@@ -4900,7 +4900,7 @@ Produce a message to a changelog topic partition.
 class RecoveryManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L178)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L178)
 
 Manages all consumer-related aspects of recovery, including:
     - assigning/revoking, pausing/resuming topic partitions (especially changelogs)
@@ -4920,7 +4920,7 @@ Recovery is attempted from the `Application` after any new partition assignment.
 def has_assignments() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L197)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L197)
 
 Whether the Application has assigned RecoveryPartitions
 
@@ -4937,7 +4937,7 @@ has assignments, as bool
 def recovering() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L206)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L206)
 
 Whether the Application is currently recovering
 
@@ -4953,7 +4953,7 @@ is recovering, as bool
 def register_changelog(topic_name: str, store_name: str, consumer_group: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L214)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L214)
 
 Register a changelog Topic with the TopicManager.
 
@@ -4971,7 +4971,7 @@ Register a changelog Topic with the TopicManager.
 def do_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L228)
 
 If there are any active RecoveryPartitions, do a recovery procedure.
 
@@ -4986,7 +4986,7 @@ def assign_partition(topic_name: str, partition_num: int,
                      store_partitions: Dict[str, StorePartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L274)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L274)
 
 Assigns `StorePartition`s (as `RecoveryPartition`s) ONLY IF recovery required.
 
@@ -5000,7 +5000,7 @@ Pauses active consumer partitions as needed.
 def revoke_partition(partition_num: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L336)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L336)
 
 revoke ALL StorePartitions (across all Stores) for a given partition number
 
@@ -5024,7 +5024,7 @@ revoke ALL StorePartitions (across all Stores) for a given partition number
 class Store(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L12)
 
 Abstract state store.
 
@@ -5040,7 +5040,7 @@ partitions' transactions.
 def topic() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L23)
 
 Topic name
 
@@ -5053,7 +5053,7 @@ Topic name
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L29)
 
 Store name
 
@@ -5066,7 +5066,7 @@ Store name
 def partitions() -> Dict[int, "StorePartition"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L35)
 
 Mapping of assigned store partitions
 
@@ -5082,7 +5082,7 @@ dict of "{partition: <StorePartition>}"
 def assign_partition(partition: int) -> "StorePartition"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L42)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L42)
 
 Assign new store partition
 
@@ -5102,7 +5102,7 @@ instance of `StorePartition`
 def revoke_partition(partition: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L51)
 
 Revoke assigned store partition
 
@@ -5119,7 +5119,7 @@ def start_partition_transaction(
         partition: int) -> Optional["PartitionTransaction"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L60)
 
 Start a new partition transaction.
 
@@ -5141,7 +5141,7 @@ instance of `PartitionTransaction`
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L71)
 
 Close store and revoke all store partitions
 
@@ -5153,7 +5153,7 @@ Close store and revoke all store partitions
 class StorePartition(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L83)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L83)
 
 A base class to access state in the underlying storage.
 It represents a single instance of some storage (e.g. a single database for
@@ -5168,7 +5168,7 @@ the persistent storage).
 def path() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L92)
 
 Absolute path to RocksDB database folder
 
@@ -5180,7 +5180,7 @@ Absolute path to RocksDB database folder
 def begin() -> "PartitionTransaction"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L98)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L98)
 
 State new `PartitionTransaction`
 
@@ -5193,7 +5193,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L103)
 
 Updates state from a given changelog message.
 
@@ -5211,7 +5211,7 @@ def produce_to_changelog(key: bytes,
                          headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L113)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L113)
 
 Produce a message to the StorePartitions respective changelog.
 
@@ -5223,7 +5223,7 @@ Produce a message to the StorePartitions respective changelog.
 def get_processed_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L124)
 
 Get last processed offset for the given partition
 
@@ -5239,7 +5239,7 @@ offset or `None` if there's no processed offset yet
 def get_changelog_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L131)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L131)
 
 Get offset that the changelog is up-to-date with.
 
@@ -5255,7 +5255,7 @@ offset or `None` if there's no processed offset yet
 def set_changelog_offset(changelog_offset: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L138)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L138)
 
 Set the changelog offset based on a message (usually an "offset-only" message).
 
@@ -5273,7 +5273,7 @@ Used during recovery.
 class State(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L149)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L149)
 
 Primary interface for working with key-value state data from `StreamingDataFrame`
 
@@ -5285,7 +5285,7 @@ Primary interface for working with key-value state data from `StreamingDataFrame
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L154)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L154)
 
 Get the value for key if key is present in the state, else default
 
@@ -5306,7 +5306,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L163)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L163)
 
 Set value for the key.
 
@@ -5323,7 +5323,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L170)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L170)
 
 Delete value for the key.
 
@@ -5341,7 +5341,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L178)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L178)
 
 Check if the key exists in state.
 
@@ -5361,7 +5361,7 @@ True if key exists, False otherwise
 class PartitionTransaction(State)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L186)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L186)
 
 A transaction class to perform simple key-value operations like
 "get", "set", "delete" and "exists" on a single storage partition.
@@ -5375,7 +5375,7 @@ A transaction class to perform simple key-value operations like
 def state() -> State
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L193)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L193)
 
 An instance of State to be provided to `StreamingDataFrame` functions
 
@@ -5389,7 +5389,7 @@ An instance of State to be provided to `StreamingDataFrame` functions
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L200)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L200)
 
 Return `True` if transaction failed to update data at some point.
 
@@ -5408,7 +5408,7 @@ bool
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L209)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L209)
 
 Return `True` if transaction is completed.
 
@@ -5426,7 +5426,7 @@ bool
 def with_prefix(prefix: Any = b"") -> Iterator[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L218)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L218)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -5449,7 +5449,7 @@ context manager
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L228)
 
 Flush the recent updates and last processed offset to the storage.
 
@@ -5465,7 +5465,7 @@ Flush the recent updates and last processed offset to the storage.
 class WindowedState(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L241)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L241)
 
 A windowed state to be provided into `StreamingDataFrame` window functions.
 
@@ -5479,7 +5479,7 @@ def get_window(start_ms: int,
                default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L246)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L246)
 
 Get the value of the window defined by `start` and `end` timestamps
 
@@ -5503,7 +5503,7 @@ value or None if the key is not found and `default` is not provided
 def update_window(start_ms: int, end_ms: int, value: Any, timestamp_ms: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L259)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L259)
 
 Set a value for the window.
 
@@ -5525,7 +5525,7 @@ using the provided `timestamp`.
 def get_latest_timestamp() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L272)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L272)
 
 Get the latest observed timestamp for the current state partition.
 
@@ -5544,7 +5544,7 @@ latest observed event timestamp in milliseconds
 def expire_windows(duration_ms: int, grace_ms: int = 0)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L282)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L282)
 
 Get a list of expired windows from RocksDB considering the current
 
@@ -5567,7 +5567,7 @@ calling this method multiple times will yield different results for the same
 class WindowedPartitionTransaction(WindowedState)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L296)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L296)
 
 <a id="quixstreams.state.types.WindowedPartitionTransaction.failed"></a>
 
@@ -5578,7 +5578,7 @@ class WindowedPartitionTransaction(WindowedState)
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L302)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L302)
 
 Return `True` if transaction failed to update data at some point.
 
@@ -5597,7 +5597,7 @@ bool
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L311)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L311)
 
 Return `True` if transaction is completed.
 
@@ -5615,7 +5615,7 @@ bool
 def with_prefix(prefix: Any = b"") -> Iterator[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L320)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L320)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -5638,7 +5638,7 @@ context manager
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L330)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L330)
 
 Flush the recent updates and last processed offset to the storage.
 
@@ -5654,7 +5654,7 @@ Flush the recent updates and last processed offset to the storage.
 class PartitionRecoveryTransaction(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L343)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L343)
 
 A class for managing recovery for a StorePartition from a changelog message
 
@@ -5666,7 +5666,7 @@ A class for managing recovery for a StorePartition from a changelog message
 def flush()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L351)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L351)
 
 Flush the recovery update and last processed offset to the storage.
 
@@ -5686,7 +5686,7 @@ Flush the recovery update and last processed offset to the storage.
 class StateStoreManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L31)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L31)
 
 Class for managing state stores and partitions.
 
@@ -5704,7 +5704,7 @@ StateStoreManager is responsible for:
 def stores() -> Dict[str, Dict[str, Store]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L71)
 
 Map of registered state stores
 
@@ -5721,7 +5721,7 @@ dict in format {topic: {store_name: store}}
 def recovery_required() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L79)
 
 Whether recovery needs to be done.
 
@@ -5734,7 +5734,7 @@ Whether recovery needs to be done.
 def using_changelogs() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L88)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L88)
 
 Whether the StateStoreManager is using changelog topics
 
@@ -5750,7 +5750,7 @@ using changelogs, as bool
 def do_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L96)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L96)
 
 Perform a state recovery, if necessary.
 
@@ -5762,7 +5762,7 @@ Perform a state recovery, if necessary.
 def stop_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L102)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L102)
 
 Stop recovery (called during app shutdown).
 
@@ -5775,7 +5775,7 @@ def get_store(topic: str,
               store_name: str = _DEFAULT_STATE_STORE_NAME) -> Store
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L108)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L108)
 
 Get a store for given name and topic
 
@@ -5797,7 +5797,7 @@ def register_store(topic_name: str,
                    store_name: str = _DEFAULT_STATE_STORE_NAME)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L141)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L141)
 
 Register a state store to be managed by StateStoreManager.
 
@@ -5819,7 +5819,7 @@ Each store can be registered only once for each topic.
 def register_windowed_store(topic_name: str, store_name: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L166)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L166)
 
 Register a windowed state store to be managed by StateStoreManager.
 
@@ -5841,7 +5841,7 @@ Each window store can be registered only once for each topic.
 def clear_stores()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L189)
 
 Delete all state stores managed by StateStoreManager.
 
@@ -5853,7 +5853,7 @@ Delete all state stores managed by StateStoreManager.
 def on_partition_assign(tp: TopicPartition) -> List[StorePartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L204)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L204)
 
 Assign store partitions for each registered store for the given `TopicPartition`
 
@@ -5875,7 +5875,7 @@ list of assigned `StorePartition`
 def on_partition_revoke(tp: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L223)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L223)
 
 Revoke store partitions for each registered store for the given `TopicPartition`
 
@@ -5891,7 +5891,7 @@ Revoke store partitions for each registered store for the given `TopicPartition`
 def on_partition_lost(tp: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L235)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L235)
 
 Revoke and close store partitions for each registered store for the given
 
@@ -5909,7 +5909,7 @@ Revoke and close store partitions for each registered store for the given
 def init()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L244)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L244)
 
 Initialize `StateStoreManager` and create a store directory
 
@@ -5922,7 +5922,7 @@ Initialize `StateStoreManager` and create a store directory
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L251)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L251)
 
 Close all registered stores
 
@@ -5935,7 +5935,7 @@ def get_store_transaction(
         store_name: str = _DEFAULT_STATE_STORE_NAME) -> PartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L259)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L259)
 
 Get active `PartitionTransaction` for the store
 
@@ -5953,7 +5953,7 @@ def start_store_transaction(topic: str, partition: int,
                             offset: int) -> Iterator["_MultiStoreTransaction"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L274)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L274)
 
 Starting the multi-store transaction for the Kafka message.
 
@@ -5982,7 +5982,7 @@ before the end of the current one will fail.
 class TransactionState(State)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L6)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L6)
 
 <a id="quixstreams.state.state.TransactionState.__init__"></a>
 
@@ -5992,7 +5992,7 @@ class TransactionState(State)
 def __init__(transaction: PartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L9)
 
 Simple key-value state to be provided into `StreamingDataFrame` functions
 
@@ -6008,7 +6008,7 @@ Simple key-value state to be provided into `StreamingDataFrame` functions
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L17)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L17)
 
 Get the value for key if key is present in the state, else default
 
@@ -6029,7 +6029,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L27)
 
 Set value for the key.
 
@@ -6046,7 +6046,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L35)
 
 Delete value for the key.
 
@@ -6064,7 +6064,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L44)
 
 Check if the key exists in state.
 
@@ -6092,7 +6092,7 @@ True if key exists, False otherwise
 class PartitionAssignmentError(QuixException)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/exceptions/assignment.py#L6)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/exceptions/assignment.py#L6)
 
 Error happened during partition rebalancing.
 Raised from `on_assign`, `on_revoke` and `on_lost` callbacks
@@ -6113,7 +6113,7 @@ Raised from `on_assign`, `on_revoke` and `on_lost` callbacks
 def set_message_context(context: Optional[MessageContext])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L22)
 
 Set a MessageContext for the current message in the given `contextvars.Context`
 
@@ -6150,7 +6150,7 @@ sdf = sdf.update(lambda value: alter_context(value))
 def message_context() -> MessageContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L53)
 
 Get a MessageContext for the current message, which houses most of the message
 
@@ -6185,7 +6185,7 @@ instance of `MessageContext`
 def message_key() -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L84)
 
 Get the current message's key.
 
@@ -6221,7 +6221,7 @@ a deserialized message key
 class Producer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/producer.py#L58)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/producer.py#L58)
 
 <a id="quixstreams.kafka.producer.Producer.__init__"></a>
 
@@ -6233,7 +6233,7 @@ def __init__(broker_address: str,
              extra_config: dict = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/producer.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/producer.py#L59)
 
 A wrapper around `confluent_kafka.Producer`.
 
@@ -6269,7 +6269,7 @@ def produce(topic: str,
             buffer_error_max_tries: int = 3)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/producer.py#L98)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/producer.py#L98)
 
 Produce message to topic.
 
@@ -6298,7 +6298,7 @@ Pass `0` to not retry after `BufferError`.
 def poll(timeout: float = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/producer.py#L156)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/producer.py#L156)
 
 Polls the producer for events and calls `on_delivery` callbacks.
 
@@ -6314,7 +6314,7 @@ Polls the producer for events and calls `on_delivery` callbacks.
 def flush(timeout: float = None) -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/producer.py#L163)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/producer.py#L163)
 
 Wait for all messages in the Producer queue to be delivered.
 
@@ -6338,7 +6338,7 @@ number of messages delivered
 class Consumer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L66)
 
 <a id="quixstreams.kafka.consumer.Consumer.__init__"></a>
 
@@ -6355,7 +6355,7 @@ def __init__(broker_address: str,
              extra_config: Optional[dict] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L67)
 
 A wrapper around `confluent_kafka.Consumer`.
 
@@ -6393,7 +6393,7 @@ Note: values passed as arguments override values in `extra_config`.
 def poll(timeout: float = None) -> Optional[Message]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L124)
 
 Consumes a single message, calls callbacks and returns events.
 
@@ -6428,7 +6428,7 @@ def subscribe(topics: List[str],
               on_lost: Optional[RebalancingCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L143)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L143)
 
 Set subscription to supplied list of topics
 
@@ -6466,7 +6466,7 @@ for example, may fail.
 def unsubscribe()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L237)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L237)
 
 Remove current subscription.
 
@@ -6484,7 +6484,7 @@ def store_offsets(message: Optional[Message] = None,
                   offsets: List[TopicPartition] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L245)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L245)
 
 .. py:function:: store_offsets([message=None], [offsets=None])
 
@@ -6515,7 +6515,7 @@ def commit(message: Message = None,
            asynchronous: bool = True) -> Optional[List[TopicPartition]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L279)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L279)
 
 Commit a message or a list of offsets.
 
@@ -6549,7 +6549,7 @@ def committed(partitions: List[TopicPartition],
               timeout: float = None) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L319)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L319)
 
 .. py:function:: committed(partitions, [timeout=None])
 
@@ -6579,7 +6579,7 @@ def get_watermark_offsets(partition: TopicPartition,
                           cached: bool = False) -> Tuple[int, int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L339)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L339)
 
 Retrieve low and high offsets for the specified partition.
 
@@ -6611,7 +6611,7 @@ def list_topics(topic: Optional[str] = None,
                 timeout: float = -1) -> ClusterMetadata
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L365)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L365)
 
 .. py:function:: list_topics([topic=None], [timeout=-1])
 
@@ -6640,7 +6640,7 @@ or -1 for infinite timeout.
 def memberid() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L386)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L386)
 
 Return this client's broker-assigned group member id.
 
@@ -6661,7 +6661,7 @@ def offsets_for_times(partitions: List[TopicPartition],
                       timeout: float = None) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L399)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L399)
 
 Look up offsets by timestamp for the specified partitions.
 
@@ -6687,7 +6687,7 @@ last message in the partition, a value of -1 will be returned.
 def pause(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L427)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L427)
 
 Pause consumption for the provided list of partitions.
 
@@ -6711,7 +6711,7 @@ Does NOT affect the result of Consumer.assignment().
 def resume(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L441)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L441)
 
 .. py:function:: resume(partitions)
 
@@ -6733,7 +6733,7 @@ Resume consumption for the provided list of partitions.
 def position(partitions: List[TopicPartition]) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L453)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L453)
 
 Retrieve current positions (offsets) for the specified partitions.
 
@@ -6760,7 +6760,7 @@ the last consumed message + 1.
 def seek(partition: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L467)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L467)
 
 Set consume position for partition to offset.
 
@@ -6788,7 +6788,7 @@ pass the offset in an `assign()` call.
 def assignment() -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L484)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L484)
 
 Returns the current partition assignment.
 
@@ -6809,7 +6809,7 @@ Returns the current partition assignment.
 def set_sasl_credentials(username: str, password: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L497)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L497)
 
 Sets the SASL credentials used for this client.
 These credentials will overwrite the old ones, and will be used the next
@@ -6826,7 +6826,7 @@ This method is applicable only to SASL PLAIN and SCRAM mechanisms.
 def incremental_assign(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L509)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L509)
 
 Assign new partitions.
 
@@ -6844,7 +6844,7 @@ Any additional partitions besides the ones passed during the `Consumer`
 def incremental_unassign(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L521)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L521)
 
 Revoke partitions.
 
@@ -6858,7 +6858,7 @@ Can be called outside an on_revoke callback.
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L529)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L529)
 
 Close down and terminate the Kafka Consumer.
 
@@ -6884,7 +6884,7 @@ see `poll()` for more info.
 class Application()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L52)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L52)
 
 The main Application class.
 
@@ -6948,7 +6948,7 @@ def __init__(broker_address: str,
              topic_manager: Optional[TopicManager] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L91)
 
 **Arguments**:
 
@@ -7025,7 +7025,7 @@ def Quix(cls,
          topic_manager: Optional[QuixTopicManager] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L228)
 
 Initialize an Application to work with Quix platform,
 
@@ -7129,7 +7129,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L386)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L386)
 
 Create a topic definition.
 
@@ -7200,7 +7200,7 @@ topic = app.topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def dataframe(topic: Topic) -> StreamingDataFrame
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L466)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L466)
 
 A simple helper method that generates a `StreamingDataFrame`, which is used
 
@@ -7242,7 +7242,7 @@ to be used as an input topic.
 def stop()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L502)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L502)
 
 Stop the internal poll loop and the message processing.
 
@@ -7260,7 +7260,7 @@ To otherwise stop an application, either send a `SIGTERM` to the process
 def get_producer() -> Producer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L516)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L516)
 
 Create and return a pre-configured Producer instance.
 The Producer is initialized with params passed to Application.
@@ -7291,7 +7291,7 @@ with app.get_producer() as producer:
 def get_consumer() -> Consumer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L547)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L547)
 
 Create and return a pre-configured Consumer instance.
 The Consumer is initialized with params passed to Application.
@@ -7332,7 +7332,7 @@ with app.get_consumer() as consumer:
 def clear_state()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L591)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L591)
 
 Clear the state of the application.
 
@@ -7344,7 +7344,7 @@ Clear the state of the application.
 def run(dataframe: StreamingDataFrame)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L670)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L670)
 
 Start processing data from Kafka using provided `StreamingDataFrame`
 
@@ -7384,7 +7384,7 @@ app.run(dataframe=df)
 class RowConsumer(Consumer, RowConsumerProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowconsumer.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowconsumer.py#L59)
 
 <a id="quixstreams.rowconsumer.RowConsumer.__init__"></a>
 
@@ -7402,7 +7402,7 @@ def __init__(broker_address: str,
              on_error: Optional[ConsumerErrorCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowconsumer.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowconsumer.py#L60)
 
 A consumer class that is capable of deserializing Kafka messages to Rows
 
@@ -7446,7 +7446,7 @@ def subscribe(topics: List[Topic],
               on_lost: Optional[RebalancingCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowconsumer.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowconsumer.py#L115)
 
 Set subscription to supplied list of topics.
 
@@ -7475,7 +7475,7 @@ for example, may fail.
 def poll_row(timeout: float = None) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowconsumer.py#L149)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowconsumer.py#L149)
 
 Consumes a single message and deserialize it to Row or a list of Rows.
 

--- a/docs/api-reference/topics-serdes.md
+++ b/docs/api-reference/topics-serdes.md
@@ -14,7 +14,7 @@
 class QuixDeserializer(JSONDeserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L70)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L70)
 
 Handles Deserialization for any Quix-formatted topic.
 
@@ -31,7 +31,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L77)
 
 
 <br>
@@ -53,7 +53,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L97)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L97)
 
 Each Quix message might contain data for multiple Rows.
 This property informs the downstream processors about that, so they can
@@ -70,7 +70,7 @@ def deserialize(model_key: str, value: Union[List[Mapping],
                                              Mapping]) -> Iterable[Mapping]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L150)
 
 Deserialization function for particular data types (Timeseries or EventData).
 
@@ -95,7 +95,7 @@ Iterable of dicts
 class QuixTimeseriesSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L315)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L315)
 
 Serialize data to JSON formatted according to Quix Timeseries format.
 
@@ -127,7 +127,7 @@ Output:
 class QuixEventsSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L403)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L403)
 
 Serialize data to JSON formatted according to Quix EventData format.
 The input value is expected to be a dictionary with the following keys:
@@ -168,7 +168,7 @@ Output:
 class BytesDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L44)
 
 A deserializer to bypass bytes without any changes
 
@@ -180,7 +180,7 @@ A deserializer to bypass bytes without any changes
 class BytesSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L55)
 
 A serializer to bypass bytes without any changes
 
@@ -192,7 +192,7 @@ A serializer to bypass bytes without any changes
 class StringDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L64)
 
 <a id="quixstreams.models.serializers.simple_types.StringDeserializer.__init__"></a>
 
@@ -204,7 +204,7 @@ class StringDeserializer(Deserializer)
 def __init__(column_name: Optional[str] = None, codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L65)
 
 Deserializes bytes to strings using the specified encoding.
 
@@ -223,7 +223,7 @@ A wrapper around `confluent_kafka.serialization.StringDeserializer`.
 class IntegerDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L84)
 
 Deserializes bytes to integers.
 
@@ -237,7 +237,7 @@ A wrapper around `confluent_kafka.serialization.IntegerDeserializer`.
 class DoubleDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L103)
 
 Deserializes float to IEEE 764 binary64.
 
@@ -251,7 +251,7 @@ A wrapper around `confluent_kafka.serialization.DoubleDeserializer`.
 class StringSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L122)
 
 <a id="quixstreams.models.serializers.simple_types.StringSerializer.__init__"></a>
 
@@ -263,7 +263,7 @@ class StringSerializer(Serializer)
 def __init__(codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L123)
 
 Serializes strings to bytes using the specified encoding.
 
@@ -281,7 +281,7 @@ Serializes strings to bytes using the specified encoding.
 class IntegerSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L135)
 
 Serializes integers to bytes
 
@@ -293,7 +293,7 @@ Serializes integers to bytes
 class DoubleSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L148)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L148)
 
 Serializes floats to bytes
 

--- a/docs/quix-platform.md
+++ b/docs/quix-platform.md
@@ -31,11 +31,10 @@ format, but Quix Platform provides additional features on top of this format in 
 
 You may connect to Quix Platform locally too (e.g. while developing the application on your machine).
 <br>
-To do that, you will need to set the following environment variables:
+To do that, you will need to set the following environment variable:
 
 ```
 Quix__Sdk__Token
-Quix__Portal__Api
 ```
 
 You can find these values on the platform in your Workspace settings.

--- a/examples/bank_example/quix_platform_version/quix_vars.env
+++ b/examples/bank_example/quix_platform_version/quix_vars.env
@@ -1,7 +1,7 @@
 # Required - will always be defined by default in a Quix platform workspace.
 Quix__Sdk__Token=
-Quix__Portal__Api=
 
 # Optional; can usually be found by the library automatically via the quix auth token.
 # It will always be defined by default in a Quix platform workspace.
 Quix__Workspace_Id=
+Quix__Portal__Api=

--- a/quixstreams/platforms/quix/api.py
+++ b/quixstreams/platforms/quix/api.py
@@ -9,6 +9,7 @@ from quixstreams.exceptions import QuixException
 from .env import QUIX_ENVIRONMENT
 
 __all__ = ("QuixPortalApiService",)
+DEFAULT_PORTAL_API_URL = "https://portal-api.platform.quix.io/"
 
 
 class QuixPortalApiService:
@@ -32,7 +33,9 @@ class QuixPortalApiService:
         api_version: Optional[str] = None,
         default_workspace_id: Optional[str] = None,
     ):
-        self._portal_api = portal_api or QUIX_ENVIRONMENT.portal_api or "https://portal-api.platform.quix.io/"
+        self._portal_api = (
+            portal_api or QUIX_ENVIRONMENT.portal_api or DEFAULT_PORTAL_API_URL
+        )
         self._auth_token = auth_token or QUIX_ENVIRONMENT.sdk_token
         self._default_workspace_id = (
             default_workspace_id or QUIX_ENVIRONMENT.workspace_id

--- a/quixstreams/platforms/quix/api.py
+++ b/quixstreams/platforms/quix/api.py
@@ -32,7 +32,7 @@ class QuixPortalApiService:
         api_version: Optional[str] = None,
         default_workspace_id: Optional[str] = None,
     ):
-        self._portal_api = portal_api or QUIX_ENVIRONMENT.portal_api
+        self._portal_api = portal_api or QUIX_ENVIRONMENT.portal_api or "https://portal-api.platform.quix.io/"
         self._auth_token = auth_token or QUIX_ENVIRONMENT.sdk_token
         self._default_workspace_id = (
             default_workspace_id or QUIX_ENVIRONMENT.workspace_id


### PR DESCRIPTION
Set a default value for portal API URL to `https://portal-api.platform.quix.io/` and remove the need to specify it in env variables when using Quix apps