### PR TITLE
Add Introduction topic (fixes collapsing nav issue)

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,41 @@
+# Quix Streams client library
+
+Quix Streams v2 is a cloud native library for processing data in Kafka using pure Python. It’s designed to give you the power of a distributed system in a lightweight library by combining the low-level scalability and resiliency features of Kafka with an easy to use Python interface.
+
+Quix Streams has the following benefits:
+
+* No JVM, no orchestrator, no server-side engine.
+* Easily integrates with the entire Python ecosystem (pandas, scikit-learn, TensorFlow, PyTorch etc).
+* Support for many serialization formats, including JSON (and Quix-specific).
+* Support for stateful operations using RocksDB.
+* Support for aggregations over tumbling and hopping time windows
+* A simple framework with Pandas-like interface to ease newcomers to streaming.
+* "At-least-once" Kafka processing guarantees.
+* Designed to run and scale resiliently via container orchestration (like Kubernetes).
+* Easily runs locally and in Jupyter Notebook for convenient development and debugging.
+* Seamless integration with the Quix platform.
+* Use Quix Streams to build event-driven, machine learning/AI or physics-based applications that depend on real-time data from Kafka.
+
+See the [Quix Streams GitHub page](https://github.com/quixio/quix-streams){target=_blank} for detailed project information, and all source code.
+
+## Next steps
+
+<div class="grid cards" markdown>
+
+- __Quickstart__
+
+    ---
+
+    Get started using Quix Streams. Get your CPU data into Quix in under 10 minutes.
+
+    [Quickstart :octicons-arrow-right-24:](./get-started/quickstart.md)
+
+- __Quix Tour__
+
+    ---
+
+    Build a complete Python stream processing application in under 20 minutes.
+
+    [Quix Tour :octicons-arrow-right-24:](./get-started/quixtour/overview.md)
+
+</div>

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -28,7 +28,7 @@ See the [Quix Streams GitHub page](https://github.com/quixio/quix-streams){targe
 
     Get started using Quix Streams. Get your CPU data into Quix in under 10 minutes.
 
-    [Quickstart :octicons-arrow-right-24:](./get-started/quickstart.md)
+    [Quickstart :octicons-arrow-right-24:](https://quix.io/docs/get-started/quickstart.html)
 
 - __Quix Tour__
 
@@ -36,6 +36,6 @@ See the [Quix Streams GitHub page](https://github.com/quixio/quix-streams){targe
 
     Build a complete Python stream processing application in under 20 minutes.
 
-    [Quix Tour :octicons-arrow-right-24:](./get-started/quixtour/overview.md)
+    [Quix Tour :octicons-arrow-right-24:](https://quix.io/docs/get-started/quixtour/overview.html)
 
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ exclude_docs: |
   build/*
 
 nav:
-#  - 'Introduction': '../quix-streams-intro.html'
+  - 'Introduction': 'introduction.md'
   - Example Applications: example.md
   - Defining your Streaming Pipeline: streamingdataframe.md
   - Windowed Aggregations: windowing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ exclude_docs: |
   build/*
 
 nav:
-  - 'Introduction': '../quix-streams-intro.html'
+#  - 'Introduction': '../quix-streams-intro.html'
   - Example Applications: example.md
   - Defining your Streaming Pipeline: streamingdataframe.md
   - Windowed Aggregations: windowing.md


### PR DESCRIPTION
## Description

Adds an introduction page to the nav. 

The introduction page at the moment contains some basic intro material based on the README. It also contains panels linking to the Quickstart and Quix Tour (which are updated to use SDF on the dev branch - currently not yet published).

This fix an annoying issue with the nav collapsing when the introduction was viewed on the main docs page. The reason this happened was because the topic being referenced was above the current layer in the nav, and so the nav collapsed (correctly) accordingly.

The solution is simply to include the introduction page in the Quix Streams repo, where this will be imported into the main docs site. The retains the introduction topic, but without the annoying collapsing of the nav.