### PR TITLE
Implement handling messages without keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,32 @@
+# Mac OS
 .DS_Store
 
+# Quixstreams (Quix Platform)
 certificates/
 
-#Ignore PyCharm files
+# PyCharm
 .idea/
+
+# VS Code
+.vscode/
 
 # Jupyter checkpoints
 .ipynb_checkpoints/
 
-# pytest cache
-.pytest_cache
+# pytest
+.pytest_cache/
+
+# mypy
+.mypy_cache/
 
 # coverage reports
 .coverage
 
-#ignore environment
+# environment
 env/
 venv/
 
-#ignore build results
+# build results
 /build/
 dist/
 *egg-info
@@ -29,6 +37,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-#direnv
+# direnv
 .direnv/
 .envrc

--- a/docs/api-reference/application.md
+++ b/docs/api-reference/application.md
@@ -10,7 +10,7 @@
 class Application()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L52)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L52)
 
 The main Application class.
 
@@ -80,7 +80,7 @@ def __init__(broker_address: str,
              topic_manager: Optional[TopicManager] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L91)
 
 
 <br>
@@ -161,7 +161,7 @@ def Quix(cls,
          topic_manager: Optional[QuixTopicManager] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L228)
 
 Initialize an Application to work with Quix platform,
 
@@ -273,7 +273,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L386)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L386)
 
 Create a topic definition.
 
@@ -354,7 +354,7 @@ topic = app.topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def dataframe(topic: Topic) -> StreamingDataFrame
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L466)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L466)
 
 A simple helper method that generates a `StreamingDataFrame`, which is used
 
@@ -404,7 +404,7 @@ to be used as an input topic.
 def stop()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L502)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L502)
 
 Stop the internal poll loop and the message processing.
 
@@ -424,7 +424,7 @@ To otherwise stop an application, either send a `SIGTERM` to the process
 def get_producer() -> Producer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L516)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L516)
 
 Create and return a pre-configured Producer instance.
 The Producer is initialized with params passed to Application.
@@ -459,7 +459,7 @@ with app.get_producer() as producer:
 def get_consumer() -> Consumer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L547)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L547)
 
 Create and return a pre-configured Consumer instance.
 The Consumer is initialized with params passed to Application.
@@ -504,7 +504,7 @@ with app.get_consumer() as consumer:
 def clear_state()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L591)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L591)
 
 Clear the state of the application.
 
@@ -518,7 +518,7 @@ Clear the state of the application.
 def run(dataframe: StreamingDataFrame)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L670)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L670)
 
 Start processing data from Kafka using provided `StreamingDataFrame`
 
@@ -562,7 +562,7 @@ app.run(dataframe=df)
 class State(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L149)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L149)
 
 Primary interface for working with key-value state data from `StreamingDataFrame`
 
@@ -576,7 +576,7 @@ Primary interface for working with key-value state data from `StreamingDataFrame
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L154)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L154)
 
 Get the value for key if key is present in the state, else default
 
@@ -603,7 +603,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L163)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L163)
 
 Set value for the key.
 
@@ -624,7 +624,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L170)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L170)
 
 Delete value for the key.
 
@@ -646,7 +646,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L178)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L178)
 
 Check if the key exists in state.
 

--- a/docs/api-reference/dataframe.md
+++ b/docs/api-reference/dataframe.md
@@ -10,7 +10,7 @@
 class StreamingDataFrame(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L29)
 
 `StreamingDataFrame` is the main object you will use for ETL work.
 
@@ -74,7 +74,7 @@ def apply(func: Union[DataFrameFunc, DataFrameStatefulFunc],
           expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L99)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L99)
 
 Apply a function to transform the value and return a new value.
 
@@ -122,7 +122,7 @@ def update(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L142)
 
 Apply a function to mutate value in-place or to perform a side effect
 
@@ -170,7 +170,7 @@ def filter(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L181)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L181)
 
 Filter value using provided function.
 
@@ -218,7 +218,7 @@ of type `State` to perform stateful operations.
 def contains(key: str) -> StreamingSeries
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L234)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L234)
 
 Check if the key is present in the Row value.
 
@@ -258,7 +258,7 @@ def to_topic(topic: Topic,
              key: Optional[Callable[[object], object]] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L257)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L257)
 
 Produce current value to a topic. You can optionally specify a new key.
 
@@ -306,7 +306,7 @@ By default, the current message key will be used.
 def compose() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L296)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L296)
 
 Compose all functions of this StreamingDataFrame into one big closure.
 
@@ -349,7 +349,7 @@ and returns a result of StreamingDataFrame
 def test(value: object, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L326)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L326)
 
 A shorthand to test `StreamingDataFrame` with provided value
 
@@ -383,7 +383,7 @@ def tumbling_window(duration_ms: Union[int, timedelta],
                     name: Optional[str] = None) -> TumblingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L344)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L344)
 
 Create a tumbling window transformation on this StreamingDataFrame.
 
@@ -461,7 +461,7 @@ def hopping_window(duration_ms: Union[int, timedelta],
                    name: Optional[str] = None) -> HoppingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L413)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L413)
 
 Create a hopping window transformation on this StreamingDataFrame.
 
@@ -552,7 +552,7 @@ like `sum`, `count`, etc. and applied to the StreamingDataFrame.
 class StreamingSeries(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L16)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L16)
 
 `StreamingSeries` are typically generated by `StreamingDataframes` when getting
 elements from, or performing certain operations on, a `StreamingDataframe`,
@@ -618,7 +618,7 @@ sdf = sdf[["column_a"] & (sdf["new_sum_field"] >= 10)]
 def from_func(cls, func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L76)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L76)
 
 Create a StreamingSeries from a function.
 
@@ -646,7 +646,7 @@ instance of `StreamingSeries`
 def apply(func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L90)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L90)
 
 Add a callable to the execution list for this series.
 
@@ -699,7 +699,7 @@ def compose(allow_filters: bool = True,
             allow_updates: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L124)
 
 Compose all functions of this StreamingSeries into one big closure.
 
@@ -759,7 +759,7 @@ and returns a result of `StreamingSeries`
 def test(value: Any, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L171)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L171)
 
 A shorthand to test `StreamingSeries` with provided value
 
@@ -791,7 +791,7 @@ result of `StreamingSeries`
 def isin(other: Container) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L202)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L202)
 
 Check if series value is in "other".
 
@@ -836,7 +836,7 @@ new StreamingSeries
 def contains(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L229)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L229)
 
 Check if series value contains "other"
 
@@ -881,7 +881,7 @@ new StreamingSeries
 def is_(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L254)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L254)
 
 Check if series value refers to the same object as `other`
 
@@ -923,7 +923,7 @@ new StreamingSeries
 def isnot(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L277)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L277)
 
 Check if series value does not refer to the same object as `other`
 
@@ -966,7 +966,7 @@ new StreamingSeries
 def isnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L301)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L301)
 
 Check if series value is None.
 
@@ -1003,7 +1003,7 @@ new StreamingSeries
 def notnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L324)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L324)
 
 Check if series value is not None.
 
@@ -1040,7 +1040,7 @@ new StreamingSeries
 def abs() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L347)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L347)
 
 Get absolute value of the series value.
 
@@ -1078,7 +1078,7 @@ new StreamingSeries
 def set_message_context(context: Optional[MessageContext])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L22)
 
 Set a MessageContext for the current message in the given `contextvars.Context`
 
@@ -1121,7 +1121,7 @@ sdf = sdf.update(lambda value: alter_context(value))
 def message_context() -> MessageContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L53)
 
 Get a MessageContext for the current message, which houses most of the message
 
@@ -1162,7 +1162,7 @@ instance of `MessageContext`
 def message_key() -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L84)
 
 Get the current message's key.
 

--- a/docs/api-reference/quix-platform-api.md
+++ b/docs/api-reference/quix-platform-api.md
@@ -10,7 +10,7 @@
 class QuixPortalApiService()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/api.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/api.py#L14)
 
 A light wrapper around the Quix Portal Api. If used in the Quix Platform, it will
 use that workspaces auth token and portal endpoint, else you must provide it.
@@ -34,7 +34,7 @@ def get_workspace_certificate(
         workspace_id: Optional[str] = None) -> Optional[bytes]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/api.py#L89)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/api.py#L89)
 
 Get a workspace TLS certificate if available.
 
@@ -65,7 +65,7 @@ certificate as bytes if present, or None
 class TopicCreationConfigs()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L51)
 
 <a id="quixstreams.platforms.quix.config.TopicCreationConfigs.name"></a>
 
@@ -85,7 +85,7 @@ Required when not created by a Quix App.
 def strip_workspace_id_prefix(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L60)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -114,7 +114,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L72)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L72)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -141,7 +141,7 @@ the string with workspace_id prepended
 class QuixKafkaConfigsBuilder()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L84)
 
 Retrieves all the necessary information from the Quix API and builds all the
 objects required to connect a confluent-kafka client to the Quix Platform.
@@ -167,7 +167,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
              workspace_cert_path: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L100)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L100)
 
 
 <br>
@@ -187,7 +187,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
 def strip_workspace_id_prefix(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L179)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L179)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -215,7 +215,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L189)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -244,7 +244,7 @@ def search_for_workspace(
         workspace_name_or_id: Optional[str] = None) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L199)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L199)
 
 Search for a workspace given an expected workspace name or id.
 
@@ -270,7 +270,7 @@ the workspace data dict if search success, else None
 def get_workspace_info(known_workspace_topic: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L222)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L222)
 
 Queries for workspace data from the Quix API, regardless of instance cache,
 
@@ -292,7 +292,7 @@ and updates instance attributes from query result.
 def search_workspace_for_topic(workspace_id: str, topic: str) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L249)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L249)
 
 Search through all the topics in the given workspace id to see if there is a
 
@@ -321,7 +321,7 @@ the workspace_id if success, else None
 def search_for_topic_workspace(topic: str) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L265)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L265)
 
 Find what workspace a topic belongs to.
 
@@ -351,7 +351,7 @@ def get_workspace_ssl_cert(
         extract_to_folder: Optional[Path] = None) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L286)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L286)
 
 Gets and extracts zipped certificate from the API to provided folder if the
 
@@ -382,7 +382,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout_seconds: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L363)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L363)
 
 Create topics in a Quix cluster.
 
@@ -404,7 +404,7 @@ marked as "Ready" (and thus ready to produce to/consume from).
 def confirm_topics_exist(topics: Union[List[Topic], List[str]])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L412)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L412)
 
 Confirm whether the desired set of topics exists in the Quix workspace.
 
@@ -424,7 +424,7 @@ Confirm whether the desired set of topics exists in the Quix workspace.
 def get_confluent_broker_config(known_topic: Optional[str] = None) -> dict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L452)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L452)
 
 Get the full client config dictionary required to authenticate a confluent-kafka
 
@@ -459,7 +459,7 @@ def get_confluent_client_configs(
 ) -> Tuple[dict, List[str], Optional[str]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L498)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L498)
 
 Get all the values you need in order to use a confluent_kafka-based client
 
@@ -496,7 +496,7 @@ and consumer group name
 class QuixEnvironment()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L7)
 
 Class to access various Quix platform environment settings
 
@@ -511,7 +511,7 @@ Class to access various Quix platform environment settings
 def state_management_enabled() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L19)
 
 Check whether "State management" is enabled for the current deployment
 
@@ -532,7 +532,7 @@ True if state management is enabled, otherwise False
 def deployment_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L27)
 
 Return current Quix deployment id.
 
@@ -556,7 +556,7 @@ deployment id or None
 def workspace_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L39)
 
 Return Quix workspace id if set
 
@@ -577,7 +577,7 @@ workspace id or None
 def portal_api() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L47)
 
 Return Quix Portal API url if set
 
@@ -598,7 +598,7 @@ portal API URL or None
 def sdk_token() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L56)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L56)
 
 Return Quix SDK token if set
 
@@ -619,7 +619,7 @@ sdk token or None
 def state_dir() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L64)
 
 Return application state directory on Quix.
 

--- a/docs/api-reference/quixstreams.md
+++ b/docs/api-reference/quixstreams.md
@@ -14,7 +14,7 @@
 def configure_logging(loglevel: Optional[LogLevel]) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/logging.py#L24)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/logging.py#L24)
 
 Configure "quixstreams" logger.
 
@@ -52,7 +52,7 @@ True if logging config has been updated, otherwise False.
 class TopicCreationConfigs()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L51)
 
 <a id="quixstreams.platforms.quix.config.TopicCreationConfigs.name"></a>
 
@@ -68,7 +68,7 @@ Required when not created by a Quix App.
 def strip_workspace_id_prefix(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L60)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -91,7 +91,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L72)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L72)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -114,7 +114,7 @@ the string with workspace_id prepended
 class QuixKafkaConfigsBuilder()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L84)
 
 Retrieves all the necessary information from the Quix API and builds all the
 objects required to connect a confluent-kafka client to the Quix Platform.
@@ -138,7 +138,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
              workspace_cert_path: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L100)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L100)
 
 **Arguments**:
 
@@ -154,7 +154,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
 def strip_workspace_id_prefix(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L179)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L179)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -176,7 +176,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L189)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -199,7 +199,7 @@ def search_for_workspace(
         workspace_name_or_id: Optional[str] = None) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L199)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L199)
 
 Search for a workspace given an expected workspace name or id.
 
@@ -219,7 +219,7 @@ the workspace data dict if search success, else None
 def get_workspace_info(known_workspace_topic: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L222)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L222)
 
 Queries for workspace data from the Quix API, regardless of instance cache,
 
@@ -237,7 +237,7 @@ and updates instance attributes from query result.
 def search_workspace_for_topic(workspace_id: str, topic: str) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L249)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L249)
 
 Search through all the topics in the given workspace id to see if there is a
 
@@ -260,7 +260,7 @@ the workspace_id if success, else None
 def search_for_topic_workspace(topic: str) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L265)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L265)
 
 Find what workspace a topic belongs to.
 
@@ -284,7 +284,7 @@ def get_workspace_ssl_cert(
         extract_to_folder: Optional[Path] = None) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L286)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L286)
 
 Gets and extracts zipped certificate from the API to provided folder if the
 
@@ -309,7 +309,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout_seconds: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L363)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L363)
 
 Create topics in a Quix cluster.
 
@@ -327,7 +327,7 @@ marked as "Ready" (and thus ready to produce to/consume from).
 def confirm_topics_exist(topics: Union[List[Topic], List[str]])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L412)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L412)
 
 Confirm whether the desired set of topics exists in the Quix workspace.
 
@@ -343,7 +343,7 @@ Confirm whether the desired set of topics exists in the Quix workspace.
 def get_confluent_broker_config(known_topic: Optional[str] = None) -> dict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L452)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L452)
 
 Get the full client config dictionary required to authenticate a confluent-kafka
 
@@ -372,7 +372,7 @@ def get_confluent_client_configs(
 ) -> Tuple[dict, List[str], Optional[str]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/config.py#L498)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/config.py#L498)
 
 Get all the values you need in order to use a confluent_kafka-based client
 
@@ -405,7 +405,7 @@ and consumer group name
 class QuixEnvironment()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L7)
 
 Class to access various Quix platform environment settings
 
@@ -418,7 +418,7 @@ Class to access various Quix platform environment settings
 def state_management_enabled() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L19)
 
 Check whether "State management" is enabled for the current deployment
 
@@ -435,7 +435,7 @@ True if state management is enabled, otherwise False
 def deployment_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L27)
 
 Return current Quix deployment id.
 
@@ -455,7 +455,7 @@ deployment id or None
 def workspace_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L39)
 
 Return Quix workspace id if set
 
@@ -472,7 +472,7 @@ workspace id or None
 def portal_api() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L47)
 
 Return Quix Portal API url if set
 
@@ -489,7 +489,7 @@ portal API URL or None
 def sdk_token() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L56)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L56)
 
 Return Quix SDK token if set
 
@@ -506,7 +506,7 @@ sdk token or None
 def state_dir() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/env.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/env.py#L64)
 
 Return application state directory on Quix.
 
@@ -526,7 +526,7 @@ path to state dir
 def check_state_management_enabled()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/checks.py#L11)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/checks.py#L11)
 
 Check if State Management feature is enabled for the current deployment on
 Quix platform.
@@ -540,7 +540,7 @@ If it's disabled, the exception will be raised.
 def check_state_dir(state_dir: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/checks.py#L28)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/checks.py#L28)
 
 Check if Application "state_dir" matches the state dir on Quix platform.
 
@@ -566,7 +566,7 @@ If it doesn't match, the warning will be logged.
 class QuixPortalApiService()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/api.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/api.py#L14)
 
 A light wrapper around the Quix Portal Api. If used in the Quix Platform, it will
 use that workspaces auth token and portal endpoint, else you must provide it.
@@ -588,7 +588,7 @@ def get_workspace_certificate(
         workspace_id: Optional[str] = None) -> Optional[bytes]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/api.py#L89)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/api.py#L89)
 
 Get a workspace TLS certificate if available.
 
@@ -614,7 +614,7 @@ certificate as bytes if present, or None
 class QuixTopicManager(TopicManager)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/topic_manager.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/topic_manager.py#L9)
 
 The source of all topic management with quixstreams.
 
@@ -636,7 +636,7 @@ def __init__(topic_admin: TopicAdmin,
              quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/platforms/quix/topic_manager.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/platforms/quix/topic_manager.py#L29)
 
 **Arguments**:
 
@@ -657,7 +657,7 @@ generated for you.
 class StreamingDataFrame(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L29)
 
 `StreamingDataFrame` is the main object you will use for ETL work.
 
@@ -713,7 +713,7 @@ def apply(func: Union[DataFrameFunc, DataFrameStatefulFunc],
           expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L99)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L99)
 
 Apply a function to transform the value and return a new value.
 
@@ -755,7 +755,7 @@ def update(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L142)
 
 Apply a function to mutate value in-place or to perform a side effect
 
@@ -797,7 +797,7 @@ def filter(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L181)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L181)
 
 Filter value using provided function.
 
@@ -839,7 +839,7 @@ of type `State` to perform stateful operations.
 def contains(key: str) -> StreamingSeries
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L234)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L234)
 
 Check if the key is present in the Row value.
 
@@ -871,7 +871,7 @@ def to_topic(topic: Topic,
              key: Optional[Callable[[object], object]] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L257)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L257)
 
 Produce current value to a topic. You can optionally specify a new key.
 
@@ -913,7 +913,7 @@ By default, the current message key will be used.
 def compose() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L296)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L296)
 
 Compose all functions of this StreamingDataFrame into one big closure.
 
@@ -950,7 +950,7 @@ and returns a result of StreamingDataFrame
 def test(value: object, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L326)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L326)
 
 A shorthand to test `StreamingDataFrame` with provided value
 
@@ -978,7 +978,7 @@ def tumbling_window(duration_ms: Union[int, timedelta],
                     name: Optional[str] = None) -> TumblingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L344)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L344)
 
 Create a tumbling window transformation on this StreamingDataFrame.
 
@@ -1048,7 +1048,7 @@ def hopping_window(duration_ms: Union[int, timedelta],
                    name: Optional[str] = None) -> HoppingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/dataframe.py#L413)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/dataframe.py#L413)
 
 Create a hopping window transformation on this StreamingDataFrame.
 
@@ -1131,7 +1131,7 @@ like `sum`, `count`, etc. and applied to the StreamingDataFrame.
 class StreamingSeries(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L16)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L16)
 
 `StreamingSeries` are typically generated by `StreamingDataframes` when getting
 elements from, or performing certain operations on, a `StreamingDataframe`,
@@ -1189,7 +1189,7 @@ sdf = sdf[["column_a"] & (sdf["new_sum_field"] >= 10)]
 def from_func(cls, func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L76)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L76)
 
 Create a StreamingSeries from a function.
 
@@ -1211,7 +1211,7 @@ instance of `StreamingSeries`
 def apply(func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L90)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L90)
 
 Add a callable to the execution list for this series.
 
@@ -1256,7 +1256,7 @@ def compose(allow_filters: bool = True,
             allow_updates: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L124)
 
 Compose all functions of this StreamingSeries into one big closure.
 
@@ -1308,7 +1308,7 @@ and returns a result of `StreamingSeries`
 def test(value: Any, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L171)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L171)
 
 A shorthand to test `StreamingSeries` with provided value
 
@@ -1334,7 +1334,7 @@ result of `StreamingSeries`
 def isin(other: Container) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L202)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L202)
 
 Check if series value is in "other".
 
@@ -1371,7 +1371,7 @@ new StreamingSeries
 def contains(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L229)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L229)
 
 Check if series value contains "other"
 
@@ -1408,7 +1408,7 @@ new StreamingSeries
 def is_(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L254)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L254)
 
 Check if series value refers to the same object as `other`
 
@@ -1442,7 +1442,7 @@ new StreamingSeries
 def isnot(other: object) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L277)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L277)
 
 Check if series value does not refer to the same object as `other`
 
@@ -1477,7 +1477,7 @@ new StreamingSeries
 def isnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L301)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L301)
 
 Check if series value is None.
 
@@ -1508,7 +1508,7 @@ new StreamingSeries
 def notnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L324)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L324)
 
 Check if series value is not None.
 
@@ -1539,7 +1539,7 @@ new StreamingSeries
 def abs() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/series.py#L347)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/series.py#L347)
 
 Get absolute value of the series value.
 
@@ -1575,7 +1575,7 @@ new StreamingSeries
 def ensure_milliseconds(delta: Union[int, timedelta]) -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/utils.py#L5)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/utils.py#L5)
 
 Convert timedelta to milliseconds.
 
@@ -1603,7 +1603,7 @@ timedelta value in milliseconds as `int`
 class FixedTimeWindowDefinition(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L20)
 
 <a id="quixstreams.dataframe.windows.definitions.FixedTimeWindowDefinition.sum"></a>
 
@@ -1613,7 +1613,7 @@ class FixedTimeWindowDefinition(abc.ABC)
 def sum() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L68)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L68)
 
 Configure the window to aggregate data by summing up values within
 
@@ -1631,7 +1631,7 @@ an instance of `FixedTimeWindow` configured to perform sum aggregation.
 def count() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L95)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L95)
 
 Configure the window to aggregate data by counting the number of values
 
@@ -1649,7 +1649,7 @@ an instance of `FixedTimeWindow` configured to perform record count.
 def mean() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L122)
 
 Configure the window to aggregate data by calculating the mean of the values
 
@@ -1669,7 +1669,7 @@ def reduce(reducer: Callable[[Any, Any], Any],
            initializer: Callable[[Any], Any]) -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L153)
 
 Configure the window to perform a custom aggregation using `reducer`
 
@@ -1718,7 +1718,7 @@ A window configured to perform custom reduce aggregation on the data.
 def max() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L213)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L213)
 
 Configure a window to aggregate the maximum value within each window period.
 
@@ -1735,7 +1735,7 @@ value within each window period.
 def min() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/definitions.py#L242)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/definitions.py#L242)
 
 Configure a window to aggregate the minimum value within each window period.
 
@@ -1760,7 +1760,7 @@ value within each window period.
 class FixedTimeWindow()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/time_based.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/time_based.py#L29)
 
 <a id="quixstreams.dataframe.windows.time_based.FixedTimeWindow.final"></a>
 
@@ -1770,7 +1770,7 @@ class FixedTimeWindow()
 def final(expand: bool = True) -> "StreamingDataFrame"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/time_based.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/time_based.py#L92)
 
 Apply the window aggregation and return results only when the windows are
 
@@ -1808,7 +1808,7 @@ Default - `True`
 def current(expand: bool = True) -> "StreamingDataFrame"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/time_based.py#L129)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/time_based.py#L129)
 
 Apply the window transformation to the StreamingDataFrame to return results
 
@@ -1846,7 +1846,7 @@ def get_window_ranges(timestamp_ms: int,
                       step_ms: Optional[int] = None) -> List[Tuple[int, int]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/dataframe/windows/base.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/dataframe/windows/base.py#L22)
 
 Get a list of window ranges for the given timestamp.
 
@@ -1876,7 +1876,7 @@ a list of (<start>, <end>) tuples
 class RowProducer(Producer, RowProducerProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowproducer.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowproducer.py#L25)
 
 A producer class that is capable of serializing Rows to bytes and send them to Kafka.
 
@@ -1914,7 +1914,7 @@ def produce_row(row: Row,
                 timestamp: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowproducer.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowproducer.py#L66)
 
 Serialize Row to bytes according to the Topic serialization settings
 
@@ -1938,7 +1938,7 @@ If this method fails, it will trigger the provided "on_error" callback.
 def poll(timeout: float = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowproducer.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowproducer.py#L103)
 
 Polls the producer for events and calls `on_delivery` callbacks.
 
@@ -1960,7 +1960,7 @@ If poll fails, it will trigger the provided "on_error" callback
 class StreamFunction(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L27)
 
 A base class for all the streaming operations in Quix Streams.
 
@@ -1978,7 +1978,7 @@ It provides two methods that return closures to be called on the input values:
 def func() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L44)
 
 The original function
 
@@ -1991,7 +1991,7 @@ The original function
 def get_executor() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L51)
 
 Returns a wrapper to be called on a single value.
 
@@ -2004,7 +2004,7 @@ Returns a wrapper to be called on a single value.
 def get_executor_expanded() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L57)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L57)
 
 Returns a wrapper to be called on a list of expanded values.
 
@@ -2016,7 +2016,7 @@ Returns a wrapper to be called on a list of expanded values.
 class ApplyFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L63)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L63)
 
 Wrap a function into "Apply" function.
 
@@ -2031,7 +2031,7 @@ and its result will always be passed downstream.
 class ApplyExpandFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L86)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L86)
 
 Wrap a function into "Apply" function and expand the returned iterable
 into separate values downstream.
@@ -2047,7 +2047,7 @@ If the returned value is not `Iterable`, `TypeError` will be raised.
 class FilterFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L115)
 
 Wraps a function into a "Filter" function.
 The result of a Filter function is interpreted as boolean.
@@ -2063,7 +2063,7 @@ value is filtered out.
 class UpdateFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L147)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L147)
 
 Wrap a function into an "Update" function.
 
@@ -2083,7 +2083,7 @@ def compose(functions: List[StreamFunction],
             allow_expands: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L176)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L176)
 
 Composes a list of functions and its parents into a single
 
@@ -2117,7 +2117,7 @@ def composer(outer_func: StreamCallable,
              inner_func: StreamCallable) -> Callable[[T], R]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/functions.py#L226)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/functions.py#L226)
 
 A function that wraps two other functions into a closure.
 
@@ -2143,7 +2143,7 @@ a function with one argument (value)
 class Stream()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L22)
 
 <a id="quixstreams.core.stream.stream.Stream.__init__"></a>
 
@@ -2154,7 +2154,7 @@ def __init__(func: Optional[StreamFunction] = None,
              parent: Optional[Self] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L23)
 
 A base class for all streaming operations.
 
@@ -2197,7 +2197,7 @@ Default - "Apply(lambda v: v)".
 def add_filter(func: Callable[[T], R]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L79)
 
 Add a function to filter values from the Stream.
 
@@ -2221,7 +2221,7 @@ a new `Stream` derived from the current one
 def add_apply(func: Callable[[T], R], expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L92)
 
 Add an "apply" function to the Stream.
 
@@ -2247,7 +2247,7 @@ a new `Stream` derived from the current one
 def add_update(func: Callable[[T], object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L109)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L109)
 
 Add an "update" function to the Stream, that will mutate the input value.
 
@@ -2270,7 +2270,7 @@ a new Stream derived from the current one
 def diff(other: "Stream") -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L121)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L121)
 
 Takes the difference between Streams `self` and `other` based on their last
 
@@ -2302,7 +2302,7 @@ new `Stream` instance including all the Streams from the diff
 def tree() -> List[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L150)
 
 Return a list of all parent Streams including the node itself.
 
@@ -2322,7 +2322,7 @@ def compose(allow_filters: bool = True,
             allow_expands: bool = True) -> Callable[[T], R]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/core/stream/stream.py#L164)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/core/stream/stream.py#L164)
 
 Compose a list of functions from this `Stream` and its parents into one
 
@@ -2364,7 +2364,7 @@ the stream has functions with "expand=True" in the tree. Default - True.
 def dict_values(d: object) -> List
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/utils/dicts.py#L4)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/utils/dicts.py#L4)
 
 Recursively unpacks a set of nested dicts to get a flattened list of leaves,
 
@@ -2392,7 +2392,7 @@ a list with all the leaves of the various contained dicts
 def dumps(value: Any) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/utils/json.py#L8)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/utils/json.py#L8)
 
 Serialize to JSON using `orjson` package.
 
@@ -2412,7 +2412,7 @@ bytes
 def loads(value: bytes) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/utils/json.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/utils/json.py#L18)
 
 Deserialize from JSON using `orjson` package.
 
@@ -2444,7 +2444,7 @@ object
 class TimestampType(enum.IntEnum)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/timestamps.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/timestamps.py#L9)
 
 <a id="quixstreams.models.timestamps.TimestampType.TIMESTAMP_NOT_AVAILABLE"></a>
 
@@ -2472,7 +2472,7 @@ broker receive time
 class MessageTimestamp()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/timestamps.py#L15)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/timestamps.py#L15)
 
 Represents a timestamp of incoming Kafka message.
 
@@ -2488,7 +2488,7 @@ it should not be mutated during message processing.
 def create(cls, timestamp_type: int, milliseconds: int) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/timestamps.py#L42)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/timestamps.py#L42)
 
 Create a Timestamp object based on data
 
@@ -2525,7 +2525,7 @@ Timestamp object
 class MessageContext()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/messagecontext.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/messagecontext.py#L7)
 
 An object with Kafka message properties.
 
@@ -2544,7 +2544,7 @@ it should not be mutated during message processing.
 class ConfluentKafkaMessageProto(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/types.py#L10)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/types.py#L10)
 
 An interface of `confluent_kafka.Message`.
 
@@ -2569,7 +2569,7 @@ see https://github.com/confluentinc/confluent-kafka-python/issues/1535.
 class IgnoreMessage(exceptions.QuixException)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/exceptions.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/exceptions.py#L51)
 
 Raise this exception from Deserializer.__call__ in order to ignore the processing
 of the particular message.
@@ -2586,7 +2586,7 @@ of the particular message.
 class QuixDeserializer(JSONDeserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L70)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L70)
 
 Handles Deserialization for any Quix-formatted topic.
 
@@ -2601,7 +2601,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L77)
 
 **Arguments**:
 
@@ -2619,7 +2619,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L97)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L97)
 
 Each Quix message might contain data for multiple Rows.
 This property informs the downstream processors about that, so they can
@@ -2634,7 +2634,7 @@ def deserialize(model_key: str, value: Union[List[Mapping],
                                              Mapping]) -> Iterable[Mapping]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L150)
 
 Deserialization function for particular data types (Timeseries or EventData).
 
@@ -2655,7 +2655,7 @@ Iterable of dicts
 class QuixSerializer(JSONSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L268)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L268)
 
 <a id="quixstreams.models.serializers.quix.QuixSerializer.__init__"></a>
 
@@ -2666,7 +2666,7 @@ def __init__(as_legacy: bool = True,
              dumps: Callable[[Any], Union[str, bytes]] = default_dumps)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L272)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L272)
 
 Serializer that returns data in json format.
 
@@ -2684,7 +2684,7 @@ Default - :py:func:`quixstreams.utils.json.dumps`
 class QuixTimeseriesSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L315)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L315)
 
 Serialize data to JSON formatted according to Quix Timeseries format.
 
@@ -2716,7 +2716,7 @@ Output:
 class QuixEventsSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L403)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L403)
 
 Serialize data to JSON formatted according to Quix EventData format.
 The input value is expected to be a dictionary with the following keys:
@@ -2757,7 +2757,7 @@ Output:
 class BytesDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L44)
 
 A deserializer to bypass bytes without any changes
 
@@ -2769,7 +2769,7 @@ A deserializer to bypass bytes without any changes
 class BytesSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L55)
 
 A serializer to bypass bytes without any changes
 
@@ -2781,7 +2781,7 @@ A serializer to bypass bytes without any changes
 class StringDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L64)
 
 <a id="quixstreams.models.serializers.simple_types.StringDeserializer.__init__"></a>
 
@@ -2791,7 +2791,7 @@ class StringDeserializer(Deserializer)
 def __init__(column_name: Optional[str] = None, codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L65)
 
 Deserializes bytes to strings using the specified encoding.
 
@@ -2808,7 +2808,7 @@ A wrapper around `confluent_kafka.serialization.StringDeserializer`.
 class IntegerDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L84)
 
 Deserializes bytes to integers.
 
@@ -2822,7 +2822,7 @@ A wrapper around `confluent_kafka.serialization.IntegerDeserializer`.
 class DoubleDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L103)
 
 Deserializes float to IEEE 764 binary64.
 
@@ -2836,7 +2836,7 @@ A wrapper around `confluent_kafka.serialization.DoubleDeserializer`.
 class StringSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L122)
 
 <a id="quixstreams.models.serializers.simple_types.StringSerializer.__init__"></a>
 
@@ -2846,7 +2846,7 @@ class StringSerializer(Serializer)
 def __init__(codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L123)
 
 Serializes strings to bytes using the specified encoding.
 
@@ -2862,7 +2862,7 @@ Serializes strings to bytes using the specified encoding.
 class IntegerSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L135)
 
 Serializes integers to bytes
 
@@ -2874,7 +2874,7 @@ Serializes integers to bytes
 class DoubleSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L148)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L148)
 
 Serializes floats to bytes
 
@@ -2890,7 +2890,7 @@ Serializes floats to bytes
 class JSONSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/json.py#L13)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/json.py#L13)
 
 <a id="quixstreams.models.serializers.json.JSONSerializer.__init__"></a>
 
@@ -2900,7 +2900,7 @@ class JSONSerializer(Serializer)
 def __init__(dumps: Callable[[Any], Union[str, bytes]] = default_dumps)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/json.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/json.py#L14)
 
 Serializer that returns data in json format.
 
@@ -2917,7 +2917,7 @@ Default - :py:func:`quixstreams.utils.json.dumps`
 class JSONDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/json.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/json.py#L35)
 
 <a id="quixstreams.models.serializers.json.JSONDeserializer.__init__"></a>
 
@@ -2928,7 +2928,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/json.py#L36)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/json.py#L36)
 
 Deserializer that parses data from JSON
 
@@ -2951,7 +2951,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 class SerializationContext()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L22)
 
 Provides additional context for message serialization/deserialization.
 
@@ -2965,7 +2965,7 @@ Every `Serializer` and `Deserializer` receives an instance of `SerializationCont
 def to_confluent_ctx(field: MessageField) -> _SerializationContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L35)
 
 Convert `SerializationContext` to `confluent_kafka.SerializationContext`
 
@@ -2987,7 +2987,7 @@ instance of `confluent_kafka.serialization.SerializationContext`
 class Deserializer(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L47)
 
 <a id="quixstreams.models.serializers.base.Deserializer.__init__"></a>
 
@@ -2997,7 +2997,7 @@ class Deserializer(abc.ABC)
 def __init__(column_name: Optional[str] = None, *args, **kwargs)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L48)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L48)
 
 A base class for all Deserializers
 
@@ -3015,7 +3015,7 @@ dictionary with `column_name` as a key.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L58)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L58)
 
 Return True if the deserialized message should be considered as Iterable
 and each item in it should be processed as a separate message.
@@ -3028,7 +3028,7 @@ and each item in it should be processed as a separate message.
 class Serializer(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L75)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L75)
 
 A base class for all Serializers
 
@@ -3041,7 +3041,7 @@ A base class for all Serializers
 def extra_headers() -> MessageHeadersMapping
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/base.py#L81)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/base.py#L81)
 
 Informs producer to set additional headers
 
@@ -3070,7 +3070,7 @@ dict with headers
 class Row()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/rows.py#L11)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/rows.py#L11)
 
 Row is a dict-like interface on top of the message data + some Kafka props
 
@@ -3082,7 +3082,7 @@ Row is a dict-like interface on top of the message data + some Kafka props
 def keys() -> KeysView
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/rows.py#L73)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/rows.py#L73)
 
 Also allows unpacking row.value via **row
 
@@ -3094,7 +3094,7 @@ Also allows unpacking row.value via **row
 def clone(value: dict) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/rows.py#L85)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/rows.py#L85)
 
 Manually clone the Row; doing it this way is much faster than doing a deepcopy
 on the entire Row object.
@@ -3115,7 +3115,7 @@ on the entire Row object.
 def convert_topic_list(topics: List[Topic]) -> List[ConfluentTopic]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L23)
 
 Converts `Topic`s to `ConfluentTopic`s as required for Confluent's
 
@@ -3137,7 +3137,7 @@ list of confluent_kafka `ConfluentTopic`s
 class TopicAdmin()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L46)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L46)
 
 For performing "admin"-level operations on a Kafka cluster, mostly around topics.
 
@@ -3151,7 +3151,7 @@ Primarily used to create and inspect topic configurations.
 def __init__(broker_address: str, extra_config: Optional[Mapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L53)
 
 **Arguments**:
 
@@ -3166,7 +3166,7 @@ def __init__(broker_address: str, extra_config: Optional[Mapping] = None)
 def list_topics() -> Dict[str, ConfluentTopicMetadata]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L74)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L74)
 
 Get a list of topics and their metadata from a Kafka cluster
 
@@ -3182,7 +3182,7 @@ a dict of topic names and their metadata objects
 def inspect_topics(topic_names: List[str]) -> Dict[str, Optional[TopicConfig]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L83)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L83)
 
 A simplified way of getting the topic configurations of the provided topics
 
@@ -3206,7 +3206,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout: int = 60)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/admin.py#L152)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/admin.py#L152)
 
 Create the given list of topics and confirm they are ready.
 
@@ -3232,7 +3232,7 @@ fail (it ignores issues for a topic already existing).
 class TopicConfig()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L42)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L42)
 
 Represents all kafka-level configuration for a kafka topic.
 
@@ -3246,7 +3246,7 @@ Generally used by Topic and any topic creation procedures.
 class Topic()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L81)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L81)
 
 A representation of a Kafka topic and its expected data format via
 designated key and value serializers/deserializers.
@@ -3270,7 +3270,7 @@ def __init__(
         timestamp_extractor: Optional[TimestampExtractor] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L91)
 
 Can specify serialization that should be used when consuming/producing
 
@@ -3327,7 +3327,7 @@ topic = Topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L155)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L155)
 
 Topic name
 
@@ -3339,7 +3339,7 @@ Topic name
 def row_serialize(row: Row, key: Optional[Any] = None) -> KafkaMessage
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L165)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L165)
 
 Serialize Row to a Kafka message structure
 
@@ -3361,7 +3361,7 @@ def row_deserialize(
         message: ConfluentKafkaMessageProto) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/topic.py#L188)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/topic.py#L188)
 
 Deserialize incoming Kafka message to a Row.
 
@@ -3389,7 +3389,7 @@ Row, list of Rows or None if the message is ignored.
 def affirm_ready_for_create(topics: List[Topic])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L19)
 
 Validate a list of topics is ready for creation attempt
 
@@ -3405,7 +3405,7 @@ Validate a list of topics is ready for creation attempt
 class TopicManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L29)
 
 The source of all topic management with quixstreams.
 
@@ -3423,7 +3423,7 @@ See methods for details.
 def __init__(topic_admin: TopicAdmin, create_timeout: int = 60)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L48)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L48)
 
 **Arguments**:
 
@@ -3439,7 +3439,7 @@ def __init__(topic_admin: TopicAdmin, create_timeout: int = 60)
 def changelog_topics() -> Dict[str, Dict[str, Topic]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L71)
 
 Note: `Topic`s are the changelogs.
 
@@ -3455,7 +3455,7 @@ def topic_config(num_partitions: Optional[int] = None,
                  extra_config: Optional[dict] = None) -> TopicConfig
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L121)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L121)
 
 Convenience method for generating a `TopicConfig` with default settings
 
@@ -3483,7 +3483,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L142)
 
 A convenience method for generating a `Topic`. Will use default config options
 
@@ -3513,7 +3513,7 @@ def changelog_topic(topic_name: str, store_name: str,
                     consumer_group: str) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L191)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L191)
 
 Performs all the logic necessary to generate a changelog topic based on a
 
@@ -3552,7 +3552,7 @@ generate changelog topics. To turn off changelogs, init an Application with
 def create_topics(topics: List[Topic])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L262)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L262)
 
 Creates topics via an explicit list of provided `Topics`.
 
@@ -3571,7 +3571,7 @@ Exists as a way to manually specify what topics to create; otherwise,
 def create_all_topics()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L277)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L277)
 
 A convenience method to create all Topic objects stored on this TopicManager.
 
@@ -3583,7 +3583,7 @@ A convenience method to create all Topic objects stored on this TopicManager.
 def validate_all_topics()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/topics/manager.py#L283)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/topics/manager.py#L283)
 
 Validates all topics exist and changelogs have correct topic and rep factor.
 
@@ -3601,7 +3601,7 @@ Issues are pooled and raised as an Exception once inspections are complete.
 class WindowedRocksDBStore(RocksDBStore)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/store.py#L10)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/store.py#L10)
 
 RocksDB-based windowed state store.
 
@@ -3621,7 +3621,7 @@ def __init__(
         options: Optional[RocksDBOptionsType] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/store.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/store.py#L18)
 
 **Arguments**:
 
@@ -3644,7 +3644,7 @@ if using changelogs
 class WindowedRocksDBStorePartition(RocksDBStorePartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/partition.py#L24)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/partition.py#L24)
 
 A base class to access windowed state in RocksDB.
 
@@ -3674,7 +3674,7 @@ stores the expiration index to delete expired windows.
 class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/transaction.py#L21)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/transaction.py#L21)
 
 <a id="quixstreams.state.rocksdb.windowed.transaction.WindowedRocksDBPartitionTransaction.expire_windows"></a>
 
@@ -3685,7 +3685,7 @@ def expire_windows(duration_ms: int,
                    grace_ms: int = 0) -> List[Tuple[Tuple[int, int], Any]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/transaction.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/transaction.py#L79)
 
 Get a list of expired windows from RocksDB considering latest timestamp,
 
@@ -3723,7 +3723,7 @@ sorted list of tuples in format `((start, end), value)`
 def parse_window_key(key: bytes) -> Tuple[bytes, int, int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/serialization.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/serialization.py#L12)
 
 Parse the window key from Rocksdb into (message_key, start, end) structure.
 
@@ -3746,7 +3746,7 @@ a tuple with message key, start timestamp, end timestamp
 def encode_window_key(start_ms: int, end_ms: int) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/serialization.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/serialization.py#L39)
 
 Encode window start and end timestamps into bytes of the following format:
 
@@ -3771,7 +3771,7 @@ window timestamps as bytes
 def encode_window_prefix(prefix: bytes, start_ms: int) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/serialization.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/serialization.py#L53)
 
 Encode window prefix and start time to iterate over keys in RocksDB
 
@@ -3799,7 +3799,7 @@ bytes
 class WindowedTransactionState(WindowedState)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L9)
 
 <a id="quixstreams.state.rocksdb.windowed.state.WindowedTransactionState.__init__"></a>
 
@@ -3809,7 +3809,7 @@ class WindowedTransactionState(WindowedState)
 def __init__(transaction: "WindowedRocksDBPartitionTransaction")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L12)
 
 A windowed state to be provided into `StreamingDataFrame` window functions.
 
@@ -3827,7 +3827,7 @@ def get_window(start_ms: int,
                default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L20)
 
 Get the value of the window defined by `start` and `end` timestamps
 
@@ -3851,7 +3851,7 @@ value or None if the key is not found and `default` is not provided
 def update_window(start_ms: int, end_ms: int, value: Any, timestamp_ms: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L36)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L36)
 
 Set a value for the window.
 
@@ -3873,7 +3873,7 @@ using the provided `timestamp`.
 def get_latest_timestamp() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L53)
 
 Get the latest observed timestamp for the current state partition.
 
@@ -3893,7 +3893,7 @@ def expire_windows(duration_ms: int,
                    grace_ms: int = 0) -> List[Tuple[Tuple[int, int], Any]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/windowed/state.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/windowed/state.py#L65)
 
 Get a list of expired windows from RocksDB considering the current
 latest timestamp, window duration and grace period.
@@ -3915,7 +3915,7 @@ calling this method multiple times will yield different results for the same
 class RocksDBOptions(RocksDBOptionsType)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/options.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/options.py#L25)
 
 RocksDB database options.
 
@@ -3960,7 +3960,7 @@ Please see `rocksdict.Options` for a complete description of other options.
 def to_options() -> rocksdict.Options
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/options.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/options.py#L53)
 
 Convert parameters to `rocksdict.Options`
 
@@ -3980,7 +3980,7 @@ instance of `rocksdict.Options`
 class RocksDBStore(Store)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L19)
 
 RocksDB-based state store.
 
@@ -4000,7 +4000,7 @@ def __init__(
         options: Optional[options_type] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L29)
 
 **Arguments**:
 
@@ -4020,7 +4020,7 @@ if using changelogs
 def topic() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L53)
 
 Store topic name
 
@@ -4033,7 +4033,7 @@ Store topic name
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L60)
 
 Store name
 
@@ -4046,7 +4046,7 @@ Store name
 def partitions() -> Dict[int, RocksDBStorePartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L67)
 
 Mapping of assigned store partitions
 
@@ -4058,7 +4058,7 @@ Mapping of assigned store partitions
 def assign_partition(partition: int) -> RocksDBStorePartition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L80)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L80)
 
 Open and assign store partition.
 
@@ -4081,7 +4081,7 @@ instance of`RocksDBStorePartition`
 def revoke_partition(partition: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L115)
 
 Revoke and close the assigned store partition.
 
@@ -4099,7 +4099,7 @@ If the partition is not assigned, it will log the message and return.
 def start_partition_transaction(partition: int) -> RocksDBPartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L136)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L136)
 
 Start a new partition transaction.
 
@@ -4122,7 +4122,7 @@ instance of `RocksDBPartitionTransaction`
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/store.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/store.py#L158)
 
 Close the store and revoke all assigned partitions
 
@@ -4138,7 +4138,7 @@ Close the store and revoke all assigned partitions
 class RocksDBStorePartition(StorePartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L40)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L40)
 
 A base class to access state in RocksDB.
 
@@ -4166,7 +4166,7 @@ it will retry according to `open_max_retries` and `open_retry_backoff` options.
 def begin() -> RocksDBPartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L80)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L80)
 
 Create a new `RocksDBTransaction` object.
 
@@ -4185,7 +4185,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L106)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L106)
 
 Updates state from a given changelog message.
 
@@ -4201,7 +4201,7 @@ Updates state from a given changelog message.
 def set_changelog_offset(changelog_offset: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L130)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L130)
 
 Set the changelog offset based on a message (usually an "offset-only" message).
 
@@ -4221,7 +4221,7 @@ def produce_to_changelog(key: bytes,
                          headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L140)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L140)
 
 Produce a message to the StorePartitions respective changelog.
 
@@ -4233,7 +4233,7 @@ Produce a message to the StorePartitions respective changelog.
 def write(batch: WriteBatch)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L151)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L151)
 
 Write `WriteBatch` to RocksDB
 
@@ -4251,7 +4251,7 @@ def get(key: bytes,
         cf_name: str = "default") -> Union[None, bytes, Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L158)
 
 Get a key from RocksDB.
 
@@ -4273,7 +4273,7 @@ a value if the key is present in the DB. Otherwise, `default`
 def exists(key: bytes, cf_name: str = "default") -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L172)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L172)
 
 Check if a key is present in the DB.
 
@@ -4294,7 +4294,7 @@ Check if a key is present in the DB.
 def get_processed_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L183)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L183)
 
 Get last processed offset for the given partition
 
@@ -4310,7 +4310,7 @@ offset or `None` if there's no processed offset yet
 def get_changelog_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L195)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L195)
 
 Get offset that the changelog is up-to-date with.
 
@@ -4326,7 +4326,7 @@ offset or `None` if there's no processed offset yet
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L205)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L205)
 
 Close the underlying RocksDB
 
@@ -4339,7 +4339,7 @@ Close the underlying RocksDB
 def path() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L220)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L220)
 
 Absolute path to RocksDB database folder
 
@@ -4356,7 +4356,7 @@ file path
 def destroy(cls, path: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L228)
 
 Delete underlying RocksDB database
 
@@ -4374,7 +4374,7 @@ The database must be closed first.
 def get_column_family_handle(cf_name: str) -> ColumnFamily
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L238)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L238)
 
 Get a column family handle to pass to it WriteBatch.
 
@@ -4397,7 +4397,7 @@ instance of `rocksdict.ColumnFamily`
 def get_column_family(cf_name: str) -> Rdict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/partition.py#L259)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/partition.py#L259)
 
 Get a column family instance.
 
@@ -4427,7 +4427,7 @@ instance of `rocksdict.Rdict` for the given column family
 class RocksDBPartitionTransaction(PartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L71)
 
 A transaction class to perform simple key-value operations like
 "get", "set", "delete" and "exists" on a single RocksDB partition.
@@ -4466,7 +4466,7 @@ def __init__(partition: "RocksDBStorePartition", dumps: DumpsFunc,
              loads: LoadsFunc)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L114)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L114)
 
 **Arguments**:
 
@@ -4484,7 +4484,7 @@ the underlying RocksDB
 def with_prefix(prefix: Any = b"") -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L141)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L141)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -4514,7 +4514,7 @@ def get(key: Any,
         cf_name: str = "default") -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L170)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L170)
 
 Get a key from the store.
 
@@ -4543,7 +4543,7 @@ value or `default`
 def set(key: Any, value: Any, cf_name: str = "default")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L205)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L205)
 
 Set a key to the store.
 
@@ -4564,7 +4564,7 @@ It first updates the key in the update cache.
 def delete(key: Any, cf_name: str = "default")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L230)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L230)
 
 Delete a key from the store.
 
@@ -4584,7 +4584,7 @@ It first deletes the key from the update cache.
 def exists(key: Any, cf_name: str = "default") -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L253)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L253)
 
 Check if a key exists in the store.
 
@@ -4608,7 +4608,7 @@ It first looks up the key in the update cache.
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L275)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L275)
 
 Check if the transaction is completed.
 
@@ -4630,7 +4630,7 @@ The completed transaction should not be re-used.
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L289)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L289)
 
 Check if the transaction has failed.
 
@@ -4650,7 +4650,7 @@ and
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/rocksdb/transaction.py#L318)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/rocksdb/transaction.py#L318)
 
 Flush the recent updates to the database and empty the update cache.
 
@@ -4696,7 +4696,7 @@ cannot be used anymore.
 class RecoveryPartition()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L20)
 
 A changelog topic partition mapped to a respective `StorePartition` with helper
 methods to determine its current recovery status.
@@ -4712,7 +4712,7 @@ Since `StorePartition`s do recovery directly, it also handles recovery transacti
 def offset() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L41)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L41)
 
 Get the changelog offset from the underlying `StorePartition`.
 
@@ -4729,7 +4729,7 @@ changelog offset (int)
 def needs_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L50)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L50)
 
 Determine whether recovery is necessary for underlying `StorePartition`.
 
@@ -4742,7 +4742,7 @@ Determine whether recovery is necessary for underlying `StorePartition`.
 def needs_offset_update()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L59)
 
 Determine if an offset update is required.
 
@@ -4756,7 +4756,7 @@ Usually checked during assign if recovery was not required.
 def update_offset()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L67)
 
 Update only the changelog offset of a StorePartition.
 
@@ -4769,7 +4769,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L87)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L87)
 
 Recover the StorePartition using a message read from its respective changelog.
 
@@ -4785,7 +4785,7 @@ Recover the StorePartition using a message read from its respective changelog.
 def set_watermarks(lowwater: int, highwater: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L99)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L99)
 
 Set the changelog watermarks as gathered from Consumer.get_watermark_offsets()
 
@@ -4802,7 +4802,7 @@ Set the changelog watermarks as gathered from Consumer.get_watermark_offsets()
 class ChangelogProducerFactory()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L110)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L110)
 
 Generates ChangelogProducers, which produce changelog messages to a StorePartition.
 
@@ -4814,7 +4814,7 @@ Generates ChangelogProducers, which produce changelog messages to a StorePartiti
 def __init__(changelog_name: str, producer: RowProducer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L115)
 
 **Arguments**:
 
@@ -4833,7 +4833,7 @@ a ChangelogWriter instance
 def get_partition_producer(partition_num)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L125)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L125)
 
 Generate a ChangelogProducer for producing to a specific partition number
 
@@ -4851,7 +4851,7 @@ Generate a ChangelogProducer for producing to a specific partition number
 class ChangelogProducer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L137)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L137)
 
 Generated for a `StorePartition` to produce state changes to its respective
 kafka changelog partition.
@@ -4864,7 +4864,7 @@ kafka changelog partition.
 def __init__(changelog_name: str, partition_num: int, producer: RowProducer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L143)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L143)
 
 **Arguments**:
 
@@ -4882,7 +4882,7 @@ def produce(key: bytes,
             headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L153)
 
 Produce a message to a changelog topic partition.
 
@@ -4900,7 +4900,7 @@ Produce a message to a changelog topic partition.
 class RecoveryManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L178)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L178)
 
 Manages all consumer-related aspects of recovery, including:
     - assigning/revoking, pausing/resuming topic partitions (especially changelogs)
@@ -4920,7 +4920,7 @@ Recovery is attempted from the `Application` after any new partition assignment.
 def has_assignments() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L197)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L197)
 
 Whether the Application has assigned RecoveryPartitions
 
@@ -4937,7 +4937,7 @@ has assignments, as bool
 def recovering() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L206)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L206)
 
 Whether the Application is currently recovering
 
@@ -4953,7 +4953,7 @@ is recovering, as bool
 def register_changelog(topic_name: str, store_name: str, consumer_group: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L214)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L214)
 
 Register a changelog Topic with the TopicManager.
 
@@ -4971,7 +4971,7 @@ Register a changelog Topic with the TopicManager.
 def do_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L228)
 
 If there are any active RecoveryPartitions, do a recovery procedure.
 
@@ -4986,7 +4986,7 @@ def assign_partition(topic_name: str, partition_num: int,
                      store_partitions: Dict[str, StorePartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L274)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L274)
 
 Assigns `StorePartition`s (as `RecoveryPartition`s) ONLY IF recovery required.
 
@@ -5000,7 +5000,7 @@ Pauses active consumer partitions as needed.
 def revoke_partition(partition_num: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/recovery.py#L336)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/recovery.py#L336)
 
 revoke ALL StorePartitions (across all Stores) for a given partition number
 
@@ -5024,7 +5024,7 @@ revoke ALL StorePartitions (across all Stores) for a given partition number
 class Store(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L12)
 
 Abstract state store.
 
@@ -5040,7 +5040,7 @@ partitions' transactions.
 def topic() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L23)
 
 Topic name
 
@@ -5053,7 +5053,7 @@ Topic name
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L29)
 
 Store name
 
@@ -5066,7 +5066,7 @@ Store name
 def partitions() -> Dict[int, "StorePartition"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L35)
 
 Mapping of assigned store partitions
 
@@ -5082,7 +5082,7 @@ dict of "{partition: <StorePartition>}"
 def assign_partition(partition: int) -> "StorePartition"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L42)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L42)
 
 Assign new store partition
 
@@ -5102,7 +5102,7 @@ instance of `StorePartition`
 def revoke_partition(partition: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L51)
 
 Revoke assigned store partition
 
@@ -5119,7 +5119,7 @@ def start_partition_transaction(
         partition: int) -> Optional["PartitionTransaction"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L60)
 
 Start a new partition transaction.
 
@@ -5141,7 +5141,7 @@ instance of `PartitionTransaction`
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L71)
 
 Close store and revoke all store partitions
 
@@ -5153,7 +5153,7 @@ Close store and revoke all store partitions
 class StorePartition(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L83)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L83)
 
 A base class to access state in the underlying storage.
 It represents a single instance of some storage (e.g. a single database for
@@ -5168,7 +5168,7 @@ the persistent storage).
 def path() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L92)
 
 Absolute path to RocksDB database folder
 
@@ -5180,7 +5180,7 @@ Absolute path to RocksDB database folder
 def begin() -> "PartitionTransaction"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L98)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L98)
 
 State new `PartitionTransaction`
 
@@ -5193,7 +5193,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L103)
 
 Updates state from a given changelog message.
 
@@ -5211,7 +5211,7 @@ def produce_to_changelog(key: bytes,
                          headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L113)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L113)
 
 Produce a message to the StorePartitions respective changelog.
 
@@ -5223,7 +5223,7 @@ Produce a message to the StorePartitions respective changelog.
 def get_processed_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L124)
 
 Get last processed offset for the given partition
 
@@ -5239,7 +5239,7 @@ offset or `None` if there's no processed offset yet
 def get_changelog_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L131)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L131)
 
 Get offset that the changelog is up-to-date with.
 
@@ -5255,7 +5255,7 @@ offset or `None` if there's no processed offset yet
 def set_changelog_offset(changelog_offset: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L138)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L138)
 
 Set the changelog offset based on a message (usually an "offset-only" message).
 
@@ -5273,7 +5273,7 @@ Used during recovery.
 class State(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L149)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L149)
 
 Primary interface for working with key-value state data from `StreamingDataFrame`
 
@@ -5285,7 +5285,7 @@ Primary interface for working with key-value state data from `StreamingDataFrame
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L154)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L154)
 
 Get the value for key if key is present in the state, else default
 
@@ -5306,7 +5306,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L163)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L163)
 
 Set value for the key.
 
@@ -5323,7 +5323,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L170)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L170)
 
 Delete value for the key.
 
@@ -5341,7 +5341,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L178)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L178)
 
 Check if the key exists in state.
 
@@ -5361,7 +5361,7 @@ True if key exists, False otherwise
 class PartitionTransaction(State)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L186)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L186)
 
 A transaction class to perform simple key-value operations like
 "get", "set", "delete" and "exists" on a single storage partition.
@@ -5375,7 +5375,7 @@ A transaction class to perform simple key-value operations like
 def state() -> State
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L193)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L193)
 
 An instance of State to be provided to `StreamingDataFrame` functions
 
@@ -5389,7 +5389,7 @@ An instance of State to be provided to `StreamingDataFrame` functions
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L200)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L200)
 
 Return `True` if transaction failed to update data at some point.
 
@@ -5408,7 +5408,7 @@ bool
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L209)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L209)
 
 Return `True` if transaction is completed.
 
@@ -5426,7 +5426,7 @@ bool
 def with_prefix(prefix: Any = b"") -> Iterator[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L218)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L218)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -5449,7 +5449,7 @@ context manager
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L228)
 
 Flush the recent updates and last processed offset to the storage.
 
@@ -5465,7 +5465,7 @@ Flush the recent updates and last processed offset to the storage.
 class WindowedState(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L241)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L241)
 
 A windowed state to be provided into `StreamingDataFrame` window functions.
 
@@ -5479,7 +5479,7 @@ def get_window(start_ms: int,
                default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L246)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L246)
 
 Get the value of the window defined by `start` and `end` timestamps
 
@@ -5503,7 +5503,7 @@ value or None if the key is not found and `default` is not provided
 def update_window(start_ms: int, end_ms: int, value: Any, timestamp_ms: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L259)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L259)
 
 Set a value for the window.
 
@@ -5525,7 +5525,7 @@ using the provided `timestamp`.
 def get_latest_timestamp() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L272)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L272)
 
 Get the latest observed timestamp for the current state partition.
 
@@ -5544,7 +5544,7 @@ latest observed event timestamp in milliseconds
 def expire_windows(duration_ms: int, grace_ms: int = 0)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L282)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L282)
 
 Get a list of expired windows from RocksDB considering the current
 
@@ -5567,7 +5567,7 @@ calling this method multiple times will yield different results for the same
 class WindowedPartitionTransaction(WindowedState)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L296)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L296)
 
 <a id="quixstreams.state.types.WindowedPartitionTransaction.failed"></a>
 
@@ -5578,7 +5578,7 @@ class WindowedPartitionTransaction(WindowedState)
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L302)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L302)
 
 Return `True` if transaction failed to update data at some point.
 
@@ -5597,7 +5597,7 @@ bool
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L311)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L311)
 
 Return `True` if transaction is completed.
 
@@ -5615,7 +5615,7 @@ bool
 def with_prefix(prefix: Any = b"") -> Iterator[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L320)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L320)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -5638,7 +5638,7 @@ context manager
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L330)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L330)
 
 Flush the recent updates and last processed offset to the storage.
 
@@ -5654,7 +5654,7 @@ Flush the recent updates and last processed offset to the storage.
 class PartitionRecoveryTransaction(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L343)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L343)
 
 A class for managing recovery for a StorePartition from a changelog message
 
@@ -5666,7 +5666,7 @@ A class for managing recovery for a StorePartition from a changelog message
 def flush()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/types.py#L351)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/types.py#L351)
 
 Flush the recovery update and last processed offset to the storage.
 
@@ -5686,7 +5686,7 @@ Flush the recovery update and last processed offset to the storage.
 class StateStoreManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L31)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L31)
 
 Class for managing state stores and partitions.
 
@@ -5704,7 +5704,7 @@ StateStoreManager is responsible for:
 def stores() -> Dict[str, Dict[str, Store]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L71)
 
 Map of registered state stores
 
@@ -5721,7 +5721,7 @@ dict in format {topic: {store_name: store}}
 def recovery_required() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L79)
 
 Whether recovery needs to be done.
 
@@ -5734,7 +5734,7 @@ Whether recovery needs to be done.
 def using_changelogs() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L88)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L88)
 
 Whether the StateStoreManager is using changelog topics
 
@@ -5750,7 +5750,7 @@ using changelogs, as bool
 def do_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L96)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L96)
 
 Perform a state recovery, if necessary.
 
@@ -5762,7 +5762,7 @@ Perform a state recovery, if necessary.
 def stop_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L102)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L102)
 
 Stop recovery (called during app shutdown).
 
@@ -5775,7 +5775,7 @@ def get_store(topic: str,
               store_name: str = _DEFAULT_STATE_STORE_NAME) -> Store
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L108)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L108)
 
 Get a store for given name and topic
 
@@ -5797,7 +5797,7 @@ def register_store(topic_name: str,
                    store_name: str = _DEFAULT_STATE_STORE_NAME)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L141)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L141)
 
 Register a state store to be managed by StateStoreManager.
 
@@ -5819,7 +5819,7 @@ Each store can be registered only once for each topic.
 def register_windowed_store(topic_name: str, store_name: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L166)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L166)
 
 Register a windowed state store to be managed by StateStoreManager.
 
@@ -5841,7 +5841,7 @@ Each window store can be registered only once for each topic.
 def clear_stores()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L189)
 
 Delete all state stores managed by StateStoreManager.
 
@@ -5853,7 +5853,7 @@ Delete all state stores managed by StateStoreManager.
 def on_partition_assign(tp: TopicPartition) -> List[StorePartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L204)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L204)
 
 Assign store partitions for each registered store for the given `TopicPartition`
 
@@ -5875,7 +5875,7 @@ list of assigned `StorePartition`
 def on_partition_revoke(tp: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L223)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L223)
 
 Revoke store partitions for each registered store for the given `TopicPartition`
 
@@ -5891,7 +5891,7 @@ Revoke store partitions for each registered store for the given `TopicPartition`
 def on_partition_lost(tp: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L235)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L235)
 
 Revoke and close store partitions for each registered store for the given
 
@@ -5909,7 +5909,7 @@ Revoke and close store partitions for each registered store for the given
 def init()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L244)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L244)
 
 Initialize `StateStoreManager` and create a store directory
 
@@ -5922,7 +5922,7 @@ Initialize `StateStoreManager` and create a store directory
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L251)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L251)
 
 Close all registered stores
 
@@ -5935,7 +5935,7 @@ def get_store_transaction(
         store_name: str = _DEFAULT_STATE_STORE_NAME) -> PartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L259)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L259)
 
 Get active `PartitionTransaction` for the store
 
@@ -5953,7 +5953,7 @@ def start_store_transaction(topic: str, partition: int,
                             offset: int) -> Iterator["_MultiStoreTransaction"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/manager.py#L274)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/manager.py#L274)
 
 Starting the multi-store transaction for the Kafka message.
 
@@ -5982,7 +5982,7 @@ before the end of the current one will fail.
 class TransactionState(State)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L6)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L6)
 
 <a id="quixstreams.state.state.TransactionState.__init__"></a>
 
@@ -5992,7 +5992,7 @@ class TransactionState(State)
 def __init__(transaction: PartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L9)
 
 Simple key-value state to be provided into `StreamingDataFrame` functions
 
@@ -6008,7 +6008,7 @@ Simple key-value state to be provided into `StreamingDataFrame` functions
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L17)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L17)
 
 Get the value for key if key is present in the state, else default
 
@@ -6029,7 +6029,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L27)
 
 Set value for the key.
 
@@ -6046,7 +6046,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L35)
 
 Delete value for the key.
 
@@ -6064,7 +6064,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/state/state.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/state/state.py#L44)
 
 Check if the key exists in state.
 
@@ -6092,7 +6092,7 @@ True if key exists, False otherwise
 class PartitionAssignmentError(QuixException)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/exceptions/assignment.py#L6)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/exceptions/assignment.py#L6)
 
 Error happened during partition rebalancing.
 Raised from `on_assign`, `on_revoke` and `on_lost` callbacks
@@ -6113,7 +6113,7 @@ Raised from `on_assign`, `on_revoke` and `on_lost` callbacks
 def set_message_context(context: Optional[MessageContext])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L22)
 
 Set a MessageContext for the current message in the given `contextvars.Context`
 
@@ -6150,7 +6150,7 @@ sdf = sdf.update(lambda value: alter_context(value))
 def message_context() -> MessageContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L53)
 
 Get a MessageContext for the current message, which houses most of the message
 
@@ -6185,7 +6185,7 @@ instance of `MessageContext`
 def message_key() -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/context.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/context.py#L84)
 
 Get the current message's key.
 
@@ -6221,7 +6221,7 @@ a deserialized message key
 class Producer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/producer.py#L58)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/producer.py#L58)
 
 <a id="quixstreams.kafka.producer.Producer.__init__"></a>
 
@@ -6233,7 +6233,7 @@ def __init__(broker_address: str,
              extra_config: dict = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/producer.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/producer.py#L59)
 
 A wrapper around `confluent_kafka.Producer`.
 
@@ -6269,7 +6269,7 @@ def produce(topic: str,
             buffer_error_max_tries: int = 3)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/producer.py#L98)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/producer.py#L98)
 
 Produce message to topic.
 
@@ -6298,7 +6298,7 @@ Pass `0` to not retry after `BufferError`.
 def poll(timeout: float = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/producer.py#L156)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/producer.py#L156)
 
 Polls the producer for events and calls `on_delivery` callbacks.
 
@@ -6314,7 +6314,7 @@ Polls the producer for events and calls `on_delivery` callbacks.
 def flush(timeout: float = None) -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/producer.py#L163)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/producer.py#L163)
 
 Wait for all messages in the Producer queue to be delivered.
 
@@ -6338,7 +6338,7 @@ number of messages delivered
 class Consumer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L66)
 
 <a id="quixstreams.kafka.consumer.Consumer.__init__"></a>
 
@@ -6355,7 +6355,7 @@ def __init__(broker_address: str,
              extra_config: Optional[dict] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L67)
 
 A wrapper around `confluent_kafka.Consumer`.
 
@@ -6393,7 +6393,7 @@ Note: values passed as arguments override values in `extra_config`.
 def poll(timeout: float = None) -> Optional[Message]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L124)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L124)
 
 Consumes a single message, calls callbacks and returns events.
 
@@ -6428,7 +6428,7 @@ def subscribe(topics: List[str],
               on_lost: Optional[RebalancingCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L143)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L143)
 
 Set subscription to supplied list of topics
 
@@ -6466,7 +6466,7 @@ for example, may fail.
 def unsubscribe()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L237)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L237)
 
 Remove current subscription.
 
@@ -6484,7 +6484,7 @@ def store_offsets(message: Optional[Message] = None,
                   offsets: List[TopicPartition] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L245)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L245)
 
 .. py:function:: store_offsets([message=None], [offsets=None])
 
@@ -6515,7 +6515,7 @@ def commit(message: Message = None,
            asynchronous: bool = True) -> Optional[List[TopicPartition]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L279)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L279)
 
 Commit a message or a list of offsets.
 
@@ -6549,7 +6549,7 @@ def committed(partitions: List[TopicPartition],
               timeout: float = None) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L319)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L319)
 
 .. py:function:: committed(partitions, [timeout=None])
 
@@ -6579,7 +6579,7 @@ def get_watermark_offsets(partition: TopicPartition,
                           cached: bool = False) -> Tuple[int, int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L339)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L339)
 
 Retrieve low and high offsets for the specified partition.
 
@@ -6611,7 +6611,7 @@ def list_topics(topic: Optional[str] = None,
                 timeout: float = -1) -> ClusterMetadata
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L365)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L365)
 
 .. py:function:: list_topics([topic=None], [timeout=-1])
 
@@ -6640,7 +6640,7 @@ or -1 for infinite timeout.
 def memberid() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L386)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L386)
 
 Return this client's broker-assigned group member id.
 
@@ -6661,7 +6661,7 @@ def offsets_for_times(partitions: List[TopicPartition],
                       timeout: float = None) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L399)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L399)
 
 Look up offsets by timestamp for the specified partitions.
 
@@ -6687,7 +6687,7 @@ last message in the partition, a value of -1 will be returned.
 def pause(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L427)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L427)
 
 Pause consumption for the provided list of partitions.
 
@@ -6711,7 +6711,7 @@ Does NOT affect the result of Consumer.assignment().
 def resume(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L441)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L441)
 
 .. py:function:: resume(partitions)
 
@@ -6733,7 +6733,7 @@ Resume consumption for the provided list of partitions.
 def position(partitions: List[TopicPartition]) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L453)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L453)
 
 Retrieve current positions (offsets) for the specified partitions.
 
@@ -6760,7 +6760,7 @@ the last consumed message + 1.
 def seek(partition: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L467)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L467)
 
 Set consume position for partition to offset.
 
@@ -6788,7 +6788,7 @@ pass the offset in an `assign()` call.
 def assignment() -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L484)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L484)
 
 Returns the current partition assignment.
 
@@ -6809,7 +6809,7 @@ Returns the current partition assignment.
 def set_sasl_credentials(username: str, password: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L497)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L497)
 
 Sets the SASL credentials used for this client.
 These credentials will overwrite the old ones, and will be used the next
@@ -6826,7 +6826,7 @@ This method is applicable only to SASL PLAIN and SCRAM mechanisms.
 def incremental_assign(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L509)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L509)
 
 Assign new partitions.
 
@@ -6844,7 +6844,7 @@ Any additional partitions besides the ones passed during the `Consumer`
 def incremental_unassign(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L521)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L521)
 
 Revoke partitions.
 
@@ -6858,7 +6858,7 @@ Can be called outside an on_revoke callback.
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/kafka/consumer.py#L529)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/kafka/consumer.py#L529)
 
 Close down and terminate the Kafka Consumer.
 
@@ -6884,7 +6884,7 @@ see `poll()` for more info.
 class Application()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L52)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L52)
 
 The main Application class.
 
@@ -6948,7 +6948,7 @@ def __init__(broker_address: str,
              topic_manager: Optional[TopicManager] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L91)
 
 **Arguments**:
 
@@ -7025,7 +7025,7 @@ def Quix(cls,
          topic_manager: Optional[QuixTopicManager] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L228)
 
 Initialize an Application to work with Quix platform,
 
@@ -7129,7 +7129,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L386)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L386)
 
 Create a topic definition.
 
@@ -7200,7 +7200,7 @@ topic = app.topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def dataframe(topic: Topic) -> StreamingDataFrame
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L466)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L466)
 
 A simple helper method that generates a `StreamingDataFrame`, which is used
 
@@ -7242,7 +7242,7 @@ to be used as an input topic.
 def stop()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L502)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L502)
 
 Stop the internal poll loop and the message processing.
 
@@ -7260,7 +7260,7 @@ To otherwise stop an application, either send a `SIGTERM` to the process
 def get_producer() -> Producer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L516)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L516)
 
 Create and return a pre-configured Producer instance.
 The Producer is initialized with params passed to Application.
@@ -7291,7 +7291,7 @@ with app.get_producer() as producer:
 def get_consumer() -> Consumer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L547)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L547)
 
 Create and return a pre-configured Consumer instance.
 The Consumer is initialized with params passed to Application.
@@ -7332,7 +7332,7 @@ with app.get_consumer() as consumer:
 def clear_state()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L591)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L591)
 
 Clear the state of the application.
 
@@ -7344,7 +7344,7 @@ Clear the state of the application.
 def run(dataframe: StreamingDataFrame)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/app.py#L670)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/app.py#L670)
 
 Start processing data from Kafka using provided `StreamingDataFrame`
 
@@ -7384,7 +7384,7 @@ app.run(dataframe=df)
 class RowConsumer(Consumer, RowConsumerProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowconsumer.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowconsumer.py#L59)
 
 <a id="quixstreams.rowconsumer.RowConsumer.__init__"></a>
 
@@ -7402,7 +7402,7 @@ def __init__(broker_address: str,
              on_error: Optional[ConsumerErrorCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowconsumer.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowconsumer.py#L60)
 
 A consumer class that is capable of deserializing Kafka messages to Rows
 
@@ -7446,7 +7446,7 @@ def subscribe(topics: List[Topic],
               on_lost: Optional[RebalancingCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowconsumer.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowconsumer.py#L115)
 
 Set subscription to supplied list of topics.
 
@@ -7475,7 +7475,7 @@ for example, may fail.
 def poll_row(timeout: float = None) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/rowconsumer.py#L149)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/rowconsumer.py#L149)
 
 Consumes a single message and deserialize it to Row or a list of Rows.
 

--- a/docs/api-reference/topics-serdes.md
+++ b/docs/api-reference/topics-serdes.md
@@ -14,7 +14,7 @@
 class QuixDeserializer(JSONDeserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L70)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L70)
 
 Handles Deserialization for any Quix-formatted topic.
 
@@ -31,7 +31,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L77)
 
 
 <br>
@@ -53,7 +53,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L97)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L97)
 
 Each Quix message might contain data for multiple Rows.
 This property informs the downstream processors about that, so they can
@@ -70,7 +70,7 @@ def deserialize(model_key: str, value: Union[List[Mapping],
                                              Mapping]) -> Iterable[Mapping]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L150)
 
 Deserialization function for particular data types (Timeseries or EventData).
 
@@ -95,7 +95,7 @@ Iterable of dicts
 class QuixTimeseriesSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L315)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L315)
 
 Serialize data to JSON formatted according to Quix Timeseries format.
 
@@ -127,7 +127,7 @@ Output:
 class QuixEventsSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/quix.py#L403)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/quix.py#L403)
 
 Serialize data to JSON formatted according to Quix EventData format.
 The input value is expected to be a dictionary with the following keys:
@@ -168,7 +168,7 @@ Output:
 class BytesDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L44)
 
 A deserializer to bypass bytes without any changes
 
@@ -180,7 +180,7 @@ A deserializer to bypass bytes without any changes
 class BytesSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L55)
 
 A serializer to bypass bytes without any changes
 
@@ -192,7 +192,7 @@ A serializer to bypass bytes without any changes
 class StringDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L64)
 
 <a id="quixstreams.models.serializers.simple_types.StringDeserializer.__init__"></a>
 
@@ -204,7 +204,7 @@ class StringDeserializer(Deserializer)
 def __init__(column_name: Optional[str] = None, codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L65)
 
 Deserializes bytes to strings using the specified encoding.
 
@@ -223,7 +223,7 @@ A wrapper around `confluent_kafka.serialization.StringDeserializer`.
 class IntegerDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L84)
 
 Deserializes bytes to integers.
 
@@ -237,7 +237,7 @@ A wrapper around `confluent_kafka.serialization.IntegerDeserializer`.
 class DoubleDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L103)
 
 Deserializes float to IEEE 764 binary64.
 
@@ -251,7 +251,7 @@ A wrapper around `confluent_kafka.serialization.DoubleDeserializer`.
 class StringSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L122)
 
 <a id="quixstreams.models.serializers.simple_types.StringSerializer.__init__"></a>
 
@@ -263,7 +263,7 @@ class StringSerializer(Serializer)
 def __init__(codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L123)
 
 Serializes strings to bytes using the specified encoding.
 
@@ -281,7 +281,7 @@ Serializes strings to bytes using the specified encoding.
 class IntegerSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L135)
 
 Serializes integers to bytes
 
@@ -293,7 +293,7 @@ Serializes integers to bytes
 class DoubleSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/20c0122af530d72f624e2aa3b1359ac1c1afe265/quixstreams/models/serializers/simple_types.py#L148)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/f9167c5cce85007d874c522a955847ea13e9d200/quixstreams/models/serializers/simple_types.py#L148)
 
 Serializes floats to bytes
 

--- a/docs/quix-platform.md
+++ b/docs/quix-platform.md
@@ -31,11 +31,10 @@ format, but Quix Platform provides additional features on top of this format in 
 
 You may connect to Quix Platform locally too (e.g. while developing the application on your machine).
 <br>
-To do that, you will need to set the following environment variables:
+To do that, you will need to set the following environment variable:
 
 ```
 Quix__Sdk__Token
-Quix__Portal__Api
 ```
 
 You can find these values on the platform in your Workspace settings.

--- a/docs/windowing.md
+++ b/docs/windowing.md
@@ -190,7 +190,8 @@ topic = app.topic("input-topic", timestamp_extractor=custom_ts_extractor)
 Here are some general concepts about how windowed aggregations are implemented in Quix Streams:
 
 - Only time-based windows are supported. 
-- Every window is grouped by the current Kafka message key. 
+- Every window is grouped by the current Kafka message key.
+- Messages with `None` key will be ignored.
 - The minimal window unit is a **millisecond**. More fine-grained values (e.g. microseconds) will be rounded towards the closest millisecond number.
 
 

--- a/examples/bank_example/json_version/consumer.py
+++ b/examples/bank_example/json_version/consumer.py
@@ -21,6 +21,7 @@ def count_transactions(value: dict, state: State):
     :param value: message value
     :param state: instance of State store
     """
+    state = {}
     total = state.get("total_transactions", 0)
     total += 1
     state.set("total_transactions", total)

--- a/examples/bank_example/quix_platform_version/quix_vars.env
+++ b/examples/bank_example/quix_platform_version/quix_vars.env
@@ -1,7 +1,7 @@
 # Required - will always be defined by default in a Quix platform workspace.
 Quix__Sdk__Token=
-Quix__Portal__Api=
 
 # Optional; can usually be found by the library automatically via the quix auth token.
 # It will always be defined by default in a Quix platform workspace.
 Quix__Workspace_Id=
+Quix__Portal__Api=

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -205,20 +205,24 @@ class Application:
             group_id=consumer_group,
             state_dir=state_dir,
             rocksdb_options=rocksdb_options,
-            producer=RowProducer(
-                broker_address=broker_address,
-                partitioner=partitioner,
-                extra_config=producer_extra_config,
-                on_error=on_producer_error,
-            )
-            if use_changelog_topics
-            else None,
-            recovery_manager=RecoveryManager(
-                consumer=self._consumer,
-                topic_manager=self._topic_manager,
-            )
-            if use_changelog_topics
-            else None,
+            producer=(
+                RowProducer(
+                    broker_address=broker_address,
+                    partitioner=partitioner,
+                    extra_config=producer_extra_config,
+                    on_error=on_producer_error,
+                )
+                if use_changelog_topics
+                else None
+            ),
+            recovery_manager=(
+                RecoveryManager(
+                    consumer=self._consumer,
+                    topic_manager=self._topic_manager,
+                )
+                if use_changelog_topics
+                else None
+            ),
         )
 
     def _set_quix_config_builder(self, config_builder: QuixKafkaConfigsBuilder):

--- a/quixstreams/core/stream/stream.py
+++ b/quixstreams/core/stream/stream.py
@@ -1,6 +1,6 @@
 import copy
 import itertools
-from typing import List, Callable, Optional, TypeVar
+from typing import List, Callable, Optional, TypeVar, Any
 
 from typing_extensions import Self
 

--- a/quixstreams/dataframe/__init__.py
+++ b/quixstreams/dataframe/__init__.py
@@ -1,2 +1,3 @@
 from .dataframe import StreamingDataFrame
+from .exceptions import *
 from .series import *

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import contextvars
 import functools
 import operator
 from datetime import timedelta
-from typing import Optional, Callable, Union, List, TypeVar, Any
+from typing import Optional, Callable, Union, List, TypeVar, Any, overload
 
 from typing_extensions import Self
 
@@ -344,7 +346,7 @@ class StreamingDataFrame(BaseStreaming):
     def tumbling_window(
         self,
         duration_ms: Union[int, timedelta],
-        grace_ms: Optional[Union[int, timedelta]] = 0,
+        grace_ms: Union[int, timedelta] = 0,
         name: Optional[str] = None,
     ) -> TumblingWindowDefinition:
         """
@@ -414,7 +416,7 @@ class StreamingDataFrame(BaseStreaming):
         self,
         duration_ms: Union[int, timedelta],
         step_ms: Union[int, timedelta],
-        grace_ms: Optional[Union[int, timedelta]] = 0,
+        grace_ms: Union[int, timedelta] = 0,
         name: Optional[str] = None,
     ) -> HoppingWindowDefinition:
         """
@@ -535,6 +537,14 @@ class StreamingDataFrame(BaseStreaming):
         else:
             stream = self.stream.add_update(lambda v: operator.setitem(v, key, value))
         self._stream = stream
+
+    @overload
+    def __getitem__(self, item: str) -> StreamingSeries:
+        ...
+
+    @overload
+    def __getitem__(self, item: Union[StreamingSeries, List[str], Self]) -> Self:
+        ...
 
     def __getitem__(
         self, item: Union[str, List[str], StreamingSeries, Self]

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -18,6 +18,7 @@ from quixstreams.models import Topic, Row, MessageContext
 from quixstreams.rowproducer import RowProducerProto
 from quixstreams.state import StateStoreManager, State
 from .base import BaseStreaming
+from .exceptions import InvalidOperation
 from .series import StreamingSeries
 from .utils import ensure_milliseconds
 from .windows import TumblingWindowDefinition, HoppingWindowDefinition
@@ -97,6 +98,13 @@ class StreamingDataFrame(BaseStreaming):
     @property
     def state_manager(self) -> StateStoreManager:
         return self._state_manager
+
+    def __bool__(self):
+        raise InvalidOperation(
+            f"Cannot assess truth level of a {self.__class__.__name__} "
+            f"using 'bool()' or any operations that rely on it; "
+            f"use '&' or '|' for logical and/or comparisons"
+        )
 
     def apply(
         self,

--- a/quixstreams/dataframe/exceptions.py
+++ b/quixstreams/dataframe/exceptions.py
@@ -1,0 +1,8 @@
+from quixstreams.exceptions.base import QuixException
+
+
+__all__ = ("InvalidOperation",)
+
+
+class InvalidOperation(QuixException):
+    ...

--- a/quixstreams/dataframe/series.py
+++ b/quixstreams/dataframe/series.py
@@ -9,6 +9,7 @@ from quixstreams.core.stream.functions import StreamCallable, ApplyFunction
 from quixstreams.core.stream.stream import Stream
 from quixstreams.models.messagecontext import MessageContext
 from .base import BaseStreaming
+from .exceptions import InvalidOperation
 
 __all__ = ("StreamingSeries",)
 
@@ -369,6 +370,13 @@ class StreamingSeries(BaseStreaming):
         :return: new StreamingSeries
         """
         return self.apply(func=lambda v: abs(v))
+
+    def __bool__(self):
+        raise InvalidOperation(
+            f"Cannot assess truth level of a {self.__class__.__name__} "
+            f"using 'bool()' or any operations that rely on it; "
+            f"use '&' or '|' for logical and/or comparisons"
+        )
 
     def __getitem__(self, item: Union[str, int]) -> Self:
         return self._operation(item, operator.getitem)

--- a/quixstreams/dataframe/series.py
+++ b/quixstreams/dataframe/series.py
@@ -1,6 +1,6 @@
 import contextvars
 import operator
-from typing import Optional, Union, Callable, Container, Any
+from typing import Optional, Union, Callable, Container, Any, Mapping, overload
 
 from typing_extensions import Self
 
@@ -186,7 +186,12 @@ class StreamingSeries(BaseStreaming):
         return context.run(composed, value)
 
     def _operation(
-        self, other: Union[Self, object], operator_: Callable[[object, object], object]
+        self,
+        other: Union[Self, str, int, object],
+        operator_: Callable[
+            [Union[Self, Container, Mapping, object], Union[Self, str, int, object]],
+            Union[bool, object],
+        ],
     ) -> Self:
         self_composed = self.compose()
         if isinstance(other, self.__class__):
@@ -226,7 +231,7 @@ class StreamingSeries(BaseStreaming):
             other, lambda a, b, contains=operator.contains: contains(b, a)
         )
 
-    def contains(self, other: object) -> Self:
+    def contains(self, other: Union[Self, object]) -> Self:
         """
         Check if series value contains "other"
         Same as "other in StreamingSeries".
@@ -251,7 +256,7 @@ class StreamingSeries(BaseStreaming):
         """
         return self._operation(other, operator.contains)
 
-    def is_(self, other: object) -> Self:
+    def is_(self, other: Union[Self, object]) -> Self:
         """
         Check if series value refers to the same object as `other`
 
@@ -274,7 +279,7 @@ class StreamingSeries(BaseStreaming):
         """
         return self._operation(other, operator.is_)
 
-    def isnot(self, other: object) -> Self:
+    def isnot(self, other: Union[Self, object]) -> Self:
         """
         Check if series value does not refer to the same object as `other`
 
@@ -368,40 +373,40 @@ class StreamingSeries(BaseStreaming):
     def __getitem__(self, item: Union[str, int]) -> Self:
         return self._operation(item, operator.getitem)
 
-    def __mod__(self, other: object) -> Self:
+    def __mod__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.mod)
 
-    def __add__(self, other: object) -> Self:
+    def __add__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.add)
 
-    def __sub__(self, other: object) -> Self:
+    def __sub__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.sub)
 
-    def __mul__(self, other: object) -> Self:
+    def __mul__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.mul)
 
-    def __truediv__(self, other: object) -> Self:
+    def __truediv__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.truediv)
 
-    def __eq__(self, other: object) -> Self:
+    def __eq__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.eq)
 
-    def __ne__(self, other: object) -> Self:
+    def __ne__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.ne)
 
-    def __lt__(self, other: object) -> Self:
+    def __lt__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.lt)
 
-    def __le__(self, other: object) -> Self:
+    def __le__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.le)
 
-    def __gt__(self, other: object) -> Self:
+    def __gt__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.gt)
 
-    def __ge__(self, other: object) -> Self:
+    def __ge__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.ge)
 
-    def __and__(self, other: object) -> Self:
+    def __and__(self, other: Union[Self, object]) -> Self:
         """
         Do a logical "and" comparison.
 
@@ -422,7 +427,7 @@ class StreamingSeries(BaseStreaming):
         else:
             return self.from_func(func=lambda v: self_composed(v) and other)
 
-    def __or__(self, other: object) -> Self:
+    def __or__(self, other: Union[Self, object]) -> Self:
         """
         Do a logical "or" comparison.
 

--- a/quixstreams/dataframe/windows/definitions.py
+++ b/quixstreams/dataframe/windows/definitions.py
@@ -184,7 +184,7 @@ class FixedTimeWindowDefinition(abc.ABC):
             (the accumulated value and a new value) and returns a single value.
             The returned value will be saved to the state store and sent downstream.
         :param initializer: A function to call for every first element of the window.
-            This function is used to initialize the aggreation within a window.
+            This function is used to initialize the aggregation within a window.
 
         :return: A window configured to perform custom reduce aggregation on the data.
         """

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -1,6 +1,6 @@
 import logging
 import functools
-from typing import Any, Optional, List, TYPE_CHECKING, cast
+from typing import Any, Optional, List, TYPE_CHECKING, cast, Tuple
 
 from quixstreams.context import (
     message_context,
@@ -57,7 +57,7 @@ class FixedTimeWindow:
 
     def process_window(
         self, value: Any, state: WindowedState, timestamp_ms: int
-    ) -> (List[WindowResult], List[WindowResult]):
+    ) -> Tuple[List[WindowResult], List[WindowResult]]:
         duration_ms = self._duration_ms
         grace_ms = self._grace_ms
 

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -1,3 +1,4 @@
+import logging
 import functools
 from typing import Any, Optional, List, TYPE_CHECKING, cast
 
@@ -20,6 +21,8 @@ from .base import (
 
 if TYPE_CHECKING:
     from quixstreams.dataframe.dataframe import StreamingDataFrame, DataFrameFunc
+
+logger = logging.getLogger(__name__)
 
 
 def _default_merge_func(state_value: Any) -> Any:
@@ -180,6 +183,16 @@ class FixedTimeWindow:
         return self._dataframe.apply(func=func, expand=expand)
 
 
+def _noop() -> None:
+    """
+    No-operation function for skipping messages due to None keys.
+
+    Messages with None keys are ignored because keys are essential for performing
+    accurate and meaningful windowed aggregation.
+    """
+    return []
+
+
 def _as_windowed(
     func: WindowedDataFrameFunc, state_manager: StateStoreManager, store_name: str
 ) -> "DataFrameFunc":
@@ -189,7 +202,16 @@ def _as_windowed(
             WindowedPartitionTransaction,
             state_manager.get_store_transaction(store_name=store_name),
         )
+
         key = message_key()
+        if not key:
+            ctx = message_context()
+            logger.warning(
+                f"Skipping window processing for a message because the key is None."
+                f"Message offset: {ctx.offset}, partition: {ctx.partition}."
+            )
+            return _noop()
+
         with transaction.with_prefix(prefix=key):
             return func(value, transaction.state)
 

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -207,7 +207,7 @@ def _as_windowed(
         if not key:
             ctx = message_context()
             logger.warning(
-                f"Skipping window processing for a message because the key is None."
+                f"Skipping window processing for a message because the key is None. "
                 f"Message offset: {ctx.offset}, partition: {ctx.partition}."
             )
             return _noop()

--- a/quixstreams/models/messagecontext.py
+++ b/quixstreams/models/messagecontext.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, Union, Mapping
 
-from .messages import MessageHeadersTuples
+from .types import MessageHeadersTuples
 from .timestamps import MessageTimestamp
 
 

--- a/quixstreams/models/messages.py
+++ b/quixstreams/models/messages.py
@@ -1,10 +1,9 @@
-from typing import Optional, Union
+from typing import Optional
 
 from .types import (
+    Headers,
     MessageKey,
     MessageValue,
-    MessageHeadersTuples,
-    MessageHeadersMapping,
 )
 
 
@@ -15,7 +14,7 @@ class KafkaMessage:
         self,
         key: Optional[MessageKey],
         value: Optional[MessageValue],
-        headers: Optional[Union[MessageHeadersTuples, MessageHeadersMapping]],
+        headers: Optional[Headers],
         timestamp: Optional[int] = None,
     ):
         self.key = key

--- a/quixstreams/models/rows.py
+++ b/quixstreams/models/rows.py
@@ -3,9 +3,9 @@ from typing import Optional, Union, List, Any, KeysView, ValuesView, ItemsView, 
 
 from typing_extensions import Self
 
-from .messages import MessageHeadersTuples
-from .timestamps import MessageTimestamp
 from .messagecontext import MessageContext
+from .timestamps import MessageTimestamp
+from .types import MessageHeadersTuples
 
 
 class Row:

--- a/quixstreams/models/serializers/base.py
+++ b/quixstreams/models/serializers/base.py
@@ -91,7 +91,7 @@ class Serializer(abc.ABC):
         return {}
 
     @abc.abstractmethod
-    def __call__(self, *args, **kwargs) -> bytes:
+    def __call__(self, *args, **kwargs) -> Union[str, bytes]:
         ...
 
 

--- a/quixstreams/models/serializers/quix.py
+++ b/quixstreams/models/serializers/quix.py
@@ -1,10 +1,10 @@
 import base64
-from typing import List, Mapping, Iterable, Optional, Union, Tuple, Any, Callable
+from typing import List, Mapping, Iterable, Optional, Union, Tuple, Any, Callable, Dict
 
 from .base import SerializationContext
 from .exceptions import SerializationError, IgnoreMessage
 from .json import JSONDeserializer, JSONSerializer
-from ..types import MessageHeadersMapping
+from quixstreams.models.types import MessageHeadersMapping
 from quixstreams.utils.json import (
     dumps as default_dumps,
     loads as default_loads,
@@ -253,9 +253,7 @@ class QuixDeserializer(JSONDeserializer):
         except AttributeError:
             return False
 
-    def _parse_legacy_format(
-        self, value: bytes
-    ) -> Tuple[Union[Mapping, List[Mapping]], Mapping]:
+    def _parse_legacy_format(self, value: bytes) -> Tuple[Mapping, Mapping]:
         value = self._loads(value)
         headers = {
             QCodecId.HEADER_NAME: value.pop(LegacyHeaders.Q_CODEC_ID),
@@ -266,8 +264,8 @@ class QuixDeserializer(JSONDeserializer):
 
 
 class QuixSerializer(JSONSerializer):
-    _legacy = {}
-    _extra_headers = {}
+    _legacy: Dict[str, str] = {}
+    _extra_headers: Dict[str, str] = {}
 
     def __init__(
         self,

--- a/quixstreams/models/timestamps.py
+++ b/quixstreams/models/timestamps.py
@@ -1,5 +1,4 @@
 import enum
-from typing import Optional
 
 from typing_extensions import Self
 
@@ -24,7 +23,7 @@ class MessageTimestamp:
 
     def __init__(
         self,
-        milliseconds: Optional[int],
+        milliseconds: int,
         type: TimestampType,
     ):
         self._milliseconds = milliseconds

--- a/quixstreams/models/topics/admin.py
+++ b/quixstreams/models/topics/admin.py
@@ -103,13 +103,17 @@ class TopicAdmin:
             for config_resource, config in futures_dict.items()
         }
         return {
-            topic: TopicConfig(
-                num_partitions=len(cluster_topics[topic].partitions),
-                replication_factor=len(cluster_topics[topic].partitions[0].replicas),
-                extra_config=configs[topic],
+            topic: (
+                TopicConfig(
+                    num_partitions=len(cluster_topics[topic].partitions),
+                    replication_factor=len(
+                        cluster_topics[topic].partitions[0].replicas
+                    ),
+                    extra_config=configs[topic],
+                )
+                if topic in existing_topics
+                else None
             )
-            if topic in existing_topics
-            else None
             for topic in topic_names
         }
 

--- a/quixstreams/models/types.py
+++ b/quixstreams/models/types.py
@@ -3,8 +3,10 @@ from typing_extensions import Protocol
 
 MessageKey = Union[str, bytes]
 MessageValue = Union[str, bytes]
-MessageHeadersTuples = List[Tuple[str, bytes]]
-MessageHeadersMapping = Mapping[str, Union[str, bytes, None]]
+HeaderValue = Optional[Union[str, bytes]]
+MessageHeadersTuples = List[Tuple[str, HeaderValue]]
+MessageHeadersMapping = Mapping[str, HeaderValue]
+Headers = Union[MessageHeadersTuples, MessageHeadersMapping]
 
 
 class ConfluentKafkaMessageProto(Protocol):
@@ -18,10 +20,10 @@ class ConfluentKafkaMessageProto(Protocol):
 
     """
 
-    def headers(self, *args, **kwargs) -> Optional[List[Tuple[str, bytes]]]:
+    def headers(self, *args, **kwargs) -> Optional[MessageHeadersTuples]:
         ...
 
-    def key(self, *args, **kwargs) -> Optional[Union[str, bytes]]:
+    def key(self, *args, **kwargs) -> Optional[MessageKey]:
         ...
 
     def offset(self, *args, **kwargs) -> int:
@@ -30,13 +32,13 @@ class ConfluentKafkaMessageProto(Protocol):
     def partition(self, *args, **kwargs) -> int:
         ...
 
-    def timestamp(self, *args, **kwargs) -> (int, int):
+    def timestamp(self, *args, **kwargs) -> Tuple[int, int]:
         ...
 
     def topic(self, *args, **kwargs) -> str:
         ...
 
-    def value(self, *args, **kwargs) -> Optional[Union[str, bytes]]:
+    def value(self, *args, **kwargs) -> Optional[MessageValue]:
         ...
 
     def latency(self, *args, **kwargs) -> Optional[float]:

--- a/quixstreams/platforms/quix/api.py
+++ b/quixstreams/platforms/quix/api.py
@@ -9,6 +9,7 @@ from quixstreams.exceptions import QuixException
 from .env import QUIX_ENVIRONMENT
 
 __all__ = ("QuixPortalApiService",)
+DEFAULT_PORTAL_API_URL = "https://portal-api.platform.quix.io/"
 
 
 class QuixPortalApiService:
@@ -32,7 +33,9 @@ class QuixPortalApiService:
         api_version: Optional[str] = None,
         default_workspace_id: Optional[str] = None,
     ):
-        self._portal_api = portal_api or QUIX_ENVIRONMENT.portal_api
+        self._portal_api = (
+            portal_api or QUIX_ENVIRONMENT.portal_api or DEFAULT_PORTAL_API_URL
+        )
         self._auth_token = auth_token or QUIX_ENVIRONMENT.sdk_token
         self._default_workspace_id = (
             default_workspace_id or QUIX_ENVIRONMENT.workspace_id

--- a/quixstreams/platforms/quix/config.py
+++ b/quixstreams/platforms/quix/config.py
@@ -312,7 +312,7 @@ class QuixKafkaConfigsBuilder:
         """
         The actual API call to create the topic
 
-        :param topic: a TopicConfig instance
+        :param topic: a Topic instance
         """
         topic_name = self.strip_workspace_id_prefix(topic.name)
         cfg = topic.config

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -1,10 +1,11 @@
 import logging
 import time
-from typing import Any, Union, Optional, List
+from typing import Any, Union, Optional, List, Dict
 
 from rocksdict import WriteBatch, Rdict, ColumnFamily, AccessType
 
 from quixstreams.models import ConfluentKafkaMessageProto
+from quixstreams.state.recovery import ChangelogProducer
 from quixstreams.models.types import MessageHeadersMapping
 from quixstreams.state.types import (
     StorePartition,
@@ -29,7 +30,6 @@ from .transaction import (
     RocksDBPartitionTransaction,
 )
 from .types import RocksDBOptionsType
-from ..recovery import ChangelogProducer
 
 __all__ = ("RocksDBStorePartition",)
 
@@ -69,8 +69,8 @@ class RocksDBStorePartition(StorePartition):
         self._open_max_retries = self._options.open_max_retries
         self._open_retry_backoff = self._options.open_retry_backoff
         self._db = self._init_rocksdb()
-        self._cf_cache = {}
-        self._cf_handle_cache = {}
+        self._cf_cache: Dict[str, Rdict] = {}
+        self._cf_handle_cache: Dict[str, ColumnFamily] = {}
         self._changelog_producer = changelog_producer
 
     @property

--- a/quixstreams/state/rocksdb/store.py
+++ b/quixstreams/state/rocksdb/store.py
@@ -98,9 +98,11 @@ class RocksDBStore(Store):
         path = str((self._partitions_dir / str(partition)).absolute())
         store_partition = self.create_new_partition(
             path,
-            self._changelog_producer_factory.get_partition_producer(partition)
-            if self._changelog_producer_factory
-            else None,
+            (
+                self._changelog_producer_factory.get_partition_producer(partition)
+                if self._changelog_producer_factory
+                else None
+            ),
         )
 
         self._partitions[partition] = store_partition

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -1,3 +1,5 @@
+import contextlib
+
 from typing import Protocol, Any, Optional, Iterator, Callable, Dict, ClassVar
 
 from typing_extensions import Self
@@ -24,12 +26,14 @@ class Store(Protocol):
         """
         Topic name
         """
+        ...
 
     @property
     def name(self) -> str:
         """
         Store name
         """
+        ...
 
     @property
     def partitions(self) -> Dict[int, "StorePartition"]:
@@ -54,7 +58,6 @@ class Store(Protocol):
 
         :param partition: partition number
         """
-
         ...
 
     def start_partition_transaction(
@@ -72,6 +75,7 @@ class Store(Protocol):
         """
         Close store and revoke all store partitions
         """
+        ...
 
     def __enter__(self):
         ...
@@ -159,6 +163,7 @@ class State(Protocol):
         :param default: default value to return if the key is not found
         :return: value or None if the key is not found and `default` is not provided
         """
+        ...
 
     def set(self, key: Any, value: Any):
         """
@@ -166,6 +171,7 @@ class State(Protocol):
         :param key: key
         :param value: value
         """
+        ...
 
     def delete(self, key: Any):
         """
@@ -174,6 +180,7 @@ class State(Protocol):
         This function always returns `None`, even if value is not found.
         :param key: key
         """
+        ...
 
     def exists(self, key: Any) -> bool:
         """
@@ -181,6 +188,7 @@ class State(Protocol):
         :param key: key
         :return: True if key exists, False otherwise
         """
+        ...
 
 
 class PartitionTransaction(State):
@@ -195,6 +203,7 @@ class PartitionTransaction(State):
         An instance of State to be provided to `StreamingDataFrame` functions
         :return:
         """
+        ...
 
     @property
     def failed(self) -> bool:
@@ -204,6 +213,7 @@ class PartitionTransaction(State):
         Failed transactions cannot be re-used.
         :return: bool
         """
+        ...
 
     @property
     def completed(self) -> bool:
@@ -215,6 +225,7 @@ class PartitionTransaction(State):
         """
         ...
 
+    @contextlib.contextmanager
     def with_prefix(self, prefix: Any = b"") -> Iterator[Self]:
         """
         A context manager set the prefix for all keys in the scope.
@@ -224,6 +235,7 @@ class PartitionTransaction(State):
         :param prefix: key prefix
         :return: context manager
         """
+        ...
 
     def maybe_flush(self, offset: Optional[int] = None):
         """
@@ -255,6 +267,7 @@ class WindowedState(Protocol):
         :param default: default value to return if the key is not found
         :return: value or None if the key is not found and `default` is not provided
         """
+        ...
 
     def update_window(self, start_ms: int, end_ms: int, value: Any, timestamp_ms: int):
         """
@@ -268,6 +281,7 @@ class WindowedState(Protocol):
         :param value: value of the window
         :param timestamp_ms: current message timestamp in milliseconds
         """
+        ...
 
     def get_latest_timestamp(self) -> int:
         """
@@ -278,6 +292,7 @@ class WindowedState(Protocol):
 
         :return: latest observed event timestamp in milliseconds
         """
+        ...
 
     def expire_windows(self, duration_ms: int, grace_ms: int = 0):
         """
@@ -291,6 +306,7 @@ class WindowedState(Protocol):
         :param duration_ms: duration of the windows in milliseconds
         :param grace_ms: grace period in milliseconds. Default - "0"
         """
+        ...
 
 
 class WindowedPartitionTransaction(WindowedState):
@@ -306,6 +322,7 @@ class WindowedPartitionTransaction(WindowedState):
         Failed transactions cannot be re-used.
         :return: bool
         """
+        ...
 
     @property
     def completed(self) -> bool:
@@ -326,6 +343,7 @@ class WindowedPartitionTransaction(WindowedState):
         :param prefix: key prefix
         :return: context manager
         """
+        ...
 
     def maybe_flush(self, offset: Optional[int] = None):
         """

--- a/tests/test_quixstreams/fixtures.py
+++ b/tests/test_quixstreams/fixtures.py
@@ -35,7 +35,13 @@ from quixstreams.models.timestamps import (
     TimestampType,
     MessageTimestamp,
 )
-from quixstreams.models.topics import Topic, TopicManager, TopicAdmin
+from quixstreams.models.topics import (
+    Topic,
+    TopicManager,
+    TopicAdmin,
+    TopicConfig,
+    TimestampExtractor,
+)
 from quixstreams.platforms.quix import QuixTopicManager
 from quixstreams.platforms.quix.config import (
     QuixKafkaConfigsBuilder,
@@ -165,6 +171,7 @@ def topic_json_serdes_factory(topic_factory):
             topic_name = uuid.uuid4()
         return Topic(
             name=topic or topic_name,
+            config=TopicConfig(num_partitions=num_partitions, replication_factor=1),
             value_deserializer=JSONDeserializer(),
             value_serializer=JSONSerializer(),
         )
@@ -356,11 +363,11 @@ def quix_mock_config_builder_factory(kafka_container):
         }
         # Slight change to ws stuff in case you pass a blank workspace (which makes
         #  some things easier
-        cfg_builder.prepend_workspace_id.side_effect = (
-            lambda s: prepend_workspace_id(workspace_id, s) if workspace_id else s
+        cfg_builder.prepend_workspace_id.side_effect = lambda s: (
+            prepend_workspace_id(workspace_id, s) if workspace_id else s
         )
-        cfg_builder.strip_workspace_id_prefix.side_effect = (
-            lambda s: strip_workspace_id_prefix(workspace_id, s) if workspace_id else s
+        cfg_builder.strip_workspace_id_prefix.side_effect = lambda s: (
+            strip_workspace_id_prefix(workspace_id, s) if workspace_id else s
         )
         return cfg_builder
 
@@ -488,11 +495,12 @@ def topic_manager_topic_factory(topic_manager_factory):
     def factory(
         name: Optional[str] = str(uuid.uuid4()),
         partitions: int = 1,
-        create_topic: bool = True,
+        create_topic: bool = False,
         key_serializer: Optional[Union[Serializer, str]] = None,
         value_serializer: Optional[Union[Serializer, str]] = None,
         key_deserializer: Optional[Union[Deserializer, str]] = None,
         value_deserializer: Optional[Union[Deserializer, str]] = None,
+        timestamp_extractor: Optional[TimestampExtractor] = None,
     ):
         topic_manager = topic_manager_factory()
         topic_args = {
@@ -501,6 +509,7 @@ def topic_manager_topic_factory(topic_manager_factory):
             "key_deserializer": key_deserializer,
             "value_deserializer": value_deserializer,
             "config": topic_manager.topic_config(num_partitions=partitions),
+            "timestamp_extractor": timestamp_extractor,
         }
         topic = topic_manager.topic(
             name, **{k: v for k, v in topic_args.items() if v is not None}

--- a/tests/test_quixstreams/test_app.py
+++ b/tests/test_quixstreams/test_app.py
@@ -9,6 +9,7 @@ import pytest
 from confluent_kafka import KafkaException, TopicPartition
 
 from quixstreams.app import Application
+from quixstreams.dataframe import StreamingDataFrame
 from quixstreams.dataframe.windows.base import get_window_ranges
 from quixstreams.models import (
     DoubleDeserializer,
@@ -352,7 +353,7 @@ class TestApplication:
         app = Application(broker_address="localhost", consumer_group="test")
         topic = app.topic(name="test-topic")
         sdf = app.dataframe(topic)
-        assert sdf
+        assert isinstance(sdf, StreamingDataFrame)
 
     def test_topic_auto_create_true(self, app_factory):
         """

--- a/tests/test_quixstreams/test_dataframe/fixtures.py
+++ b/tests/test_quixstreams/test_dataframe/fixtures.py
@@ -9,13 +9,13 @@ from quixstreams.state import StateStoreManager
 
 
 @pytest.fixture()
-def dataframe_factory():
+def dataframe_factory(topic_manager_topic_factory):
     def factory(
         topic: Optional[Topic] = None,
         state_manager: Optional[StateStoreManager] = None,
     ) -> StreamingDataFrame:
         return StreamingDataFrame(
-            topic=topic or Topic(name="test"),
+            topic=topic or topic_manager_topic_factory("test"),
             state_manager=state_manager or MagicMock(spec=StateStoreManager),
         )
 

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -858,40 +858,6 @@ class TestStreamingDataFrameTumblingWindow:
             WindowResult(value=2, start=20, end=30),
         ]
 
-    def test_tumbling_window_current_with_null_key_ignored(
-        self, dataframe_factory, state_manager, message_context_factory
-    ):
-        topic = Topic("test")
-
-        sdf = dataframe_factory(topic, state_manager=state_manager)
-        sdf = sdf.tumbling_window(duration_ms=10).sum().current()
-
-        state_manager.on_partition_assign(
-            tp=TopicPartitionStub(topic=topic.name, partition=0)
-        )
-        messages = [
-            # Create window [0,10) - Before null key message
-            (1, message_context_factory(key="test", timestamp_ms=1)),
-            # Introduce message with None key, expected to be ignored
-            (10, message_context_factory(key=None, timestamp_ms=100)),
-            # Update window [0,10) - After null key message
-            (2, message_context_factory(key="test", timestamp_ms=2)),
-        ]
-
-        results = []
-        for value, ctx in messages:
-            with state_manager.start_store_transaction(
-                topic=ctx.topic, partition=ctx.partition, offset=ctx.offset
-            ):
-                results += sdf.test(value=value, ctx=ctx)
-
-        assert len(results) == 2
-        # Ensure that the windows are returned with correct values and order
-        assert results == [
-            WindowResult(value=1, start=0, end=10),
-            WindowResult(value=3, start=0, end=10),
-        ]
-
 
 class TestStreamingDataFrameHoppingWindow:
     def test_hopping_window_define_from_milliseconds(

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -811,11 +811,11 @@ class TestStreamingDataFrameTumblingWindow:
             tp=TopicPartitionStub(topic=topic.name, partition=0)
         )
         messages = [
-            # Create window [0,10) - Before null key message
+            # Create window [0,10)
             (1, message_context_factory(key="test", timestamp_ms=1)),
-            # Introduce message with None key, expected to be ignored
+            # Message with None key, expected to be ignored
             (10, message_context_factory(key=None, timestamp_ms=100)),
-            # Update window [0,10) - After null key message
+            # Update window [0,10)
             (2, message_context_factory(key="test", timestamp_ms=2)),
         ]
 
@@ -1038,11 +1038,11 @@ class TestStreamingDataFrameHoppingWindow:
             tp=TopicPartitionStub(topic=topic.name, partition=0)
         )
         messages = [
-            # Create window [0,10) - Before null key message
+            # Create window [0,10)
             (1, message_context_factory(key="test", timestamp_ms=1)),
-            # Introduce message with None key, expected to be ignored
+            # Message with None key, expected to be ignored
             (10, message_context_factory(key=None, timestamp_ms=100)),
-            # Update window [0,10) - After null key message
+            # Update window [0,10)
             (2, message_context_factory(key="test", timestamp_ms=2)),
         ]
 

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -7,7 +7,7 @@ from quixstreams import MessageContext, State
 from quixstreams.core.stream import Filtered
 from quixstreams.dataframe.exceptions import InvalidOperation
 from quixstreams.dataframe.windows import WindowResult
-from quixstreams.models import MessageTimestamp
+from quixstreams.models import MessageTimestamp, Topic
 from tests.utils import TopicPartitionStub
 
 
@@ -856,6 +856,40 @@ class TestStreamingDataFrameTumblingWindow:
         assert results == [
             WindowResult(value=2, start=0, end=10),
             WindowResult(value=2, start=20, end=30),
+        ]
+
+    def test_tumbling_window_none_key_messages(
+        self, dataframe_factory, state_manager, message_context_factory
+    ):
+        topic = Topic("test")
+
+        sdf = dataframe_factory(topic, state_manager=state_manager)
+        sdf = sdf.tumbling_window(duration_ms=10).sum().current()
+
+        state_manager.on_partition_assign(
+            tp=TopicPartitionStub(topic=topic.name, partition=0)
+        )
+        messages = [
+            # Create window [0,10)
+            (1, message_context_factory(key="test", timestamp_ms=1)),
+            # Message with None key, expected to be ignored
+            (10, message_context_factory(key=None, timestamp_ms=100)),
+            # Update window [0,10)
+            (2, message_context_factory(key="test", timestamp_ms=2)),
+        ]
+
+        results = []
+        for value, ctx in messages:
+            with state_manager.start_store_transaction(
+                topic=ctx.topic, partition=ctx.partition, offset=ctx.offset
+            ):
+                results += sdf.test(value=value, ctx=ctx)
+
+        assert len(results) == 2
+        # Ensure that the windows are returned with correct values and order
+        assert results == [
+            WindowResult(value=1, start=0, end=10),
+            WindowResult(value=3, start=0, end=10),
         ]
 
 

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -761,6 +761,40 @@ class TestStreamingDataFrameTumblingWindow:
             WindowResult(value=2, start=20, end=30),
         ]
 
+    def test_tumbling_window_none_key_messages(
+        self, dataframe_factory, state_manager, message_context_factory
+    ):
+        topic = Topic("test")
+
+        sdf = dataframe_factory(topic, state_manager=state_manager)
+        sdf = sdf.tumbling_window(duration_ms=10).sum().current()
+
+        state_manager.on_partition_assign(
+            tp=TopicPartitionStub(topic=topic.name, partition=0)
+        )
+        messages = [
+            # Create window [0,10)
+            (1, message_context_factory(key="test", timestamp_ms=1)),
+            # Message with None key, expected to be ignored
+            (10, message_context_factory(key=None, timestamp_ms=100)),
+            # Update window [0,10)
+            (2, message_context_factory(key="test", timestamp_ms=2)),
+        ]
+
+        results = []
+        for value, ctx in messages:
+            with state_manager.start_store_transaction(
+                topic=ctx.topic, partition=ctx.partition, offset=ctx.offset
+            ):
+                results += sdf.test(value=value, ctx=ctx)
+
+        assert len(results) == 2
+        # Ensure that the windows are returned with correct values and order
+        assert results == [
+            WindowResult(value=1, start=0, end=10),
+            WindowResult(value=3, start=0, end=10),
+        ]
+
     def test_tumbling_window_final(
         self, dataframe_factory, state_manager, message_context_factory
     ):
@@ -797,40 +831,6 @@ class TestStreamingDataFrameTumblingWindow:
         assert results == [
             WindowResult(value=2, start=0, end=10),
             WindowResult(value=2, start=20, end=30),
-        ]
-
-    def test_tumbling_window_none_key_messages(
-        self, dataframe_factory, state_manager, message_context_factory
-    ):
-        topic = Topic("test")
-
-        sdf = dataframe_factory(topic, state_manager=state_manager)
-        sdf = sdf.tumbling_window(duration_ms=10).sum().current()
-
-        state_manager.on_partition_assign(
-            tp=TopicPartitionStub(topic=topic.name, partition=0)
-        )
-        messages = [
-            # Create window [0,10)
-            (1, message_context_factory(key="test", timestamp_ms=1)),
-            # Message with None key, expected to be ignored
-            (10, message_context_factory(key=None, timestamp_ms=100)),
-            # Update window [0,10)
-            (2, message_context_factory(key="test", timestamp_ms=2)),
-        ]
-
-        results = []
-        for value, ctx in messages:
-            with state_manager.start_store_transaction(
-                topic=ctx.topic, partition=ctx.partition, offset=ctx.offset
-            ):
-                results += sdf.test(value=value, ctx=ctx)
-
-        assert len(results) == 2
-        # Ensure that the windows are returned with correct values and order
-        assert results == [
-            WindowResult(value=1, start=0, end=10),
-            WindowResult(value=3, start=0, end=10),
         ]
 
 

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -7,7 +7,6 @@ from quixstreams import MessageContext, State
 from quixstreams.core.stream import Filtered
 from quixstreams.dataframe.windows import WindowResult
 from quixstreams.models import MessageTimestamp
-from quixstreams.models.topics import Topic
 from tests.utils import TopicPartitionStub
 
 
@@ -272,11 +271,9 @@ class TestStreamingDataFrameToTopic:
         dataframe_factory,
         row_consumer_factory,
         row_producer_factory,
-        topic_factory,
+        topic_manager_topic_factory,
     ):
-        topic_name, _ = topic_factory()
-        topic = Topic(
-            topic_name,
+        topic = topic_manager_topic_factory(
             key_deserializer="str",
             value_serializer="json",
             value_deserializer="json",
@@ -314,11 +311,9 @@ class TestStreamingDataFrameToTopic:
         dataframe_factory,
         row_consumer_factory,
         row_producer_factory,
-        topic_factory,
+        topic_manager_topic_factory,
     ):
-        topic_name, _ = topic_factory()
-        topic = Topic(
-            topic_name,
+        topic = topic_manager_topic_factory(
             key_deserializer="str",
             value_serializer="json",
             value_deserializer="json",
@@ -361,11 +356,9 @@ class TestStreamingDataFrameToTopic:
         dataframe_factory,
         row_consumer_factory,
         row_producer_factory,
-        topic_factory,
+        topic_manager_topic_factory,
     ):
-        topic_name, _ = topic_factory()
-        topic = Topic(
-            topic_name,
+        topic = topic_manager_topic_factory(
             value_serializer="json",
             value_deserializer="json",
             key_serializer="int",
@@ -405,18 +398,13 @@ class TestStreamingDataFrameToTopic:
         dataframe_factory,
         row_consumer_factory,
         row_producer_factory,
-        topic_factory,
+        topic_manager_topic_factory,
     ):
-        topic_0_name, _ = topic_factory()
-        topic_1_name, _ = topic_factory()
-
-        topic_0 = Topic(
-            topic_0_name,
+        topic_0 = topic_manager_topic_factory(
             value_serializer="json",
             value_deserializer="json",
         )
-        topic_1 = Topic(
-            topic_1_name,
+        topic_1 = topic_manager_topic_factory(
             value_serializer="json",
             value_deserializer="json",
         )
@@ -454,8 +442,10 @@ class TestStreamingDataFrameToTopic:
             assert consumed_row.key == ctx.key
             assert consumed_row.value == value
 
-    def test_to_topic_no_producer_assigned(self, dataframe_factory):
-        topic = Topic("test")
+    def test_to_topic_no_producer_assigned(
+        self, dataframe_factory, topic_manager_topic_factory
+    ):
+        topic = topic_manager_topic_factory()
 
         sdf = dataframe_factory()
         sdf = sdf.to_topic(topic)
@@ -477,8 +467,10 @@ class TestStreamingDataFrameToTopic:
 
 
 class TestStreamingDataframeStateful:
-    def test_apply_stateful(self, dataframe_factory, state_manager):
-        topic = Topic("test")
+    def test_apply_stateful(
+        self, dataframe_factory, state_manager, topic_manager_topic_factory
+    ):
+        topic = topic_manager_topic_factory()
 
         def stateful_func(value_: dict, state: State) -> int:
             current_max = state.get("max")
@@ -503,7 +495,7 @@ class TestStreamingDataframeStateful:
         result = None
         ctx = MessageContext(
             key=b"test",
-            topic="test",
+            topic=topic.name,
             partition=0,
             offset=0,
             size=0,
@@ -517,8 +509,10 @@ class TestStreamingDataframeStateful:
 
         assert result == 10
 
-    def test_update_stateful(self, dataframe_factory, state_manager):
-        topic = Topic("test")
+    def test_update_stateful(
+        self, dataframe_factory, state_manager, topic_manager_topic_factory
+    ):
+        topic = topic_manager_topic_factory()
 
         def stateful_func(value_: dict, state: State):
             current_max = state.get("max")
@@ -543,7 +537,7 @@ class TestStreamingDataframeStateful:
         ]
         ctx = MessageContext(
             key=b"test",
-            topic="test",
+            topic=topic.name,
             partition=0,
             offset=0,
             size=0,
@@ -558,8 +552,10 @@ class TestStreamingDataframeStateful:
         assert result is not None
         assert result["max"] == 10
 
-    def test_filter_stateful(self, dataframe_factory, state_manager):
-        topic = Topic("test")
+    def test_filter_stateful(
+        self, dataframe_factory, state_manager, topic_manager_topic_factory
+    ):
+        topic = topic_manager_topic_factory()
 
         def stateful_func(value_: dict, state: State):
             current_max = state.get("max")
@@ -584,7 +580,7 @@ class TestStreamingDataframeStateful:
         ]
         ctx = MessageContext(
             key=b"test",
-            topic="test",
+            topic=topic.name,
             partition=0,
             offset=0,
             size=0,
@@ -603,9 +599,9 @@ class TestStreamingDataframeStateful:
         assert results[0]["max"] == 3
 
     def test_filter_with_another_sdf_apply_stateful(
-        self, dataframe_factory, state_manager
+        self, dataframe_factory, state_manager, topic_manager_topic_factory
     ):
-        topic = Topic("test")
+        topic = topic_manager_topic_factory()
 
         def stateful_func(value_: dict, state: State):
             current_max = state.get("max")
@@ -630,7 +626,7 @@ class TestStreamingDataframeStateful:
         ]
         ctx = MessageContext(
             key=b"test",
-            topic="test",
+            topic=topic.name,
             partition=0,
             offset=0,
             size=0,
@@ -684,9 +680,15 @@ class TestStreamingDataFrameTumblingWindow:
         assert window_definition.grace_ms == grace_ms
 
     def test_tumbling_window_current(
-        self, dataframe_factory, state_manager, message_context_factory
+        self,
+        dataframe_factory,
+        state_manager,
+        message_context_factory,
+        topic_manager_topic_factory,
     ):
-        topic = Topic("test")
+        topic = topic_manager_topic_factory(
+            name="test",
+        )
 
         sdf = dataframe_factory(topic, state_manager=state_manager)
         sdf = (
@@ -723,13 +725,19 @@ class TestStreamingDataFrameTumblingWindow:
         ]
 
     def test_tumbling_window_current_out_of_order_late(
-        self, dataframe_factory, state_manager, message_context_factory
+        self,
+        dataframe_factory,
+        state_manager,
+        message_context_factory,
+        topic_manager_topic_factory,
     ):
         """
         Test that window with "latest" doesn't output the result if incoming timestamp
         is late
         """
-        topic = Topic("test")
+        topic = topic_manager_topic_factory(
+            name="test",
+        )
 
         sdf = dataframe_factory(topic, state_manager=state_manager)
         sdf = sdf.tumbling_window(duration_ms=10, grace_ms=0).sum().current()
@@ -796,9 +804,15 @@ class TestStreamingDataFrameTumblingWindow:
         ]
 
     def test_tumbling_window_final(
-        self, dataframe_factory, state_manager, message_context_factory
+        self,
+        dataframe_factory,
+        state_manager,
+        message_context_factory,
+        topic_manager_topic_factory,
     ):
-        topic = Topic("test")
+        topic = topic_manager_topic_factory(
+            name="test",
+        )
 
         sdf = dataframe_factory(topic, state_manager=state_manager)
         sdf = sdf.tumbling_window(duration_ms=10, grace_ms=0).sum().final()
@@ -903,9 +917,13 @@ class TestStreamingDataFrameHoppingWindow:
         assert window_definition.step_ms == step_ms
 
     def test_hopping_window_current(
-        self, dataframe_factory, state_manager, message_context_factory
+        self,
+        dataframe_factory,
+        state_manager,
+        message_context_factory,
+        topic_manager_topic_factory,
     ):
-        topic = Topic("test")
+        topic = topic_manager_topic_factory(name="test")
 
         sdf = dataframe_factory(topic, state_manager=state_manager)
         sdf = sdf.hopping_window(duration_ms=10, step_ms=5).sum().current()
@@ -948,9 +966,13 @@ class TestStreamingDataFrameHoppingWindow:
         ]
 
     def test_hopping_window_current_out_of_order_late(
-        self, dataframe_factory, state_manager, message_context_factory
+        self,
+        dataframe_factory,
+        state_manager,
+        message_context_factory,
+        topic_manager_topic_factory,
     ):
-        topic = Topic("test")
+        topic = topic_manager_topic_factory(name="test")
 
         sdf = dataframe_factory(topic, state_manager=state_manager)
         sdf = sdf.hopping_window(duration_ms=10, step_ms=5).sum().current()
@@ -987,9 +1009,13 @@ class TestStreamingDataFrameHoppingWindow:
         ]
 
     def test_hopping_window_final(
-        self, dataframe_factory, state_manager, message_context_factory
+        self,
+        dataframe_factory,
+        state_manager,
+        message_context_factory,
+        topic_manager_topic_factory,
     ):
-        topic = Topic("test")
+        topic = topic_manager_topic_factory(name="test")
 
         sdf = dataframe_factory(topic, state_manager=state_manager)
         sdf = sdf.hopping_window(duration_ms=10, step_ms=5).sum().final()

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -858,6 +858,40 @@ class TestStreamingDataFrameTumblingWindow:
             WindowResult(value=2, start=20, end=30),
         ]
 
+    def test_tumbling_window_current_with_null_key_ignored(
+        self, dataframe_factory, state_manager, message_context_factory
+    ):
+        topic = Topic("test")
+
+        sdf = dataframe_factory(topic, state_manager=state_manager)
+        sdf = sdf.tumbling_window(duration_ms=10).sum().current()
+
+        state_manager.on_partition_assign(
+            tp=TopicPartitionStub(topic=topic.name, partition=0)
+        )
+        messages = [
+            # Create window [0,10) - Before null key message
+            (1, message_context_factory(key="test", timestamp_ms=1)),
+            # Introduce message with None key, expected to be ignored
+            (10, message_context_factory(key=None, timestamp_ms=100)),
+            # Update window [0,10) - After null key message
+            (2, message_context_factory(key="test", timestamp_ms=2)),
+        ]
+
+        results = []
+        for value, ctx in messages:
+            with state_manager.start_store_transaction(
+                topic=ctx.topic, partition=ctx.partition, offset=ctx.offset
+            ):
+                results += sdf.test(value=value, ctx=ctx)
+
+        assert len(results) == 2
+        # Ensure that the windows are returned with correct values and order
+        assert results == [
+            WindowResult(value=1, start=0, end=10),
+            WindowResult(value=3, start=0, end=10),
+        ]
+
 
 class TestStreamingDataFrameHoppingWindow:
     def test_hopping_window_define_from_milliseconds(

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -5,6 +5,7 @@ import pytest
 
 from quixstreams import MessageContext, State
 from quixstreams.core.stream import Filtered
+from quixstreams.dataframe.exceptions import InvalidOperation
 from quixstreams.dataframe.windows import WindowResult
 from quixstreams.models import MessageTimestamp
 from tests.utils import TopicPartitionStub
@@ -223,6 +224,16 @@ class TestStreamingDataFrame:
         invalid_value = {"y": 2}
         with pytest.raises(Filtered):
             sdf.test(invalid_value)
+
+    def test_cannot_use_logical_and(self, dataframe_factory):
+        sdf = dataframe_factory()
+        with pytest.raises(InvalidOperation):
+            sdf["truth"] = sdf[sdf.apply(lambda x: x["a"] > 0)] and sdf[["b"]]
+
+    def test_cannot_use_logical_or(self, dataframe_factory):
+        sdf = dataframe_factory()
+        with pytest.raises(InvalidOperation):
+            sdf["truth"] = sdf[sdf.apply(lambda x: x["a"] > 0)] or sdf[["b"]]
 
 
 class TestStreamingDataFrameApplyExpand:

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -799,7 +799,7 @@ class TestStreamingDataFrameTumblingWindow:
             WindowResult(value=2, start=20, end=30),
         ]
 
-    def test_tumbling_window_current_with_null_key_ignored(
+    def test_tumbling_window_none_key_messages(
         self, dataframe_factory, state_manager, message_context_factory
     ):
         topic = Topic("test")
@@ -1026,47 +1026,7 @@ class TestStreamingDataFrameHoppingWindow:
             WindowResult(value=3, start=10, end=20),
         ]
 
-    def test_hopping_window_null_key_messages(
-        self, dataframe_factory, state_manager, message_context_factory
-    ):
-        topic = Topic("test")
-
-        sdf = dataframe_factory(topic, state_manager=state_manager)
-        sdf = sdf.hopping_window(duration_ms=10, step_ms=5).sum().final()
-
-        state_manager.on_partition_assign(
-            tp=TopicPartitionStub(topic=topic.name, partition=0)
-        )
-        messages = [
-            # Create window [0,10)
-            (1, message_context_factory(key="test", timestamp_ms=1)),
-            # Update window [0,10) and create window [5,15)
-            (2, message_context_factory(key="test", timestamp_ms=7)),
-            # Update window [5,15) and create window [10,20)
-            (3, message_context_factory(key="test", timestamp_ms=10)),
-            # Create windows [30, 40) and [35, 45).
-            # Windows [0,10), [5,15) and [10,20) should be expired
-            (4, message_context_factory(key="test", timestamp_ms=35)),
-            # Update windows [30, 40) and [35, 45)
-            (5, message_context_factory(key="test", timestamp_ms=35)),
-        ]
-
-        results = []
-        for value, ctx in messages:
-            with state_manager.start_store_transaction(
-                topic=ctx.topic, partition=ctx.partition, offset=ctx.offset
-            ):
-                results += sdf.test(value=value, ctx=ctx)
-
-        assert len(results) == 3
-        # Ensure that the windows are returned with correct values and order
-        assert results == [
-            WindowResult(value=3, start=0, end=10),
-            WindowResult(value=5, start=5, end=15),
-            WindowResult(value=3, start=10, end=20),
-        ]
-
-    def test_hopping_window_current_with_null_key_ignored(
+    def test_hopping_window_none_key_messages(
         self, dataframe_factory, state_manager, message_context_factory
     ):
         topic = Topic("test")

--- a/tests/test_quixstreams/test_dataframe/test_series.py
+++ b/tests/test_quixstreams/test_dataframe/test_series.py
@@ -1,5 +1,6 @@
 import pytest
 
+from quixstreams.dataframe.exceptions import InvalidOperation
 from quixstreams.dataframe.series import StreamingSeries
 
 
@@ -321,3 +322,11 @@ class TestStreamingSeries:
         series = StreamingSeries("x") | StreamingSeries("y")
         # Ensure it doesn't fail with KeyError ("y" is not present in value)
         series.test({"x": True})
+
+    def test_cannot_use_logical_and(self):
+        with pytest.raises(InvalidOperation):
+            StreamingSeries("x") and StreamingSeries("y")
+
+    def test_cannot_use_logical_or(self):
+        with pytest.raises(InvalidOperation):
+            StreamingSeries("x") or StreamingSeries("y")

--- a/tests/test_quixstreams/test_kafka/test_consumer.py
+++ b/tests/test_quixstreams/test_kafka/test_consumer.py
@@ -52,11 +52,7 @@ class TestConsumerSubscribe:
             assert topic_name in metadata.topics
             assert len(metadata.topics[topic_name].partitions) == num_partitions
 
-    def test_consumer_subscribe_topic_doesnt_exist(
-        self,
-        consumer,
-        topic_factory,
-    ):
+    def test_consumer_subscribe_topic_doesnt_exist(self, consumer):
         topic_name = str(uuid.uuid4())
 
         with consumer:

--- a/tests/test_quixstreams/test_models/fixtures.py
+++ b/tests/test_quixstreams/test_models/fixtures.py
@@ -56,12 +56,14 @@ def quix_timeseries_factory():
                 if as_legacy
                 else value
             ).encode(),
-            headers=None
-            if as_legacy
-            else [
-                ("__Q_ModelKey", model_key.encode()),
-                ("__Q_CodecId", codec_id.encode()),
-            ],
+            headers=(
+                None
+                if as_legacy
+                else [
+                    ("__Q_ModelKey", model_key.encode()),
+                    ("__Q_CodecId", codec_id.encode()),
+                ]
+            ),
         )
         return message
 
@@ -118,12 +120,14 @@ def quix_eventdata_factory():
                 if as_legacy
                 else event
             ).encode(),
-            headers=None
-            if as_legacy
-            else [
-                ("__Q_ModelKey", model_key.encode()),
-                ("__Q_CodecId", codec_id.encode()),
-            ],
+            headers=(
+                None
+                if as_legacy
+                else [
+                    ("__Q_ModelKey", model_key.encode()),
+                    ("__Q_CodecId", codec_id.encode()),
+                ]
+            ),
         )
         return message
 
@@ -153,12 +157,14 @@ def quix_eventdata_list_factory():
                 if as_legacy
                 else events
             ).encode(),
-            headers=None
-            if as_legacy
-            else [
-                ("__Q_ModelKey", model_key.encode()),
-                ("__Q_CodecId", codec_id.encode()),
-            ],
+            headers=(
+                None
+                if as_legacy
+                else [
+                    ("__Q_ModelKey", model_key.encode()),
+                    ("__Q_CodecId", codec_id.encode()),
+                ]
+            ),
         )
         return message
 

--- a/tests/test_quixstreams/test_platforms/test_quix/test_config.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/test_config.py
@@ -7,7 +7,6 @@ from unittest.mock import patch, call, create_autospec
 import pytest
 from requests import HTTPError, Response
 
-from quixstreams.models.topics import Topic
 from quixstreams.platforms.quix.config import (
     QUIX_CONNECTIONS_MAX_IDLE_MS,
     QUIX_METADATA_MAX_AGE_MS,
@@ -511,7 +510,9 @@ class TestQuixKafkaConfigsBuilder:
         )
         assert cfg_factory.get_topics() == api_data
 
-    def test_create_topics(self, quix_kafka_config_factory):
+    def test_create_topics(
+        self, quix_kafka_config_factory, topic_manager_topic_factory
+    ):
         get_topics_return = [
             {
                 "id": "12345-topic_a",
@@ -530,9 +531,9 @@ class TestQuixKafkaConfigsBuilder:
             },
         ]
 
-        topic_b = Topic("12345-topic_b")
-        topic_c = Topic("12345-topic_c")
-        topic_d = Topic("12345-topic_d")
+        topic_b = topic_manager_topic_factory("12345-topic_b")
+        topic_c = topic_manager_topic_factory("12345-topic_c")
+        topic_d = topic_manager_topic_factory("12345-topic_d")
 
         cfg_factory = quix_kafka_config_factory(workspace_id="12345")
         stack = ExitStack()
@@ -547,7 +548,9 @@ class TestQuixKafkaConfigsBuilder:
         create_topic.assert_called_once_with(topic_d)
         finalize.assert_called_with({t.name for t in [topic_c, topic_d]}, timeout=1)
 
-    def test_create_topics_parallel_create_attempt(self, quix_kafka_config_factory):
+    def test_create_topics_parallel_create_attempt(
+        self, quix_kafka_config_factory, topic_manager_topic_factory
+    ):
         """When another app or something tries to create a topic at the same time"""
         get_topics_return = [
             {
@@ -557,7 +560,7 @@ class TestQuixKafkaConfigsBuilder:
             },
         ]
 
-        topic_b = Topic("12345-topic_b")
+        topic_b = topic_manager_topic_factory("12345-topic_b")
 
         mock_response = create_autospec(Response)
         mock_response.text = "already exists"
@@ -639,7 +642,9 @@ class TestQuixKafkaConfigsBuilder:
         assert "topic_c" not in e and "topic_d" in e
         assert get_topics.call_count == 1
 
-    def test_confirm_topics_exist(self, quix_kafka_config_factory):
+    def test_confirm_topics_exist(
+        self, quix_kafka_config_factory, topic_manager_topic_factory
+    ):
         api_data_stub = [
             {
                 "id": "12345-topic_a",
@@ -663,16 +668,18 @@ class TestQuixKafkaConfigsBuilder:
             },
         ]
 
-        topic_b = Topic("12345-topic_b")
-        topic_c = Topic("12345-topic_c")
-        topic_d = Topic("12345-topic_d")
+        topic_b = topic_manager_topic_factory("12345-topic_b")
+        topic_c = topic_manager_topic_factory("12345-topic_c")
+        topic_d = topic_manager_topic_factory("12345-topic_d")
 
         cfg_factory = quix_kafka_config_factory(
             workspace_id="12345", api_responses={"get_topics": api_data_stub}
         )
         cfg_factory.confirm_topics_exist([topic_b, topic_c, topic_d])
 
-    def test_confirm_topics_exist_topics_missing(self, quix_kafka_config_factory):
+    def test_confirm_topics_exist_topics_missing(
+        self, quix_kafka_config_factory, topic_manager_topic_factory
+    ):
         api_data_stub = [
             {
                 "id": "12345-topic_a",
@@ -686,9 +693,9 @@ class TestQuixKafkaConfigsBuilder:
             },
         ]
 
-        topic_b = Topic("12345-topic_b")
-        topic_c = Topic("12345-topic_c")
-        topic_d = Topic("12345-topic_d")
+        topic_b = topic_manager_topic_factory("12345-topic_b")
+        topic_c = topic_manager_topic_factory("12345-topic_c")
+        topic_d = topic_manager_topic_factory("12345-topic_d")
 
         cfg_factory = quix_kafka_config_factory(
             workspace_id="12345", api_responses={"get_topics": api_data_stub}

--- a/tests/test_quixstreams/test_rowproducer.py
+++ b/tests/test_quixstreams/test_rowproducer.py
@@ -4,7 +4,6 @@ import pytest
 from confluent_kafka import KafkaException
 
 from quixstreams.models import (
-    Topic,
     JSONSerializer,
     SerializationError,
 )
@@ -76,12 +75,9 @@ class TestRowProducer:
         assert not row.headers
 
     def test_produce_row_serialization_error_raise(
-        self, row_producer_factory, row_factory
+        self, row_producer_factory, row_factory, topic_manager_topic_factory
     ):
-        topic = Topic(
-            "test",
-            value_serializer=JSONSerializer(),
-        )
+        topic = topic_manager_topic_factory(value_serializer=JSONSerializer())
 
         with row_producer_factory() as producer:
             row = row_factory(
@@ -91,11 +87,10 @@ class TestRowProducer:
             with pytest.raises(SerializationError):
                 producer.produce_row(topic=topic, row=row)
 
-    def test_produce_row_produce_error_raise(self, row_producer_factory, row_factory):
-        topic = Topic(
-            "test",
-            value_serializer=JSONSerializer(),
-        )
+    def test_produce_row_produce_error_raise(
+        self, row_producer_factory, row_factory, topic_manager_topic_factory
+    ):
+        topic = topic_manager_topic_factory(value_serializer=JSONSerializer())
 
         with row_producer_factory(extra_config={"message.max.bytes": 1000}) as producer:
             row = row_factory(
@@ -106,12 +101,13 @@ class TestRowProducer:
                 producer.produce_row(topic=topic, row=row)
 
     def test_produce_row_serialization_error_suppress(
-        self, row_consumer_factory, row_producer_factory, row_factory
+        self,
+        row_consumer_factory,
+        row_producer_factory,
+        row_factory,
+        topic_manager_topic_factory,
     ):
-        topic = Topic(
-            "test",
-            value_serializer=JSONSerializer(),
-        )
+        topic = topic_manager_topic_factory(value_serializer=JSONSerializer())
 
         suppressed = Future()
 


### PR DESCRIPTION
#### Allow events with `null` keys overall in StreamingDataFrame.
* `null` is still a value, plus users can change the key to something else

#### Skip events with `null` keys in Windows and log warnings:
* The result of the window with `null` key is a random value, so having counting them doesn't make sense.
* Note, users may correct the keys before data enters the window.