### PR TITLE
Implement handling messages without keys

### DIFF
--- a/docs/api-reference/application.md
+++ b/docs/api-reference/application.md
@@ -10,7 +10,7 @@
 class Application()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L52)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L52)
 
 The main Application class.
 
@@ -60,7 +60,7 @@ app.run(dataframe=df)
 
 ```python
 def __init__(broker_address: str,
-             consumer_group: str,
+             consumer_group: str = "quixstreams-default",
              auto_offset_reset: AutoOffsetReset = "latest",
              auto_commit_enable: bool = True,
              partitioner: Partitioner = "murmur2",
@@ -80,7 +80,7 @@ def __init__(broker_address: str,
              topic_manager: Optional[TopicManager] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L91)
 
 
 <br>
@@ -90,6 +90,7 @@ def __init__(broker_address: str,
 Passed as `bootstrap.servers` to `confluent_kafka.Consumer`.
 - `consumer_group`: Kafka consumer group.
 Passed as `group.id` to `confluent_kafka.Consumer`
+Default - "quixstreams-default".
 - `auto_offset_reset`: Consumer `auto.offset.reset` setting
 - `auto_commit_enable`: If true, periodically commit offset of
 the last message handed to the application. Default - `True`.
@@ -140,7 +141,7 @@ or to produce a message to Kafka.
 ```python
 @classmethod
 def Quix(cls,
-         consumer_group: str,
+         consumer_group: str = "quixstreams-default",
          auto_offset_reset: AutoOffsetReset = "latest",
          auto_commit_enable: bool = True,
          partitioner: Partitioner = "murmur2",
@@ -161,7 +162,7 @@ def Quix(cls,
          topic_manager: Optional[QuixTopicManager] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L232)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L233)
 
 Initialize an Application to work with Quix platform,
 
@@ -185,7 +186,7 @@ producer to properly connect to the Quix platform.
 ```python
 from quixstreams import Application
 
-# Set up an `app = Application.Quix` and  `sdf = StreamingDataFrame`;
+# Set up an `app = Application.Quix` and `sdf = StreamingDataFrame`;
 # add some operations to `sdf` and then run everything. Also shows off how to
 # use the quix-specific serializers and deserializers.
 
@@ -204,7 +205,8 @@ app.run(dataframe=df)
 
 - `consumer_group`: Kafka consumer group.
 Passed as `group.id` to `confluent_kafka.Consumer`.
->***NOTE:*** The consumer group will be prefixed by Quix workspace id.
+Default - "quixstreams-default".
+  >***NOTE:*** The consumer group will be prefixed by Quix workspace id.
 - `auto_offset_reset`: Consumer `auto.offset.reset` setting
 - `auto_commit_enable`: If true, periodically commit offset of
 the last message handed to the application. Default - `True`.
@@ -273,7 +275,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L390)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L392)
 
 Create a topic definition.
 
@@ -354,7 +356,7 @@ topic = app.topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def dataframe(topic: Topic) -> StreamingDataFrame
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L470)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L472)
 
 A simple helper method that generates a `StreamingDataFrame`, which is used
 
@@ -404,7 +406,7 @@ to be used as an input topic.
 def stop()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L506)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L508)
 
 Stop the internal poll loop and the message processing.
 
@@ -424,7 +426,7 @@ To otherwise stop an application, either send a `SIGTERM` to the process
 def get_producer() -> Producer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L520)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L522)
 
 Create and return a pre-configured Producer instance.
 The Producer is initialized with params passed to Application.
@@ -459,7 +461,7 @@ with app.get_producer() as producer:
 def get_consumer() -> Consumer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L551)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L553)
 
 Create and return a pre-configured Consumer instance.
 The Consumer is initialized with params passed to Application.
@@ -504,7 +506,7 @@ with app.get_consumer() as consumer:
 def clear_state()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L595)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L597)
 
 Clear the state of the application.
 
@@ -518,7 +520,7 @@ Clear the state of the application.
 def run(dataframe: StreamingDataFrame)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L674)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L676)
 
 Start processing data from Kafka using provided `StreamingDataFrame`
 
@@ -562,7 +564,7 @@ app.run(dataframe=df)
 class State(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L153)
 
 Primary interface for working with key-value state data from `StreamingDataFrame`
 
@@ -576,7 +578,7 @@ Primary interface for working with key-value state data from `StreamingDataFrame
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L158)
 
 Get the value for key if key is present in the state, else default
 
@@ -603,7 +605,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L168)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L168)
 
 Set value for the key.
 
@@ -624,7 +626,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L176)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L176)
 
 Delete value for the key.
 
@@ -646,7 +648,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L185)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L185)
 
 Check if the key exists in state.
 

--- a/docs/api-reference/application.md
+++ b/docs/api-reference/application.md
@@ -10,7 +10,7 @@
 class Application()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L52)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L52)
 
 The main Application class.
 
@@ -80,7 +80,7 @@ def __init__(broker_address: str,
              topic_manager: Optional[TopicManager] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L91)
 
 
 <br>
@@ -161,7 +161,7 @@ def Quix(cls,
          topic_manager: Optional[QuixTopicManager] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L232)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L232)
 
 Initialize an Application to work with Quix platform,
 
@@ -273,7 +273,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L390)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L390)
 
 Create a topic definition.
 
@@ -354,7 +354,7 @@ topic = app.topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def dataframe(topic: Topic) -> StreamingDataFrame
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L470)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L470)
 
 A simple helper method that generates a `StreamingDataFrame`, which is used
 
@@ -404,7 +404,7 @@ to be used as an input topic.
 def stop()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L506)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L506)
 
 Stop the internal poll loop and the message processing.
 
@@ -424,7 +424,7 @@ To otherwise stop an application, either send a `SIGTERM` to the process
 def get_producer() -> Producer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L520)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L520)
 
 Create and return a pre-configured Producer instance.
 The Producer is initialized with params passed to Application.
@@ -459,7 +459,7 @@ with app.get_producer() as producer:
 def get_consumer() -> Consumer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L551)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L551)
 
 Create and return a pre-configured Consumer instance.
 The Consumer is initialized with params passed to Application.
@@ -504,7 +504,7 @@ with app.get_consumer() as consumer:
 def clear_state()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L595)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L595)
 
 Clear the state of the application.
 
@@ -518,7 +518,7 @@ Clear the state of the application.
 def run(dataframe: StreamingDataFrame)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L674)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L674)
 
 Start processing data from Kafka using provided `StreamingDataFrame`
 
@@ -562,7 +562,7 @@ app.run(dataframe=df)
 class State(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L153)
 
 Primary interface for working with key-value state data from `StreamingDataFrame`
 
@@ -576,7 +576,7 @@ Primary interface for working with key-value state data from `StreamingDataFrame
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L158)
 
 Get the value for key if key is present in the state, else default
 
@@ -603,7 +603,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L168)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L168)
 
 Set value for the key.
 
@@ -624,7 +624,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L176)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L176)
 
 Delete value for the key.
 
@@ -646,7 +646,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L185)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L185)
 
 Check if the key exists in state.
 

--- a/docs/api-reference/dataframe.md
+++ b/docs/api-reference/dataframe.md
@@ -10,7 +10,7 @@
 class StreamingDataFrame(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L32)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L32)
 
 `StreamingDataFrame` is the main object you will use for ETL work.
 
@@ -74,7 +74,7 @@ def apply(func: Union[DataFrameFunc, DataFrameStatefulFunc],
           expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L109)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L109)
 
 Apply a function to transform the value and return a new value.
 
@@ -122,7 +122,7 @@ def update(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L152)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L152)
 
 Apply a function to mutate value in-place or to perform a side effect
 
@@ -170,7 +170,7 @@ def filter(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L191)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L191)
 
 Filter value using provided function.
 
@@ -218,7 +218,7 @@ of type `State` to perform stateful operations.
 def contains(key: str) -> StreamingSeries
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L244)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L244)
 
 Check if the key is present in the Row value.
 
@@ -258,7 +258,7 @@ def to_topic(topic: Topic,
              key: Optional[Callable[[object], object]] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L267)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L267)
 
 Produce current value to a topic. You can optionally specify a new key.
 
@@ -306,7 +306,7 @@ By default, the current message key will be used.
 def compose() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L306)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L306)
 
 Compose all functions of this StreamingDataFrame into one big closure.
 
@@ -349,7 +349,7 @@ and returns a result of StreamingDataFrame
 def test(value: object, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L336)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L336)
 
 A shorthand to test `StreamingDataFrame` with provided value
 
@@ -383,7 +383,7 @@ def tumbling_window(duration_ms: Union[int, timedelta],
                     name: Optional[str] = None) -> TumblingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L354)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L354)
 
 Create a tumbling window transformation on this StreamingDataFrame.
 
@@ -392,12 +392,19 @@ Tumbling windows divide time into fixed-sized, non-overlapping windows.
 They allow to perform stateful aggregations like `sum`, `reduce`, etc.
 on top of the data and emit results downstream.
 
-The time windows always use the current event time.
+**Notes**:
 
-
+  
+  - Every window is grouped by the current Kafka message key.
+  - Messages with `None` key will be ignored.
+  - The time windows always use the current event time.
+  
+  
+  
+  
 <br>
 ***Example Snippet:***
-
+  
 ```python
 app = Application()
 sdf = app.dataframe(...)
@@ -419,34 +426,34 @@ sdf = (
     .all()
 )
 ```
-
-
+  
+  
 <br>
 ***Arguments:***
-
-- `duration_ms`: The length of each window.
-Can be specified as either an `int` representing milliseconds or a
-`timedelta` object.
->***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
-value.
-- `grace_ms`: The grace period for data arrival.
-It allows late-arriving data (data arriving after the window
-has theoretically closed) to be included in the window.
-Can be specified as either an `int` representing milliseconds
-or as a `timedelta` object.
->***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
-value.
-- `name`: The unique identifier for the window. If not provided, it will be
-automatically generated based on the window's properties.
-
-
+  
+  - `duration_ms`: The length of each window.
+  Can be specified as either an `int` representing milliseconds or a
+  `timedelta` object.
+  >***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
+  value.
+  - `grace_ms`: The grace period for data arrival.
+  It allows late-arriving data (data arriving after the window
+  has theoretically closed) to be included in the window.
+  Can be specified as either an `int` representing milliseconds
+  or as a `timedelta` object.
+  >***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
+  value.
+  - `name`: The unique identifier for the window. If not provided, it will be
+  automatically generated based on the window's properties.
+  
+  
 <br>
 ***Returns:***
-
-`TumblingWindowDefinition` instance representing the tumbling window
-configuration.
-This object can be further configured with aggregation functions
-like `sum`, `count`, etc. applied to the StreamingDataFrame.
+  
+  `TumblingWindowDefinition` instance representing the tumbling window
+  configuration.
+  This object can be further configured with aggregation functions
+  like `sum`, `count`, etc. applied to the StreamingDataFrame.
 
 <a id="quixstreams.dataframe.dataframe.StreamingDataFrame.hopping_window"></a>
 
@@ -461,7 +468,7 @@ def hopping_window(duration_ms: Union[int, timedelta],
                    name: Optional[str] = None) -> HoppingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L423)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L429)
 
 Create a hopping window transformation on this StreamingDataFrame.
 
@@ -471,13 +478,18 @@ The overlap is controlled by the `step_ms` parameter.
 They allow to perform stateful aggregations like `sum`, `reduce`, etc.
 on top of the data and emit results downstream.
 
-The time windows always use the current event time.
+**Notes**:
 
-
+  
+  - Every window is grouped by the current Kafka message key.
+  - Messages with `None` key will be ignored.
+  - The time windows always use the current event time.
+  
+  
 <br>
 ***Example Snippet:***
-
-
+  
+  
 <br>
 ***Example Snippet:***
 ```python
@@ -504,41 +516,41 @@ sdf = (
     .all()
 )
 ```
-
-
+  
+  
 <br>
 ***Arguments:***
-
-- `duration_ms`: The length of each window. It defines the time span for
-which each window aggregates data.
-Can be specified as either an `int` representing milliseconds
-or a `timedelta` object.
->***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
-value.
-- `step_ms`: The step size for the window.
-It determines how much each successive window moves forward in time.
-Can be specified as either an `int` representing milliseconds
-or a `timedelta` object.
->***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
-value.
-- `grace_ms`: The grace period for data arrival.
-It allows late-arriving data to be included in the window,
-even if it arrives after the window has theoretically moved forward.
-Can be specified as either an `int` representing milliseconds
-or a `timedelta` object.
->***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
-value.
-- `name`: The unique identifier for the window. If not provided, it will be
-automatically generated based on the window's properties.
-
-
+  
+  - `duration_ms`: The length of each window. It defines the time span for
+  which each window aggregates data.
+  Can be specified as either an `int` representing milliseconds
+  or a `timedelta` object.
+  >***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
+  value.
+  - `step_ms`: The step size for the window.
+  It determines how much each successive window moves forward in time.
+  Can be specified as either an `int` representing milliseconds
+  or a `timedelta` object.
+  >***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
+  value.
+  - `grace_ms`: The grace period for data arrival.
+  It allows late-arriving data to be included in the window,
+  even if it arrives after the window has theoretically moved forward.
+  Can be specified as either an `int` representing milliseconds
+  or a `timedelta` object.
+  >***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
+  value.
+  - `name`: The unique identifier for the window. If not provided, it will be
+  automatically generated based on the window's properties.
+  
+  
 <br>
 ***Returns:***
-
-`HoppingWindowDefinition` instance representing the hopping
-window configuration.
-This object can be further configured with aggregation functions
-like `sum`, `count`, etc. and applied to the StreamingDataFrame.
+  
+  `HoppingWindowDefinition` instance representing the hopping
+  window configuration.
+  This object can be further configured with aggregation functions
+  like `sum`, `count`, etc. and applied to the StreamingDataFrame.
 
 <a id="quixstreams.dataframe.series"></a>
 
@@ -552,7 +564,7 @@ like `sum`, `count`, etc. and applied to the StreamingDataFrame.
 class StreamingSeries(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L17)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L17)
 
 `StreamingSeries` are typically generated by `StreamingDataframes` when getting
 elements from, or performing certain operations on, a `StreamingDataframe`,
@@ -618,7 +630,7 @@ sdf = sdf[["column_a"] & (sdf["new_sum_field"] >= 10)]
 def from_func(cls, func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L77)
 
 Create a StreamingSeries from a function.
 
@@ -646,7 +658,7 @@ instance of `StreamingSeries`
 def apply(func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L91)
 
 Add a callable to the execution list for this series.
 
@@ -699,7 +711,7 @@ def compose(allow_filters: bool = True,
             allow_updates: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L125)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L125)
 
 Compose all functions of this StreamingSeries into one big closure.
 
@@ -759,7 +771,7 @@ and returns a result of `StreamingSeries`
 def test(value: Any, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L172)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L172)
 
 A shorthand to test `StreamingSeries` with provided value
 
@@ -791,7 +803,7 @@ result of `StreamingSeries`
 def isin(other: Container) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L208)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L208)
 
 Check if series value is in "other".
 
@@ -836,7 +848,7 @@ new StreamingSeries
 def contains(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L235)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L235)
 
 Check if series value contains "other"
 
@@ -881,7 +893,7 @@ new StreamingSeries
 def is_(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L260)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L260)
 
 Check if series value refers to the same object as `other`
 
@@ -923,7 +935,7 @@ new StreamingSeries
 def isnot(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L283)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L283)
 
 Check if series value does not refer to the same object as `other`
 
@@ -966,7 +978,7 @@ new StreamingSeries
 def isnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L307)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L307)
 
 Check if series value is None.
 
@@ -1003,7 +1015,7 @@ new StreamingSeries
 def notnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L330)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L330)
 
 Check if series value is not None.
 
@@ -1040,7 +1052,7 @@ new StreamingSeries
 def abs() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L353)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L353)
 
 Get absolute value of the series value.
 
@@ -1078,7 +1090,7 @@ new StreamingSeries
 def set_message_context(context: Optional[MessageContext])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/context.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L22)
 
 Set a MessageContext for the current message in the given `contextvars.Context`
 
@@ -1121,7 +1133,7 @@ sdf = sdf.update(lambda value: alter_context(value))
 def message_context() -> MessageContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/context.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L53)
 
 Get a MessageContext for the current message, which houses most of the message
 
@@ -1162,7 +1174,7 @@ instance of `MessageContext`
 def message_key() -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/context.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L84)
 
 Get the current message's key.
 

--- a/docs/api-reference/dataframe.md
+++ b/docs/api-reference/dataframe.md
@@ -10,7 +10,7 @@
 class StreamingDataFrame(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L32)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L32)
 
 `StreamingDataFrame` is the main object you will use for ETL work.
 
@@ -74,7 +74,7 @@ def apply(func: Union[DataFrameFunc, DataFrameStatefulFunc],
           expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L109)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L109)
 
 Apply a function to transform the value and return a new value.
 
@@ -122,7 +122,7 @@ def update(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L152)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L152)
 
 Apply a function to mutate value in-place or to perform a side effect
 
@@ -170,7 +170,7 @@ def filter(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L191)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L191)
 
 Filter value using provided function.
 
@@ -218,7 +218,7 @@ of type `State` to perform stateful operations.
 def contains(key: str) -> StreamingSeries
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L244)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L244)
 
 Check if the key is present in the Row value.
 
@@ -258,7 +258,7 @@ def to_topic(topic: Topic,
              key: Optional[Callable[[object], object]] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L267)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L267)
 
 Produce current value to a topic. You can optionally specify a new key.
 
@@ -306,7 +306,7 @@ By default, the current message key will be used.
 def compose() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L306)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L306)
 
 Compose all functions of this StreamingDataFrame into one big closure.
 
@@ -349,7 +349,7 @@ and returns a result of StreamingDataFrame
 def test(value: object, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L336)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L336)
 
 A shorthand to test `StreamingDataFrame` with provided value
 
@@ -383,7 +383,7 @@ def tumbling_window(duration_ms: Union[int, timedelta],
                     name: Optional[str] = None) -> TumblingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L354)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L354)
 
 Create a tumbling window transformation on this StreamingDataFrame.
 
@@ -468,7 +468,7 @@ def hopping_window(duration_ms: Union[int, timedelta],
                    name: Optional[str] = None) -> HoppingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L429)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L429)
 
 Create a hopping window transformation on this StreamingDataFrame.
 
@@ -564,7 +564,7 @@ sdf = (
 class StreamingSeries(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L17)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L17)
 
 `StreamingSeries` are typically generated by `StreamingDataframes` when getting
 elements from, or performing certain operations on, a `StreamingDataframe`,
@@ -630,7 +630,7 @@ sdf = sdf[["column_a"] & (sdf["new_sum_field"] >= 10)]
 def from_func(cls, func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L77)
 
 Create a StreamingSeries from a function.
 
@@ -658,7 +658,7 @@ instance of `StreamingSeries`
 def apply(func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L91)
 
 Add a callable to the execution list for this series.
 
@@ -711,7 +711,7 @@ def compose(allow_filters: bool = True,
             allow_updates: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L125)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L125)
 
 Compose all functions of this StreamingSeries into one big closure.
 
@@ -771,7 +771,7 @@ and returns a result of `StreamingSeries`
 def test(value: Any, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L172)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L172)
 
 A shorthand to test `StreamingSeries` with provided value
 
@@ -803,7 +803,7 @@ result of `StreamingSeries`
 def isin(other: Container) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L208)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L208)
 
 Check if series value is in "other".
 
@@ -848,7 +848,7 @@ new StreamingSeries
 def contains(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L235)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L235)
 
 Check if series value contains "other"
 
@@ -893,7 +893,7 @@ new StreamingSeries
 def is_(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L260)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L260)
 
 Check if series value refers to the same object as `other`
 
@@ -935,7 +935,7 @@ new StreamingSeries
 def isnot(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L283)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L283)
 
 Check if series value does not refer to the same object as `other`
 
@@ -978,7 +978,7 @@ new StreamingSeries
 def isnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L307)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L307)
 
 Check if series value is None.
 
@@ -1015,7 +1015,7 @@ new StreamingSeries
 def notnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L330)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L330)
 
 Check if series value is not None.
 
@@ -1052,7 +1052,7 @@ new StreamingSeries
 def abs() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L353)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L353)
 
 Get absolute value of the series value.
 
@@ -1090,7 +1090,7 @@ new StreamingSeries
 def set_message_context(context: Optional[MessageContext])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/context.py#L22)
 
 Set a MessageContext for the current message in the given `contextvars.Context`
 
@@ -1133,7 +1133,7 @@ sdf = sdf.update(lambda value: alter_context(value))
 def message_context() -> MessageContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/context.py#L53)
 
 Get a MessageContext for the current message, which houses most of the message
 
@@ -1174,7 +1174,7 @@ instance of `MessageContext`
 def message_key() -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/context.py#L84)
 
 Get the current message's key.
 

--- a/docs/api-reference/quix-platform-api.md
+++ b/docs/api-reference/quix-platform-api.md
@@ -10,7 +10,7 @@
 class QuixPortalApiService()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/api.py#L15)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/api.py#L15)
 
 A light wrapper around the Quix Portal Api. If used in the Quix Platform, it will
 use that workspaces auth token and portal endpoint, else you must provide it.
@@ -34,7 +34,7 @@ def get_workspace_certificate(
         workspace_id: Optional[str] = None) -> Optional[bytes]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/api.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/api.py#L92)
 
 Get a workspace TLS certificate if available.
 
@@ -65,7 +65,7 @@ certificate as bytes if present, or None
 class TopicCreationConfigs()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L51)
 
 <a id="quixstreams.platforms.quix.config.TopicCreationConfigs.name"></a>
 
@@ -85,7 +85,7 @@ Required when not created by a Quix App.
 def strip_workspace_id_prefix(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L60)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -114,7 +114,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L72)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L72)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -141,7 +141,7 @@ the string with workspace_id prepended
 class QuixKafkaConfigsBuilder()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L84)
 
 Retrieves all the necessary information from the Quix API and builds all the
 objects required to connect a confluent-kafka client to the Quix Platform.
@@ -167,7 +167,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
              workspace_cert_path: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L100)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L100)
 
 
 <br>
@@ -187,7 +187,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
 def strip_workspace_id_prefix(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L179)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L179)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -215,7 +215,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L189)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -244,7 +244,7 @@ def search_for_workspace(
         workspace_name_or_id: Optional[str] = None) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L199)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L199)
 
 Search for a workspace given an expected workspace name or id.
 
@@ -270,7 +270,7 @@ the workspace data dict if search success, else None
 def get_workspace_info(known_workspace_topic: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L222)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L222)
 
 Queries for workspace data from the Quix API, regardless of instance cache,
 
@@ -292,7 +292,7 @@ and updates instance attributes from query result.
 def search_workspace_for_topic(workspace_id: str, topic: str) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L249)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L249)
 
 Search through all the topics in the given workspace id to see if there is a
 
@@ -321,7 +321,7 @@ the workspace_id if success, else None
 def search_for_topic_workspace(topic: str) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L265)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L265)
 
 Find what workspace a topic belongs to.
 
@@ -351,7 +351,7 @@ def get_workspace_ssl_cert(
         extract_to_folder: Optional[Path] = None) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L286)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L286)
 
 Gets and extracts zipped certificate from the API to provided folder if the
 
@@ -382,7 +382,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout_seconds: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L363)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L363)
 
 Create topics in a Quix cluster.
 
@@ -404,7 +404,7 @@ marked as "Ready" (and thus ready to produce to/consume from).
 def confirm_topics_exist(topics: Union[List[Topic], List[str]])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L412)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L412)
 
 Confirm whether the desired set of topics exists in the Quix workspace.
 
@@ -424,7 +424,7 @@ Confirm whether the desired set of topics exists in the Quix workspace.
 def get_confluent_broker_config(known_topic: Optional[str] = None) -> dict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L452)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L452)
 
 Get the full client config dictionary required to authenticate a confluent-kafka
 
@@ -459,7 +459,7 @@ def get_confluent_client_configs(
 ) -> Tuple[dict, List[str], Optional[str]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L497)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L497)
 
 Get all the values you need in order to use a confluent_kafka-based client
 
@@ -496,7 +496,7 @@ and consumer group name
 class QuixEnvironment()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L7)
 
 Class to access various Quix platform environment settings
 
@@ -511,7 +511,7 @@ Class to access various Quix platform environment settings
 def state_management_enabled() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L19)
 
 Check whether "State management" is enabled for the current deployment
 
@@ -532,7 +532,7 @@ True if state management is enabled, otherwise False
 def deployment_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L27)
 
 Return current Quix deployment id.
 
@@ -556,7 +556,7 @@ deployment id or None
 def workspace_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L39)
 
 Return Quix workspace id if set
 
@@ -577,7 +577,7 @@ workspace id or None
 def portal_api() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L47)
 
 Return Quix Portal API url if set
 
@@ -598,7 +598,7 @@ portal API URL or None
 def sdk_token() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L56)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L56)
 
 Return Quix SDK token if set
 
@@ -619,7 +619,7 @@ sdk token or None
 def state_dir() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L64)
 
 Return application state directory on Quix.
 

--- a/docs/api-reference/quix-platform-api.md
+++ b/docs/api-reference/quix-platform-api.md
@@ -10,7 +10,7 @@
 class QuixPortalApiService()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/api.py#L15)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/api.py#L15)
 
 A light wrapper around the Quix Portal Api. If used in the Quix Platform, it will
 use that workspaces auth token and portal endpoint, else you must provide it.
@@ -34,7 +34,7 @@ def get_workspace_certificate(
         workspace_id: Optional[str] = None) -> Optional[bytes]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/api.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/api.py#L92)
 
 Get a workspace TLS certificate if available.
 
@@ -65,7 +65,7 @@ certificate as bytes if present, or None
 class TopicCreationConfigs()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L51)
 
 <a id="quixstreams.platforms.quix.config.TopicCreationConfigs.name"></a>
 
@@ -85,7 +85,7 @@ Required when not created by a Quix App.
 def strip_workspace_id_prefix(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L60)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -114,7 +114,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L72)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L72)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -141,7 +141,7 @@ the string with workspace_id prepended
 class QuixKafkaConfigsBuilder()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L84)
 
 Retrieves all the necessary information from the Quix API and builds all the
 objects required to connect a confluent-kafka client to the Quix Platform.
@@ -167,7 +167,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
              workspace_cert_path: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L100)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L100)
 
 
 <br>
@@ -187,7 +187,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
 def strip_workspace_id_prefix(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L179)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L179)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -215,7 +215,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L189)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -244,7 +244,7 @@ def search_for_workspace(
         workspace_name_or_id: Optional[str] = None) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L199)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L199)
 
 Search for a workspace given an expected workspace name or id.
 
@@ -270,7 +270,7 @@ the workspace data dict if search success, else None
 def get_workspace_info(known_workspace_topic: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L222)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L222)
 
 Queries for workspace data from the Quix API, regardless of instance cache,
 
@@ -292,7 +292,7 @@ and updates instance attributes from query result.
 def search_workspace_for_topic(workspace_id: str, topic: str) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L249)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L249)
 
 Search through all the topics in the given workspace id to see if there is a
 
@@ -321,7 +321,7 @@ the workspace_id if success, else None
 def search_for_topic_workspace(topic: str) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L265)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L265)
 
 Find what workspace a topic belongs to.
 
@@ -351,7 +351,7 @@ def get_workspace_ssl_cert(
         extract_to_folder: Optional[Path] = None) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L286)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L286)
 
 Gets and extracts zipped certificate from the API to provided folder if the
 
@@ -382,7 +382,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout_seconds: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L363)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L363)
 
 Create topics in a Quix cluster.
 
@@ -404,7 +404,7 @@ marked as "Ready" (and thus ready to produce to/consume from).
 def confirm_topics_exist(topics: Union[List[Topic], List[str]])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L412)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L412)
 
 Confirm whether the desired set of topics exists in the Quix workspace.
 
@@ -424,7 +424,7 @@ Confirm whether the desired set of topics exists in the Quix workspace.
 def get_confluent_broker_config(known_topic: Optional[str] = None) -> dict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L452)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L452)
 
 Get the full client config dictionary required to authenticate a confluent-kafka
 
@@ -459,7 +459,7 @@ def get_confluent_client_configs(
 ) -> Tuple[dict, List[str], Optional[str]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L497)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L497)
 
 Get all the values you need in order to use a confluent_kafka-based client
 
@@ -496,7 +496,7 @@ and consumer group name
 class QuixEnvironment()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L7)
 
 Class to access various Quix platform environment settings
 
@@ -511,7 +511,7 @@ Class to access various Quix platform environment settings
 def state_management_enabled() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L19)
 
 Check whether "State management" is enabled for the current deployment
 
@@ -532,7 +532,7 @@ True if state management is enabled, otherwise False
 def deployment_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L27)
 
 Return current Quix deployment id.
 
@@ -556,7 +556,7 @@ deployment id or None
 def workspace_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L39)
 
 Return Quix workspace id if set
 
@@ -577,7 +577,7 @@ workspace id or None
 def portal_api() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L47)
 
 Return Quix Portal API url if set
 
@@ -598,7 +598,7 @@ portal API URL or None
 def sdk_token() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L56)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L56)
 
 Return Quix SDK token if set
 
@@ -619,7 +619,7 @@ sdk token or None
 def state_dir() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L64)
 
 Return application state directory on Quix.
 

--- a/docs/api-reference/quixstreams.md
+++ b/docs/api-reference/quixstreams.md
@@ -14,7 +14,7 @@
 def configure_logging(loglevel: Optional[LogLevel]) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/logging.py#L24)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/logging.py#L24)
 
 Configure "quixstreams" logger.
 
@@ -52,7 +52,7 @@ True if logging config has been updated, otherwise False.
 class TopicCreationConfigs()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L51)
 
 <a id="quixstreams.platforms.quix.config.TopicCreationConfigs.name"></a>
 
@@ -68,7 +68,7 @@ Required when not created by a Quix App.
 def strip_workspace_id_prefix(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L60)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -91,7 +91,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L72)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L72)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -114,7 +114,7 @@ the string with workspace_id prepended
 class QuixKafkaConfigsBuilder()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L84)
 
 Retrieves all the necessary information from the Quix API and builds all the
 objects required to connect a confluent-kafka client to the Quix Platform.
@@ -138,7 +138,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
              workspace_cert_path: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L100)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L100)
 
 **Arguments**:
 
@@ -154,7 +154,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
 def strip_workspace_id_prefix(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L179)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L179)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -176,7 +176,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L189)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -199,7 +199,7 @@ def search_for_workspace(
         workspace_name_or_id: Optional[str] = None) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L199)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L199)
 
 Search for a workspace given an expected workspace name or id.
 
@@ -219,7 +219,7 @@ the workspace data dict if search success, else None
 def get_workspace_info(known_workspace_topic: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L222)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L222)
 
 Queries for workspace data from the Quix API, regardless of instance cache,
 
@@ -237,7 +237,7 @@ and updates instance attributes from query result.
 def search_workspace_for_topic(workspace_id: str, topic: str) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L249)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L249)
 
 Search through all the topics in the given workspace id to see if there is a
 
@@ -260,7 +260,7 @@ the workspace_id if success, else None
 def search_for_topic_workspace(topic: str) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L265)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L265)
 
 Find what workspace a topic belongs to.
 
@@ -284,7 +284,7 @@ def get_workspace_ssl_cert(
         extract_to_folder: Optional[Path] = None) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L286)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L286)
 
 Gets and extracts zipped certificate from the API to provided folder if the
 
@@ -309,7 +309,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout_seconds: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L363)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L363)
 
 Create topics in a Quix cluster.
 
@@ -327,7 +327,7 @@ marked as "Ready" (and thus ready to produce to/consume from).
 def confirm_topics_exist(topics: Union[List[Topic], List[str]])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L412)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L412)
 
 Confirm whether the desired set of topics exists in the Quix workspace.
 
@@ -343,7 +343,7 @@ Confirm whether the desired set of topics exists in the Quix workspace.
 def get_confluent_broker_config(known_topic: Optional[str] = None) -> dict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L452)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L452)
 
 Get the full client config dictionary required to authenticate a confluent-kafka
 
@@ -372,7 +372,7 @@ def get_confluent_client_configs(
 ) -> Tuple[dict, List[str], Optional[str]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L497)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/config.py#L497)
 
 Get all the values you need in order to use a confluent_kafka-based client
 
@@ -405,7 +405,7 @@ and consumer group name
 class QuixEnvironment()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L7)
 
 Class to access various Quix platform environment settings
 
@@ -418,7 +418,7 @@ Class to access various Quix platform environment settings
 def state_management_enabled() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L19)
 
 Check whether "State management" is enabled for the current deployment
 
@@ -435,7 +435,7 @@ True if state management is enabled, otherwise False
 def deployment_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L27)
 
 Return current Quix deployment id.
 
@@ -455,7 +455,7 @@ deployment id or None
 def workspace_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L39)
 
 Return Quix workspace id if set
 
@@ -472,7 +472,7 @@ workspace id or None
 def portal_api() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L47)
 
 Return Quix Portal API url if set
 
@@ -489,7 +489,7 @@ portal API URL or None
 def sdk_token() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L56)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L56)
 
 Return Quix SDK token if set
 
@@ -506,7 +506,7 @@ sdk token or None
 def state_dir() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/env.py#L64)
 
 Return application state directory on Quix.
 
@@ -526,7 +526,7 @@ path to state dir
 def check_state_management_enabled()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/checks.py#L11)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/checks.py#L11)
 
 Check if State Management feature is enabled for the current deployment on
 Quix platform.
@@ -540,7 +540,7 @@ If it's disabled, the exception will be raised.
 def check_state_dir(state_dir: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/checks.py#L28)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/checks.py#L28)
 
 Check if Application "state_dir" matches the state dir on Quix platform.
 
@@ -566,7 +566,7 @@ If it doesn't match, the warning will be logged.
 class QuixPortalApiService()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/api.py#L15)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/api.py#L15)
 
 A light wrapper around the Quix Portal Api. If used in the Quix Platform, it will
 use that workspaces auth token and portal endpoint, else you must provide it.
@@ -588,7 +588,7 @@ def get_workspace_certificate(
         workspace_id: Optional[str] = None) -> Optional[bytes]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/api.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/api.py#L92)
 
 Get a workspace TLS certificate if available.
 
@@ -614,7 +614,7 @@ certificate as bytes if present, or None
 class QuixTopicManager(TopicManager)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/topic_manager.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/topic_manager.py#L9)
 
 The source of all topic management with quixstreams.
 
@@ -636,7 +636,7 @@ def __init__(topic_admin: TopicAdmin,
              quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/topic_manager.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/platforms/quix/topic_manager.py#L29)
 
 **Arguments**:
 
@@ -657,7 +657,7 @@ generated for you.
 class StreamingDataFrame(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L32)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L32)
 
 `StreamingDataFrame` is the main object you will use for ETL work.
 
@@ -713,7 +713,7 @@ def apply(func: Union[DataFrameFunc, DataFrameStatefulFunc],
           expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L109)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L109)
 
 Apply a function to transform the value and return a new value.
 
@@ -755,7 +755,7 @@ def update(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L152)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L152)
 
 Apply a function to mutate value in-place or to perform a side effect
 
@@ -797,7 +797,7 @@ def filter(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L191)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L191)
 
 Filter value using provided function.
 
@@ -839,7 +839,7 @@ of type `State` to perform stateful operations.
 def contains(key: str) -> StreamingSeries
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L244)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L244)
 
 Check if the key is present in the Row value.
 
@@ -871,7 +871,7 @@ def to_topic(topic: Topic,
              key: Optional[Callable[[object], object]] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L267)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L267)
 
 Produce current value to a topic. You can optionally specify a new key.
 
@@ -913,7 +913,7 @@ By default, the current message key will be used.
 def compose() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L306)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L306)
 
 Compose all functions of this StreamingDataFrame into one big closure.
 
@@ -950,7 +950,7 @@ and returns a result of StreamingDataFrame
 def test(value: object, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L336)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L336)
 
 A shorthand to test `StreamingDataFrame` with provided value
 
@@ -978,7 +978,7 @@ def tumbling_window(duration_ms: Union[int, timedelta],
                     name: Optional[str] = None) -> TumblingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L354)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L354)
 
 Create a tumbling window transformation on this StreamingDataFrame.
 
@@ -1054,7 +1054,7 @@ def hopping_window(duration_ms: Union[int, timedelta],
                    name: Optional[str] = None) -> HoppingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L429)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/dataframe.py#L429)
 
 Create a hopping window transformation on this StreamingDataFrame.
 
@@ -1141,7 +1141,7 @@ like `sum`, `count`, etc. and applied to the StreamingDataFrame.
 class StreamingSeries(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L17)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L17)
 
 `StreamingSeries` are typically generated by `StreamingDataframes` when getting
 elements from, or performing certain operations on, a `StreamingDataframe`,
@@ -1199,7 +1199,7 @@ sdf = sdf[["column_a"] & (sdf["new_sum_field"] >= 10)]
 def from_func(cls, func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L77)
 
 Create a StreamingSeries from a function.
 
@@ -1221,7 +1221,7 @@ instance of `StreamingSeries`
 def apply(func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L91)
 
 Add a callable to the execution list for this series.
 
@@ -1266,7 +1266,7 @@ def compose(allow_filters: bool = True,
             allow_updates: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L125)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L125)
 
 Compose all functions of this StreamingSeries into one big closure.
 
@@ -1318,7 +1318,7 @@ and returns a result of `StreamingSeries`
 def test(value: Any, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L172)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L172)
 
 A shorthand to test `StreamingSeries` with provided value
 
@@ -1344,7 +1344,7 @@ result of `StreamingSeries`
 def isin(other: Container) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L208)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L208)
 
 Check if series value is in "other".
 
@@ -1381,7 +1381,7 @@ new StreamingSeries
 def contains(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L235)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L235)
 
 Check if series value contains "other"
 
@@ -1418,7 +1418,7 @@ new StreamingSeries
 def is_(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L260)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L260)
 
 Check if series value refers to the same object as `other`
 
@@ -1452,7 +1452,7 @@ new StreamingSeries
 def isnot(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L283)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L283)
 
 Check if series value does not refer to the same object as `other`
 
@@ -1487,7 +1487,7 @@ new StreamingSeries
 def isnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L307)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L307)
 
 Check if series value is None.
 
@@ -1518,7 +1518,7 @@ new StreamingSeries
 def notnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L330)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L330)
 
 Check if series value is not None.
 
@@ -1549,7 +1549,7 @@ new StreamingSeries
 def abs() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L353)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/series.py#L353)
 
 Get absolute value of the series value.
 
@@ -1585,7 +1585,7 @@ new StreamingSeries
 def ensure_milliseconds(delta: Union[int, timedelta]) -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/utils.py#L5)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/utils.py#L5)
 
 Convert timedelta to milliseconds.
 
@@ -1617,7 +1617,7 @@ timedelta value in milliseconds as `int`
 class FixedTimeWindowDefinition(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/definitions.py#L20)
 
 <a id="quixstreams.dataframe.windows.definitions.FixedTimeWindowDefinition.sum"></a>
 
@@ -1627,7 +1627,7 @@ class FixedTimeWindowDefinition(abc.ABC)
 def sum() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L68)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/definitions.py#L68)
 
 Configure the window to aggregate data by summing up values within
 
@@ -1645,7 +1645,7 @@ an instance of `FixedTimeWindow` configured to perform sum aggregation.
 def count() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L95)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/definitions.py#L95)
 
 Configure the window to aggregate data by counting the number of values
 
@@ -1663,7 +1663,7 @@ an instance of `FixedTimeWindow` configured to perform record count.
 def mean() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/definitions.py#L122)
 
 Configure the window to aggregate data by calculating the mean of the values
 
@@ -1683,7 +1683,7 @@ def reduce(reducer: Callable[[Any, Any], Any],
            initializer: Callable[[Any], Any]) -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/definitions.py#L153)
 
 Configure the window to perform a custom aggregation using `reducer`
 
@@ -1732,7 +1732,7 @@ A window configured to perform custom reduce aggregation on the data.
 def max() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L213)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/definitions.py#L213)
 
 Configure a window to aggregate the maximum value within each window period.
 
@@ -1749,7 +1749,7 @@ value within each window period.
 def min() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L242)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/definitions.py#L242)
 
 Configure a window to aggregate the minimum value within each window period.
 
@@ -1774,7 +1774,7 @@ value within each window period.
 class FixedTimeWindow()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/time_based.py#L32)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/time_based.py#L32)
 
 <a id="quixstreams.dataframe.windows.time_based.FixedTimeWindow.final"></a>
 
@@ -1784,7 +1784,7 @@ class FixedTimeWindow()
 def final(expand: bool = True) -> "StreamingDataFrame"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/time_based.py#L95)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/time_based.py#L95)
 
 Apply the window aggregation and return results only when the windows are
 
@@ -1822,7 +1822,7 @@ Default - `True`
 def current(expand: bool = True) -> "StreamingDataFrame"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/time_based.py#L132)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/time_based.py#L132)
 
 Apply the window transformation to the StreamingDataFrame to return results
 
@@ -1860,7 +1860,7 @@ def get_window_ranges(timestamp_ms: int,
                       step_ms: Optional[int] = None) -> List[Tuple[int, int]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/base.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/dataframe/windows/base.py#L22)
 
 Get a list of window ranges for the given timestamp.
 
@@ -1890,7 +1890,7 @@ a list of (<start>, <end>) tuples
 class RowProducer(Producer, RowProducerProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowproducer.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/rowproducer.py#L25)
 
 A producer class that is capable of serializing Rows to bytes and send them to Kafka.
 
@@ -1928,7 +1928,7 @@ def produce_row(row: Row,
                 timestamp: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowproducer.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/rowproducer.py#L66)
 
 Serialize Row to bytes according to the Topic serialization settings
 
@@ -1952,7 +1952,7 @@ If this method fails, it will trigger the provided "on_error" callback.
 def poll(timeout: float = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowproducer.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/rowproducer.py#L103)
 
 Polls the producer for events and calls `on_delivery` callbacks.
 
@@ -1974,7 +1974,7 @@ If poll fails, it will trigger the provided "on_error" callback
 class StreamFunction(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/functions.py#L27)
 
 A base class for all the streaming operations in Quix Streams.
 
@@ -1992,7 +1992,7 @@ It provides two methods that return closures to be called on the input values:
 def func() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/functions.py#L44)
 
 The original function
 
@@ -2005,7 +2005,7 @@ The original function
 def get_executor() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/functions.py#L51)
 
 Returns a wrapper to be called on a single value.
 
@@ -2018,7 +2018,7 @@ Returns a wrapper to be called on a single value.
 def get_executor_expanded() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L57)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/functions.py#L57)
 
 Returns a wrapper to be called on a list of expanded values.
 
@@ -2030,7 +2030,7 @@ Returns a wrapper to be called on a list of expanded values.
 class ApplyFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L63)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/functions.py#L63)
 
 Wrap a function into "Apply" function.
 
@@ -2045,7 +2045,7 @@ and its result will always be passed downstream.
 class ApplyExpandFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L86)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/functions.py#L86)
 
 Wrap a function into "Apply" function and expand the returned iterable
 into separate values downstream.
@@ -2061,7 +2061,7 @@ If the returned value is not `Iterable`, `TypeError` will be raised.
 class FilterFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/functions.py#L115)
 
 Wraps a function into a "Filter" function.
 The result of a Filter function is interpreted as boolean.
@@ -2077,7 +2077,7 @@ value is filtered out.
 class UpdateFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L147)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/functions.py#L147)
 
 Wrap a function into an "Update" function.
 
@@ -2097,7 +2097,7 @@ def compose(functions: List[StreamFunction],
             allow_expands: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L176)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/functions.py#L176)
 
 Composes a list of functions and its parents into a single
 
@@ -2131,7 +2131,7 @@ def composer(outer_func: StreamCallable,
              inner_func: StreamCallable) -> Callable[[T], R]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/functions.py#L228)
 
 A function that wraps two other functions into a closure.
 
@@ -2157,7 +2157,7 @@ a function with one argument (value)
 class Stream()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/stream.py#L22)
 
 <a id="quixstreams.core.stream.stream.Stream.__init__"></a>
 
@@ -2168,7 +2168,7 @@ def __init__(func: Optional[StreamFunction] = None,
              parent: Optional[Self] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/stream.py#L23)
 
 A base class for all streaming operations.
 
@@ -2211,7 +2211,7 @@ Default - "Apply(lambda v: v)".
 def add_filter(func: Callable[[T], R]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/stream.py#L79)
 
 Add a function to filter values from the Stream.
 
@@ -2235,7 +2235,7 @@ a new `Stream` derived from the current one
 def add_apply(func: Callable[[T], R], expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/stream.py#L92)
 
 Add an "apply" function to the Stream.
 
@@ -2261,7 +2261,7 @@ a new `Stream` derived from the current one
 def add_update(func: Callable[[T], object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L109)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/stream.py#L109)
 
 Add an "update" function to the Stream, that will mutate the input value.
 
@@ -2284,7 +2284,7 @@ a new Stream derived from the current one
 def diff(other: "Stream") -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L121)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/stream.py#L121)
 
 Takes the difference between Streams `self` and `other` based on their last
 
@@ -2316,7 +2316,7 @@ new `Stream` instance including all the Streams from the diff
 def tree() -> List[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/stream.py#L150)
 
 Return a list of all parent Streams including the node itself.
 
@@ -2336,7 +2336,7 @@ def compose(allow_filters: bool = True,
             allow_expands: bool = True) -> Callable[[T], R]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L164)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/core/stream/stream.py#L164)
 
 Compose a list of functions from this `Stream` and its parents into one
 
@@ -2378,7 +2378,7 @@ the stream has functions with "expand=True" in the tree. Default - True.
 def dict_values(d: object) -> List
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/utils/dicts.py#L4)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/utils/dicts.py#L4)
 
 Recursively unpacks a set of nested dicts to get a flattened list of leaves,
 
@@ -2406,7 +2406,7 @@ a list with all the leaves of the various contained dicts
 def dumps(value: Any) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/utils/json.py#L8)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/utils/json.py#L8)
 
 Serialize to JSON using `orjson` package.
 
@@ -2426,7 +2426,7 @@ bytes
 def loads(value: bytes) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/utils/json.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/utils/json.py#L18)
 
 Deserialize from JSON using `orjson` package.
 
@@ -2458,7 +2458,7 @@ object
 class TimestampType(enum.IntEnum)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/timestamps.py#L8)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/timestamps.py#L8)
 
 <a id="quixstreams.models.timestamps.TimestampType.TIMESTAMP_NOT_AVAILABLE"></a>
 
@@ -2486,7 +2486,7 @@ broker receive time
 class MessageTimestamp()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/timestamps.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/timestamps.py#L14)
 
 Represents a timestamp of incoming Kafka message.
 
@@ -2502,7 +2502,7 @@ it should not be mutated during message processing.
 def create(cls, timestamp_type: int, milliseconds: int) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/timestamps.py#L41)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/timestamps.py#L41)
 
 Create a Timestamp object based on data
 
@@ -2539,7 +2539,7 @@ Timestamp object
 class MessageContext()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/messagecontext.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/messagecontext.py#L7)
 
 An object with Kafka message properties.
 
@@ -2558,7 +2558,7 @@ it should not be mutated during message processing.
 class ConfluentKafkaMessageProto(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/types.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/types.py#L12)
 
 An interface of `confluent_kafka.Message`.
 
@@ -2583,7 +2583,7 @@ see https://github.com/confluentinc/confluent-kafka-python/issues/1535.
 class IgnoreMessage(exceptions.QuixException)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/exceptions.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/exceptions.py#L51)
 
 Raise this exception from Deserializer.__call__ in order to ignore the processing
 of the particular message.
@@ -2600,7 +2600,7 @@ of the particular message.
 class QuixDeserializer(JSONDeserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L70)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L73)
 
 Handles Deserialization for any Quix-formatted topic.
 
@@ -2615,7 +2615,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L80)
 
 **Arguments**:
 
@@ -2633,7 +2633,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L97)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L100)
 
 Each Quix message might contain data for multiple Rows.
 This property informs the downstream processors about that, so they can
@@ -2648,7 +2648,7 @@ def deserialize(model_key: str, value: Union[List[Mapping],
                                              Mapping]) -> Iterable[Mapping]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L153)
 
 Deserialization function for particular data types (Timeseries or EventData).
 
@@ -2669,7 +2669,7 @@ Iterable of dicts
 class QuixSerializer(JSONSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L266)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L274)
 
 <a id="quixstreams.models.serializers.quix.QuixSerializer.__init__"></a>
 
@@ -2680,7 +2680,7 @@ def __init__(as_legacy: bool = True,
              dumps: Callable[[Any], Union[str, bytes]] = default_dumps)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L270)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L278)
 
 Serializer that returns data in json format.
 
@@ -2698,7 +2698,7 @@ Default - :py:func:`quixstreams.utils.json.dumps`
 class QuixTimeseriesSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L313)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L321)
 
 Serialize data to JSON formatted according to Quix Timeseries format.
 
@@ -2730,7 +2730,7 @@ Output:
 class QuixEventsSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L401)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L409)
 
 Serialize data to JSON formatted according to Quix EventData format.
 The input value is expected to be a dictionary with the following keys:
@@ -2771,7 +2771,7 @@ Output:
 class BytesDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L44)
 
 A deserializer to bypass bytes without any changes
 
@@ -2783,7 +2783,7 @@ A deserializer to bypass bytes without any changes
 class BytesSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L55)
 
 A serializer to bypass bytes without any changes
 
@@ -2795,7 +2795,7 @@ A serializer to bypass bytes without any changes
 class StringDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L64)
 
 <a id="quixstreams.models.serializers.simple_types.StringDeserializer.__init__"></a>
 
@@ -2805,7 +2805,7 @@ class StringDeserializer(Deserializer)
 def __init__(column_name: Optional[str] = None, codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L65)
 
 Deserializes bytes to strings using the specified encoding.
 
@@ -2822,7 +2822,7 @@ A wrapper around `confluent_kafka.serialization.StringDeserializer`.
 class IntegerDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L84)
 
 Deserializes bytes to integers.
 
@@ -2836,7 +2836,7 @@ A wrapper around `confluent_kafka.serialization.IntegerDeserializer`.
 class DoubleDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L103)
 
 Deserializes float to IEEE 764 binary64.
 
@@ -2850,7 +2850,7 @@ A wrapper around `confluent_kafka.serialization.DoubleDeserializer`.
 class StringSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L122)
 
 <a id="quixstreams.models.serializers.simple_types.StringSerializer.__init__"></a>
 
@@ -2860,7 +2860,7 @@ class StringSerializer(Serializer)
 def __init__(codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L123)
 
 Serializes strings to bytes using the specified encoding.
 
@@ -2876,7 +2876,7 @@ Serializes strings to bytes using the specified encoding.
 class IntegerSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L135)
 
 Serializes integers to bytes
 
@@ -2888,7 +2888,7 @@ Serializes integers to bytes
 class DoubleSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L148)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L148)
 
 Serializes floats to bytes
 
@@ -2904,7 +2904,7 @@ Serializes floats to bytes
 class JSONSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/json.py#L13)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/json.py#L13)
 
 <a id="quixstreams.models.serializers.json.JSONSerializer.__init__"></a>
 
@@ -2914,7 +2914,7 @@ class JSONSerializer(Serializer)
 def __init__(dumps: Callable[[Any], Union[str, bytes]] = default_dumps)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/json.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/json.py#L14)
 
 Serializer that returns data in json format.
 
@@ -2931,7 +2931,7 @@ Default - :py:func:`quixstreams.utils.json.dumps`
 class JSONDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/json.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/json.py#L35)
 
 <a id="quixstreams.models.serializers.json.JSONDeserializer.__init__"></a>
 
@@ -2942,7 +2942,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/json.py#L36)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/json.py#L36)
 
 Deserializer that parses data from JSON
 
@@ -2965,7 +2965,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 class SerializationContext()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/base.py#L22)
 
 Provides additional context for message serialization/deserialization.
 
@@ -2979,7 +2979,7 @@ Every `Serializer` and `Deserializer` receives an instance of `SerializationCont
 def to_confluent_ctx(field: MessageField) -> _SerializationContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/base.py#L35)
 
 Convert `SerializationContext` to `confluent_kafka.SerializationContext`
 
@@ -3001,7 +3001,7 @@ instance of `confluent_kafka.serialization.SerializationContext`
 class Deserializer(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/base.py#L47)
 
 <a id="quixstreams.models.serializers.base.Deserializer.__init__"></a>
 
@@ -3011,7 +3011,7 @@ class Deserializer(abc.ABC)
 def __init__(column_name: Optional[str] = None, *args, **kwargs)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L48)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/base.py#L48)
 
 A base class for all Deserializers
 
@@ -3029,7 +3029,7 @@ dictionary with `column_name` as a key.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L58)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/base.py#L58)
 
 Return True if the deserialized message should be considered as Iterable
 and each item in it should be processed as a separate message.
@@ -3042,7 +3042,7 @@ and each item in it should be processed as a separate message.
 class Serializer(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L75)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/base.py#L75)
 
 A base class for all Serializers
 
@@ -3055,7 +3055,7 @@ A base class for all Serializers
 def extra_headers() -> MessageHeadersMapping
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L81)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/base.py#L81)
 
 Informs producer to set additional headers
 
@@ -3084,7 +3084,7 @@ dict with headers
 class Row()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/rows.py#L11)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/rows.py#L11)
 
 Row is a dict-like interface on top of the message data + some Kafka props
 
@@ -3096,7 +3096,7 @@ Row is a dict-like interface on top of the message data + some Kafka props
 def keys() -> KeysView
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/rows.py#L73)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/rows.py#L73)
 
 Also allows unpacking row.value via **row
 
@@ -3108,7 +3108,7 @@ Also allows unpacking row.value via **row
 def clone(value: dict) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/rows.py#L85)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/rows.py#L85)
 
 Manually clone the Row; doing it this way is much faster than doing a deepcopy
 on the entire Row object.
@@ -3129,7 +3129,7 @@ on the entire Row object.
 def convert_topic_list(topics: List[Topic]) -> List[ConfluentTopic]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/admin.py#L23)
 
 Converts `Topic`s to `ConfluentTopic`s as required for Confluent's
 
@@ -3151,7 +3151,7 @@ list of confluent_kafka `ConfluentTopic`s
 class TopicAdmin()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L46)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/admin.py#L46)
 
 For performing "admin"-level operations on a Kafka cluster, mostly around topics.
 
@@ -3165,7 +3165,7 @@ Primarily used to create and inspect topic configurations.
 def __init__(broker_address: str, extra_config: Optional[Mapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/admin.py#L53)
 
 **Arguments**:
 
@@ -3180,7 +3180,7 @@ def __init__(broker_address: str, extra_config: Optional[Mapping] = None)
 def list_topics() -> Dict[str, ConfluentTopicMetadata]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L74)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/admin.py#L74)
 
 Get a list of topics and their metadata from a Kafka cluster
 
@@ -3196,7 +3196,7 @@ a dict of topic names and their metadata objects
 def inspect_topics(topic_names: List[str]) -> Dict[str, Optional[TopicConfig]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L83)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/admin.py#L83)
 
 A simplified way of getting the topic configurations of the provided topics
 
@@ -3220,7 +3220,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout: int = 60)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L156)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/admin.py#L156)
 
 Create the given list of topics and confirm they are ready.
 
@@ -3246,7 +3246,7 @@ fail (it ignores issues for a topic already existing).
 class TopicConfig()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L43)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/topic.py#L43)
 
 Represents all kafka-level configuration for a kafka topic.
 
@@ -3260,7 +3260,7 @@ Generally used by Topic and any topic creation procedures.
 class Topic()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/topic.py#L84)
 
 A representation of a Kafka topic and its expected data format via
 designated key and value serializers/deserializers.
@@ -3284,7 +3284,7 @@ def __init__(
         timestamp_extractor: Optional[TimestampExtractor] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L94)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/topic.py#L94)
 
 Can specify serialization that should be used when consuming/producing
 
@@ -3341,7 +3341,7 @@ topic = Topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/topic.py#L158)
 
 Topic name
 
@@ -3353,7 +3353,7 @@ Topic name
 def row_serialize(row: Row, key: Optional[Any] = None) -> KafkaMessage
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L168)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/topic.py#L168)
 
 Serialize Row to a Kafka message structure
 
@@ -3375,7 +3375,7 @@ def row_deserialize(
         message: ConfluentKafkaMessageProto) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L191)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/topic.py#L191)
 
 Deserialize incoming Kafka message to a Row.
 
@@ -3403,7 +3403,7 @@ Row, list of Rows or None if the message is ignored.
 def affirm_ready_for_create(topics: List[Topic])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/manager.py#L19)
 
 Validate a list of topics is ready for creation attempt
 
@@ -3419,7 +3419,7 @@ Validate a list of topics is ready for creation attempt
 class TopicManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/manager.py#L29)
 
 The source of all topic management with quixstreams.
 
@@ -3437,7 +3437,7 @@ See methods for details.
 def __init__(topic_admin: TopicAdmin, create_timeout: int = 60)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L48)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/manager.py#L48)
 
 **Arguments**:
 
@@ -3453,7 +3453,7 @@ def __init__(topic_admin: TopicAdmin, create_timeout: int = 60)
 def changelog_topics() -> Dict[str, Dict[str, Topic]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/manager.py#L71)
 
 Note: `Topic`s are the changelogs.
 
@@ -3469,7 +3469,7 @@ def topic_config(num_partitions: Optional[int] = None,
                  extra_config: Optional[dict] = None) -> TopicConfig
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L121)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/manager.py#L121)
 
 Convenience method for generating a `TopicConfig` with default settings
 
@@ -3497,7 +3497,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/manager.py#L142)
 
 A convenience method for generating a `Topic`. Will use default config options
 
@@ -3527,7 +3527,7 @@ def changelog_topic(topic_name: str, store_name: str,
                     consumer_group: str) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L191)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/manager.py#L191)
 
 Performs all the logic necessary to generate a changelog topic based on a
 
@@ -3566,7 +3566,7 @@ generate changelog topics. To turn off changelogs, init an Application with
 def create_topics(topics: List[Topic])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L262)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/manager.py#L262)
 
 Creates topics via an explicit list of provided `Topics`.
 
@@ -3585,7 +3585,7 @@ Exists as a way to manually specify what topics to create; otherwise,
 def create_all_topics()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L277)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/manager.py#L277)
 
 A convenience method to create all Topic objects stored on this TopicManager.
 
@@ -3597,7 +3597,7 @@ A convenience method to create all Topic objects stored on this TopicManager.
 def validate_all_topics()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L283)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/topics/manager.py#L283)
 
 Validates all topics exist and changelogs have correct topic and rep factor.
 
@@ -3615,7 +3615,7 @@ Issues are pooled and raised as an Exception once inspections are complete.
 class WindowedRocksDBStore(RocksDBStore)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/store.py#L10)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/store.py#L10)
 
 RocksDB-based windowed state store.
 
@@ -3635,7 +3635,7 @@ def __init__(
         options: Optional[RocksDBOptionsType] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/store.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/store.py#L18)
 
 **Arguments**:
 
@@ -3658,7 +3658,7 @@ if using changelogs
 class WindowedRocksDBStorePartition(RocksDBStorePartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/partition.py#L24)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/partition.py#L24)
 
 A base class to access windowed state in RocksDB.
 
@@ -3688,7 +3688,7 @@ stores the expiration index to delete expired windows.
 class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/transaction.py#L21)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/transaction.py#L21)
 
 <a id="quixstreams.state.rocksdb.windowed.transaction.WindowedRocksDBPartitionTransaction.expire_windows"></a>
 
@@ -3699,7 +3699,7 @@ def expire_windows(duration_ms: int,
                    grace_ms: int = 0) -> List[Tuple[Tuple[int, int], Any]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/transaction.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/transaction.py#L79)
 
 Get a list of expired windows from RocksDB considering latest timestamp,
 
@@ -3737,7 +3737,7 @@ sorted list of tuples in format `((start, end), value)`
 def parse_window_key(key: bytes) -> Tuple[bytes, int, int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/serialization.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/serialization.py#L12)
 
 Parse the window key from Rocksdb into (message_key, start, end) structure.
 
@@ -3760,7 +3760,7 @@ a tuple with message key, start timestamp, end timestamp
 def encode_window_key(start_ms: int, end_ms: int) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/serialization.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/serialization.py#L39)
 
 Encode window start and end timestamps into bytes of the following format:
 
@@ -3785,7 +3785,7 @@ window timestamps as bytes
 def encode_window_prefix(prefix: bytes, start_ms: int) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/serialization.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/serialization.py#L53)
 
 Encode window prefix and start time to iterate over keys in RocksDB
 
@@ -3813,7 +3813,7 @@ bytes
 class WindowedTransactionState(WindowedState)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/state.py#L9)
 
 <a id="quixstreams.state.rocksdb.windowed.state.WindowedTransactionState.__init__"></a>
 
@@ -3823,7 +3823,7 @@ class WindowedTransactionState(WindowedState)
 def __init__(transaction: "WindowedRocksDBPartitionTransaction")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/state.py#L12)
 
 A windowed state to be provided into `StreamingDataFrame` window functions.
 
@@ -3841,7 +3841,7 @@ def get_window(start_ms: int,
                default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/state.py#L20)
 
 Get the value of the window defined by `start` and `end` timestamps
 
@@ -3865,7 +3865,7 @@ value or None if the key is not found and `default` is not provided
 def update_window(start_ms: int, end_ms: int, value: Any, timestamp_ms: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L36)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/state.py#L36)
 
 Set a value for the window.
 
@@ -3887,7 +3887,7 @@ using the provided `timestamp`.
 def get_latest_timestamp() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/state.py#L53)
 
 Get the latest observed timestamp for the current state partition.
 
@@ -3907,7 +3907,7 @@ def expire_windows(duration_ms: int,
                    grace_ms: int = 0) -> List[Tuple[Tuple[int, int], Any]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/windowed/state.py#L65)
 
 Get a list of expired windows from RocksDB considering the current
 latest timestamp, window duration and grace period.
@@ -3929,7 +3929,7 @@ calling this method multiple times will yield different results for the same
 class RocksDBOptions(RocksDBOptionsType)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/options.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/options.py#L25)
 
 RocksDB database options.
 
@@ -3974,7 +3974,7 @@ Please see `rocksdict.Options` for a complete description of other options.
 def to_options() -> rocksdict.Options
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/options.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/options.py#L53)
 
 Convert parameters to `rocksdict.Options`
 
@@ -3994,7 +3994,7 @@ instance of `rocksdict.Options`
 class RocksDBStore(Store)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/store.py#L19)
 
 RocksDB-based state store.
 
@@ -4014,7 +4014,7 @@ def __init__(
         options: Optional[options_type] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/store.py#L29)
 
 **Arguments**:
 
@@ -4034,7 +4034,7 @@ if using changelogs
 def topic() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/store.py#L53)
 
 Store topic name
 
@@ -4047,7 +4047,7 @@ Store topic name
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/store.py#L60)
 
 Store name
 
@@ -4060,7 +4060,7 @@ Store name
 def partitions() -> Dict[int, RocksDBStorePartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/store.py#L67)
 
 Mapping of assigned store partitions
 
@@ -4072,7 +4072,7 @@ Mapping of assigned store partitions
 def assign_partition(partition: int) -> RocksDBStorePartition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L80)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/store.py#L80)
 
 Open and assign store partition.
 
@@ -4095,7 +4095,7 @@ instance of`RocksDBStorePartition`
 def revoke_partition(partition: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L117)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/store.py#L117)
 
 Revoke and close the assigned store partition.
 
@@ -4113,7 +4113,7 @@ If the partition is not assigned, it will log the message and return.
 def start_partition_transaction(partition: int) -> RocksDBPartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L138)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/store.py#L138)
 
 Start a new partition transaction.
 
@@ -4136,7 +4136,7 @@ instance of `RocksDBPartitionTransaction`
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L160)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/store.py#L160)
 
 Close the store and revoke all assigned partitions
 
@@ -4152,7 +4152,7 @@ Close the store and revoke all assigned partitions
 class RocksDBStorePartition(StorePartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L40)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L40)
 
 A base class to access state in RocksDB.
 
@@ -4180,7 +4180,7 @@ it will retry according to `open_max_retries` and `open_retry_backoff` options.
 def begin() -> RocksDBPartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L80)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L80)
 
 Create a new `RocksDBTransaction` object.
 
@@ -4199,7 +4199,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L106)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L106)
 
 Updates state from a given changelog message.
 
@@ -4215,7 +4215,7 @@ Updates state from a given changelog message.
 def set_changelog_offset(changelog_offset: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L130)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L130)
 
 Set the changelog offset based on a message (usually an "offset-only" message).
 
@@ -4235,7 +4235,7 @@ def produce_to_changelog(key: bytes,
                          headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L140)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L140)
 
 Produce a message to the StorePartitions respective changelog.
 
@@ -4247,7 +4247,7 @@ Produce a message to the StorePartitions respective changelog.
 def write(batch: WriteBatch)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L151)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L151)
 
 Write `WriteBatch` to RocksDB
 
@@ -4265,7 +4265,7 @@ def get(key: bytes,
         cf_name: str = "default") -> Union[None, bytes, Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L158)
 
 Get a key from RocksDB.
 
@@ -4287,7 +4287,7 @@ a value if the key is present in the DB. Otherwise, `default`
 def exists(key: bytes, cf_name: str = "default") -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L172)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L172)
 
 Check if a key is present in the DB.
 
@@ -4308,7 +4308,7 @@ Check if a key is present in the DB.
 def get_processed_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L183)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L183)
 
 Get last processed offset for the given partition
 
@@ -4324,7 +4324,7 @@ offset or `None` if there's no processed offset yet
 def get_changelog_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L195)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L195)
 
 Get offset that the changelog is up-to-date with.
 
@@ -4340,7 +4340,7 @@ offset or `None` if there's no processed offset yet
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L205)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L205)
 
 Close the underlying RocksDB
 
@@ -4353,7 +4353,7 @@ Close the underlying RocksDB
 def path() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L220)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L220)
 
 Absolute path to RocksDB database folder
 
@@ -4370,7 +4370,7 @@ file path
 def destroy(cls, path: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L228)
 
 Delete underlying RocksDB database
 
@@ -4388,7 +4388,7 @@ The database must be closed first.
 def get_column_family_handle(cf_name: str) -> ColumnFamily
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L238)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L238)
 
 Get a column family handle to pass to it WriteBatch.
 
@@ -4411,7 +4411,7 @@ instance of `rocksdict.ColumnFamily`
 def get_column_family(cf_name: str) -> Rdict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L259)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/partition.py#L259)
 
 Get a column family instance.
 
@@ -4441,7 +4441,7 @@ instance of `rocksdict.Rdict` for the given column family
 class RocksDBPartitionTransaction(PartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/transaction.py#L71)
 
 A transaction class to perform simple key-value operations like
 "get", "set", "delete" and "exists" on a single RocksDB partition.
@@ -4480,7 +4480,7 @@ def __init__(partition: "RocksDBStorePartition", dumps: DumpsFunc,
              loads: LoadsFunc)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L114)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/transaction.py#L114)
 
 **Arguments**:
 
@@ -4498,7 +4498,7 @@ the underlying RocksDB
 def with_prefix(prefix: Any = b"") -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L141)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/transaction.py#L141)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -4528,7 +4528,7 @@ def get(key: Any,
         cf_name: str = "default") -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L170)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/transaction.py#L170)
 
 Get a key from the store.
 
@@ -4557,7 +4557,7 @@ value or `default`
 def set(key: Any, value: Any, cf_name: str = "default")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L205)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/transaction.py#L205)
 
 Set a key to the store.
 
@@ -4578,7 +4578,7 @@ It first updates the key in the update cache.
 def delete(key: Any, cf_name: str = "default")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L230)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/transaction.py#L230)
 
 Delete a key from the store.
 
@@ -4598,7 +4598,7 @@ It first deletes the key from the update cache.
 def exists(key: Any, cf_name: str = "default") -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L253)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/transaction.py#L253)
 
 Check if a key exists in the store.
 
@@ -4622,7 +4622,7 @@ It first looks up the key in the update cache.
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L275)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/transaction.py#L275)
 
 Check if the transaction is completed.
 
@@ -4644,7 +4644,7 @@ The completed transaction should not be re-used.
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L289)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/transaction.py#L289)
 
 Check if the transaction has failed.
 
@@ -4664,7 +4664,7 @@ and
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L318)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/rocksdb/transaction.py#L318)
 
 Flush the recent updates to the database and empty the update cache.
 
@@ -4710,7 +4710,7 @@ cannot be used anymore.
 class RecoveryPartition()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L20)
 
 A changelog topic partition mapped to a respective `StorePartition` with helper
 methods to determine its current recovery status.
@@ -4726,7 +4726,7 @@ Since `StorePartition`s do recovery directly, it also handles recovery transacti
 def offset() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L41)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L41)
 
 Get the changelog offset from the underlying `StorePartition`.
 
@@ -4743,7 +4743,7 @@ changelog offset (int)
 def needs_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L50)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L50)
 
 Determine whether recovery is necessary for underlying `StorePartition`.
 
@@ -4756,7 +4756,7 @@ Determine whether recovery is necessary for underlying `StorePartition`.
 def needs_offset_update()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L59)
 
 Determine if an offset update is required.
 
@@ -4770,7 +4770,7 @@ Usually checked during assign if recovery was not required.
 def update_offset()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L67)
 
 Update only the changelog offset of a StorePartition.
 
@@ -4783,7 +4783,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L87)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L87)
 
 Recover the StorePartition using a message read from its respective changelog.
 
@@ -4799,7 +4799,7 @@ Recover the StorePartition using a message read from its respective changelog.
 def set_watermarks(lowwater: int, highwater: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L99)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L99)
 
 Set the changelog watermarks as gathered from Consumer.get_watermark_offsets()
 
@@ -4816,7 +4816,7 @@ Set the changelog watermarks as gathered from Consumer.get_watermark_offsets()
 class ChangelogProducerFactory()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L110)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L110)
 
 Generates ChangelogProducers, which produce changelog messages to a StorePartition.
 
@@ -4828,7 +4828,7 @@ Generates ChangelogProducers, which produce changelog messages to a StorePartiti
 def __init__(changelog_name: str, producer: RowProducer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L115)
 
 **Arguments**:
 
@@ -4847,7 +4847,7 @@ a ChangelogWriter instance
 def get_partition_producer(partition_num)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L125)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L125)
 
 Generate a ChangelogProducer for producing to a specific partition number
 
@@ -4865,7 +4865,7 @@ Generate a ChangelogProducer for producing to a specific partition number
 class ChangelogProducer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L137)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L137)
 
 Generated for a `StorePartition` to produce state changes to its respective
 kafka changelog partition.
@@ -4878,7 +4878,7 @@ kafka changelog partition.
 def __init__(changelog_name: str, partition_num: int, producer: RowProducer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L143)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L143)
 
 **Arguments**:
 
@@ -4896,7 +4896,7 @@ def produce(key: bytes,
             headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L153)
 
 Produce a message to a changelog topic partition.
 
@@ -4914,7 +4914,7 @@ Produce a message to a changelog topic partition.
 class RecoveryManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L178)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L178)
 
 Manages all consumer-related aspects of recovery, including:
     - assigning/revoking, pausing/resuming topic partitions (especially changelogs)
@@ -4934,7 +4934,7 @@ Recovery is attempted from the `Application` after any new partition assignment.
 def has_assignments() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L197)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L197)
 
 Whether the Application has assigned RecoveryPartitions
 
@@ -4951,7 +4951,7 @@ has assignments, as bool
 def recovering() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L206)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L206)
 
 Whether the Application is currently recovering
 
@@ -4967,7 +4967,7 @@ is recovering, as bool
 def register_changelog(topic_name: str, store_name: str, consumer_group: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L214)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L214)
 
 Register a changelog Topic with the TopicManager.
 
@@ -4985,7 +4985,7 @@ Register a changelog Topic with the TopicManager.
 def do_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L228)
 
 If there are any active RecoveryPartitions, do a recovery procedure.
 
@@ -5000,7 +5000,7 @@ def assign_partition(topic_name: str, partition_num: int,
                      store_partitions: Dict[str, StorePartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L274)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L274)
 
 Assigns `StorePartition`s (as `RecoveryPartition`s) ONLY IF recovery required.
 
@@ -5014,7 +5014,7 @@ Pauses active consumer partitions as needed.
 def revoke_partition(partition_num: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L336)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/recovery.py#L336)
 
 revoke ALL StorePartitions (across all Stores) for a given partition number
 
@@ -5038,7 +5038,7 @@ revoke ALL StorePartitions (across all Stores) for a given partition number
 class Store(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L14)
 
 Abstract state store.
 
@@ -5054,7 +5054,7 @@ partitions' transactions.
 def topic() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L25)
 
 Topic name
 
@@ -5067,7 +5067,7 @@ Topic name
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L32)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L32)
 
 Store name
 
@@ -5080,7 +5080,7 @@ Store name
 def partitions() -> Dict[int, "StorePartition"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L39)
 
 Mapping of assigned store partitions
 
@@ -5096,7 +5096,7 @@ dict of "{partition: <StorePartition>}"
 def assign_partition(partition: int) -> "StorePartition"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L46)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L46)
 
 Assign new store partition
 
@@ -5116,7 +5116,7 @@ instance of `StorePartition`
 def revoke_partition(partition: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L55)
 
 Revoke assigned store partition
 
@@ -5133,7 +5133,7 @@ def start_partition_transaction(
         partition: int) -> Optional["PartitionTransaction"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L63)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L63)
 
 Start a new partition transaction.
 
@@ -5155,7 +5155,7 @@ instance of `PartitionTransaction`
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L74)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L74)
 
 Close store and revoke all store partitions
 
@@ -5167,7 +5167,7 @@ Close store and revoke all store partitions
 class StorePartition(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L87)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L87)
 
 A base class to access state in the underlying storage.
 It represents a single instance of some storage (e.g. a single database for
@@ -5182,7 +5182,7 @@ the persistent storage).
 def path() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L96)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L96)
 
 Absolute path to RocksDB database folder
 
@@ -5194,7 +5194,7 @@ Absolute path to RocksDB database folder
 def begin() -> "PartitionTransaction"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L102)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L102)
 
 State new `PartitionTransaction`
 
@@ -5207,7 +5207,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L107)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L107)
 
 Updates state from a given changelog message.
 
@@ -5225,7 +5225,7 @@ def produce_to_changelog(key: bytes,
                          headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L117)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L117)
 
 Produce a message to the StorePartitions respective changelog.
 
@@ -5237,7 +5237,7 @@ Produce a message to the StorePartitions respective changelog.
 def get_processed_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L128)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L128)
 
 Get last processed offset for the given partition
 
@@ -5253,7 +5253,7 @@ offset or `None` if there's no processed offset yet
 def get_changelog_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L135)
 
 Get offset that the changelog is up-to-date with.
 
@@ -5269,7 +5269,7 @@ offset or `None` if there's no processed offset yet
 def set_changelog_offset(changelog_offset: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L142)
 
 Set the changelog offset based on a message (usually an "offset-only" message).
 
@@ -5287,7 +5287,7 @@ Used during recovery.
 class State(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L153)
 
 Primary interface for working with key-value state data from `StreamingDataFrame`
 
@@ -5299,7 +5299,7 @@ Primary interface for working with key-value state data from `StreamingDataFrame
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L158)
 
 Get the value for key if key is present in the state, else default
 
@@ -5320,7 +5320,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L168)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L168)
 
 Set value for the key.
 
@@ -5337,7 +5337,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L176)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L176)
 
 Delete value for the key.
 
@@ -5355,7 +5355,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L185)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L185)
 
 Check if the key exists in state.
 
@@ -5375,7 +5375,7 @@ True if key exists, False otherwise
 class PartitionTransaction(State)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L194)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L194)
 
 A transaction class to perform simple key-value operations like
 "get", "set", "delete" and "exists" on a single storage partition.
@@ -5389,7 +5389,7 @@ A transaction class to perform simple key-value operations like
 def state() -> State
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L201)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L201)
 
 An instance of State to be provided to `StreamingDataFrame` functions
 
@@ -5403,7 +5403,7 @@ An instance of State to be provided to `StreamingDataFrame` functions
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L209)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L209)
 
 Return `True` if transaction failed to update data at some point.
 
@@ -5422,7 +5422,7 @@ bool
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L219)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L219)
 
 Return `True` if transaction is completed.
 
@@ -5441,7 +5441,7 @@ bool
 def with_prefix(prefix: Any = b"") -> Iterator[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L229)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L229)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -5464,7 +5464,7 @@ context manager
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L240)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L240)
 
 Flush the recent updates and last processed offset to the storage.
 
@@ -5480,7 +5480,7 @@ Flush the recent updates and last processed offset to the storage.
 class WindowedState(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L253)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L253)
 
 A windowed state to be provided into `StreamingDataFrame` window functions.
 
@@ -5494,7 +5494,7 @@ def get_window(start_ms: int,
                default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L258)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L258)
 
 Get the value of the window defined by `start` and `end` timestamps
 
@@ -5518,7 +5518,7 @@ value or None if the key is not found and `default` is not provided
 def update_window(start_ms: int, end_ms: int, value: Any, timestamp_ms: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L272)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L272)
 
 Set a value for the window.
 
@@ -5540,7 +5540,7 @@ using the provided `timestamp`.
 def get_latest_timestamp() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L286)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L286)
 
 Get the latest observed timestamp for the current state partition.
 
@@ -5559,7 +5559,7 @@ latest observed event timestamp in milliseconds
 def expire_windows(duration_ms: int, grace_ms: int = 0)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L297)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L297)
 
 Get a list of expired windows from RocksDB considering the current
 
@@ -5582,7 +5582,7 @@ calling this method multiple times will yield different results for the same
 class WindowedPartitionTransaction(WindowedState)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L312)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L312)
 
 <a id="quixstreams.state.types.WindowedPartitionTransaction.failed"></a>
 
@@ -5593,7 +5593,7 @@ class WindowedPartitionTransaction(WindowedState)
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L318)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L318)
 
 Return `True` if transaction failed to update data at some point.
 
@@ -5612,7 +5612,7 @@ bool
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L328)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L328)
 
 Return `True` if transaction is completed.
 
@@ -5630,7 +5630,7 @@ bool
 def with_prefix(prefix: Any = b"") -> Iterator[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L337)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L337)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -5653,7 +5653,7 @@ context manager
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L348)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L348)
 
 Flush the recent updates and last processed offset to the storage.
 
@@ -5669,7 +5669,7 @@ Flush the recent updates and last processed offset to the storage.
 class PartitionRecoveryTransaction(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L361)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L361)
 
 A class for managing recovery for a StorePartition from a changelog message
 
@@ -5681,7 +5681,7 @@ A class for managing recovery for a StorePartition from a changelog message
 def flush()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L369)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/types.py#L369)
 
 Flush the recovery update and last processed offset to the storage.
 
@@ -5701,7 +5701,7 @@ Flush the recovery update and last processed offset to the storage.
 class StateStoreManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L31)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L31)
 
 Class for managing state stores and partitions.
 
@@ -5719,7 +5719,7 @@ StateStoreManager is responsible for:
 def stores() -> Dict[str, Dict[str, Store]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L71)
 
 Map of registered state stores
 
@@ -5736,7 +5736,7 @@ dict in format {topic: {store_name: store}}
 def recovery_required() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L79)
 
 Whether recovery needs to be done.
 
@@ -5749,7 +5749,7 @@ Whether recovery needs to be done.
 def using_changelogs() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L88)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L88)
 
 Whether the StateStoreManager is using changelog topics
 
@@ -5765,7 +5765,7 @@ using changelogs, as bool
 def do_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L96)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L96)
 
 Perform a state recovery, if necessary.
 
@@ -5777,7 +5777,7 @@ Perform a state recovery, if necessary.
 def stop_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L102)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L102)
 
 Stop recovery (called during app shutdown).
 
@@ -5790,7 +5790,7 @@ def get_store(topic: str,
               store_name: str = _DEFAULT_STATE_STORE_NAME) -> Store
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L108)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L108)
 
 Get a store for given name and topic
 
@@ -5812,7 +5812,7 @@ def register_store(topic_name: str,
                    store_name: str = _DEFAULT_STATE_STORE_NAME)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L141)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L141)
 
 Register a state store to be managed by StateStoreManager.
 
@@ -5834,7 +5834,7 @@ Each store can be registered only once for each topic.
 def register_windowed_store(topic_name: str, store_name: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L166)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L166)
 
 Register a windowed state store to be managed by StateStoreManager.
 
@@ -5856,7 +5856,7 @@ Each window store can be registered only once for each topic.
 def clear_stores()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L189)
 
 Delete all state stores managed by StateStoreManager.
 
@@ -5868,7 +5868,7 @@ Delete all state stores managed by StateStoreManager.
 def on_partition_assign(tp: TopicPartition) -> List[StorePartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L204)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L204)
 
 Assign store partitions for each registered store for the given `TopicPartition`
 
@@ -5890,7 +5890,7 @@ list of assigned `StorePartition`
 def on_partition_revoke(tp: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L223)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L223)
 
 Revoke store partitions for each registered store for the given `TopicPartition`
 
@@ -5906,7 +5906,7 @@ Revoke store partitions for each registered store for the given `TopicPartition`
 def on_partition_lost(tp: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L235)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L235)
 
 Revoke and close store partitions for each registered store for the given
 
@@ -5924,7 +5924,7 @@ Revoke and close store partitions for each registered store for the given
 def init()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L244)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L244)
 
 Initialize `StateStoreManager` and create a store directory
 
@@ -5937,7 +5937,7 @@ Initialize `StateStoreManager` and create a store directory
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L251)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L251)
 
 Close all registered stores
 
@@ -5950,7 +5950,7 @@ def get_store_transaction(
         store_name: str = _DEFAULT_STATE_STORE_NAME) -> PartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L259)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L259)
 
 Get active `PartitionTransaction` for the store
 
@@ -5968,7 +5968,7 @@ def start_store_transaction(topic: str, partition: int,
                             offset: int) -> Iterator["_MultiStoreTransaction"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L274)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/manager.py#L274)
 
 Starting the multi-store transaction for the Kafka message.
 
@@ -5997,7 +5997,7 @@ before the end of the current one will fail.
 class TransactionState(State)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L6)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/state.py#L6)
 
 <a id="quixstreams.state.state.TransactionState.__init__"></a>
 
@@ -6007,7 +6007,7 @@ class TransactionState(State)
 def __init__(transaction: PartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/state.py#L9)
 
 Simple key-value state to be provided into `StreamingDataFrame` functions
 
@@ -6023,7 +6023,7 @@ Simple key-value state to be provided into `StreamingDataFrame` functions
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L17)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/state.py#L17)
 
 Get the value for key if key is present in the state, else default
 
@@ -6044,7 +6044,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/state.py#L27)
 
 Set value for the key.
 
@@ -6061,7 +6061,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/state.py#L35)
 
 Delete value for the key.
 
@@ -6079,7 +6079,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/state/state.py#L44)
 
 Check if the key exists in state.
 
@@ -6107,7 +6107,7 @@ True if key exists, False otherwise
 class PartitionAssignmentError(QuixException)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/exceptions/assignment.py#L6)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/exceptions/assignment.py#L6)
 
 Error happened during partition rebalancing.
 Raised from `on_assign`, `on_revoke` and `on_lost` callbacks
@@ -6128,7 +6128,7 @@ Raised from `on_assign`, `on_revoke` and `on_lost` callbacks
 def set_message_context(context: Optional[MessageContext])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/context.py#L22)
 
 Set a MessageContext for the current message in the given `contextvars.Context`
 
@@ -6165,7 +6165,7 @@ sdf = sdf.update(lambda value: alter_context(value))
 def message_context() -> MessageContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/context.py#L53)
 
 Get a MessageContext for the current message, which houses most of the message
 
@@ -6200,7 +6200,7 @@ instance of `MessageContext`
 def message_key() -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/context.py#L84)
 
 Get the current message's key.
 
@@ -6236,7 +6236,7 @@ a deserialized message key
 class Producer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/producer.py#L54)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/producer.py#L54)
 
 <a id="quixstreams.kafka.producer.Producer.__init__"></a>
 
@@ -6248,7 +6248,7 @@ def __init__(broker_address: str,
              extra_config: Optional[dict] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/producer.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/producer.py#L55)
 
 A wrapper around `confluent_kafka.Producer`.
 
@@ -6284,7 +6284,7 @@ def produce(topic: str,
             buffer_error_max_tries: int = 3)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/producer.py#L94)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/producer.py#L94)
 
 Produce message to topic.
 
@@ -6313,7 +6313,7 @@ Pass `0` to not retry after `BufferError`.
 def poll(timeout: float = 0)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/producer.py#L152)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/producer.py#L152)
 
 Polls the producer for events and calls `on_delivery` callbacks.
 
@@ -6330,7 +6330,7 @@ Polls the producer for events and calls `on_delivery` callbacks.
 def flush(timeout: Optional[float] = None) -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/producer.py#L160)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/producer.py#L160)
 
 Wait for all messages in the Producer queue to be delivered.
 
@@ -6355,7 +6355,7 @@ number of messages delivered
 class Consumer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L66)
 
 <a id="quixstreams.kafka.consumer.Consumer.__init__"></a>
 
@@ -6372,7 +6372,7 @@ def __init__(broker_address: str,
              extra_config: Optional[dict] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L67)
 
 A wrapper around `confluent_kafka.Consumer`.
 
@@ -6410,7 +6410,7 @@ Note: values passed as arguments override values in `extra_config`.
 def poll(timeout: Optional[float] = None) -> Optional[Message]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L126)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L126)
 
 Consumes a single message, calls callbacks and returns events.
 
@@ -6445,7 +6445,7 @@ def subscribe(topics: List[str],
               on_lost: Optional[RebalancingCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L144)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L144)
 
 Set subscription to supplied list of topics
 
@@ -6483,7 +6483,7 @@ for example, may fail.
 def unsubscribe()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L238)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L238)
 
 Remove current subscription.
 
@@ -6501,7 +6501,7 @@ def store_offsets(message: Optional[Message] = None,
                   offsets: Optional[List[TopicPartition]] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L246)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L246)
 
 .. py:function:: store_offsets([message=None], [offsets=None])
 
@@ -6532,7 +6532,7 @@ def commit(message: Optional[Message] = None,
            asynchronous: bool = True) -> Optional[List[TopicPartition]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L280)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L280)
 
 Commit a message or a list of offsets.
 
@@ -6566,7 +6566,7 @@ def committed(partitions: List[TopicPartition],
               timeout: Optional[float] = None) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L320)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L320)
 
 .. py:function:: committed(partitions, [timeout=None])
 
@@ -6597,7 +6597,7 @@ def get_watermark_offsets(partition: TopicPartition,
                           cached: bool = False) -> Tuple[int, int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L340)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L340)
 
 Retrieve low and high offsets for the specified partition.
 
@@ -6630,7 +6630,7 @@ def list_topics(topic: Optional[str] = None,
                 timeout: Optional[float] = None) -> ClusterMetadata
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L366)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L366)
 
 .. py:function:: list_topics([topic=None], [timeout=-1])
 
@@ -6659,7 +6659,7 @@ None or -1 is infinite. Default: None
 def memberid() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L389)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L389)
 
 Return this client's broker-assigned group member id.
 
@@ -6680,7 +6680,7 @@ def offsets_for_times(partitions: List[TopicPartition],
                       timeout: Optional[float] = None) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L402)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L402)
 
 Look up offsets by timestamp for the specified partitions.
 
@@ -6707,7 +6707,7 @@ last message in the partition, a value of -1 will be returned.
 def pause(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L428)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L428)
 
 Pause consumption for the provided list of partitions.
 
@@ -6731,7 +6731,7 @@ Does NOT affect the result of Consumer.assignment().
 def resume(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L442)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L442)
 
 .. py:function:: resume(partitions)
 
@@ -6753,7 +6753,7 @@ Resume consumption for the provided list of partitions.
 def position(partitions: List[TopicPartition]) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L454)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L454)
 
 Retrieve current positions (offsets) for the specified partitions.
 
@@ -6780,7 +6780,7 @@ the last consumed message + 1.
 def seek(partition: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L468)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L468)
 
 Set consume position for partition to offset.
 
@@ -6808,7 +6808,7 @@ pass the offset in an `assign()` call.
 def assignment() -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L485)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L485)
 
 Returns the current partition assignment.
 
@@ -6829,7 +6829,7 @@ Returns the current partition assignment.
 def set_sasl_credentials(username: str, password: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L498)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L498)
 
 Sets the SASL credentials used for this client.
 These credentials will overwrite the old ones, and will be used the next
@@ -6846,7 +6846,7 @@ This method is applicable only to SASL PLAIN and SCRAM mechanisms.
 def incremental_assign(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L510)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L510)
 
 Assign new partitions.
 
@@ -6864,7 +6864,7 @@ Any additional partitions besides the ones passed during the `Consumer`
 def incremental_unassign(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L522)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L522)
 
 Revoke partitions.
 
@@ -6878,7 +6878,7 @@ Can be called outside an on_revoke callback.
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L530)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/kafka/consumer.py#L530)
 
 Close down and terminate the Kafka Consumer.
 
@@ -6904,7 +6904,7 @@ see `poll()` for more info.
 class Application()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L52)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L52)
 
 The main Application class.
 
@@ -6948,7 +6948,7 @@ app.run(dataframe=df)
 
 ```python
 def __init__(broker_address: str,
-             consumer_group: str,
+             consumer_group: str = "quixstreams-default",
              auto_offset_reset: AutoOffsetReset = "latest",
              auto_commit_enable: bool = True,
              partitioner: Partitioner = "murmur2",
@@ -6968,7 +6968,7 @@ def __init__(broker_address: str,
              topic_manager: Optional[TopicManager] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L91)
 
 **Arguments**:
 
@@ -6976,6 +6976,7 @@ def __init__(broker_address: str,
 Passed as `bootstrap.servers` to `confluent_kafka.Consumer`.
 - `consumer_group`: Kafka consumer group.
 Passed as `group.id` to `confluent_kafka.Consumer`
+Default - "quixstreams-default".
 - `auto_offset_reset`: Consumer `auto.offset.reset` setting
 - `auto_commit_enable`: If true, periodically commit offset of
 the last message handed to the application. Default - `True`.
@@ -7024,7 +7025,7 @@ or to produce a message to Kafka.
 ```python
 @classmethod
 def Quix(cls,
-         consumer_group: str,
+         consumer_group: str = "quixstreams-default",
          auto_offset_reset: AutoOffsetReset = "latest",
          auto_commit_enable: bool = True,
          partitioner: Partitioner = "murmur2",
@@ -7045,7 +7046,7 @@ def Quix(cls,
          topic_manager: Optional[QuixTopicManager] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L232)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L233)
 
 Initialize an Application to work with Quix platform,
 
@@ -7067,7 +7068,7 @@ Example Snippet:
 ```python
 from quixstreams import Application
 
-# Set up an `app = Application.Quix` and  `sdf = StreamingDataFrame`;
+# Set up an `app = Application.Quix` and `sdf = StreamingDataFrame`;
 # add some operations to `sdf` and then run everything. Also shows off how to
 # use the quix-specific serializers and deserializers.
 
@@ -7084,7 +7085,8 @@ app.run(dataframe=df)
 
 - `consumer_group`: Kafka consumer group.
 Passed as `group.id` to `confluent_kafka.Consumer`.
->***NOTE:*** The consumer group will be prefixed by Quix workspace id.
+Default - "quixstreams-default".
+  >***NOTE:*** The consumer group will be prefixed by Quix workspace id.
 - `auto_offset_reset`: Consumer `auto.offset.reset` setting
 - `auto_commit_enable`: If true, periodically commit offset of
 the last message handed to the application. Default - `True`.
@@ -7149,7 +7151,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L390)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L392)
 
 Create a topic definition.
 
@@ -7220,7 +7222,7 @@ topic = app.topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def dataframe(topic: Topic) -> StreamingDataFrame
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L470)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L472)
 
 A simple helper method that generates a `StreamingDataFrame`, which is used
 
@@ -7262,7 +7264,7 @@ to be used as an input topic.
 def stop()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L506)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L508)
 
 Stop the internal poll loop and the message processing.
 
@@ -7280,7 +7282,7 @@ To otherwise stop an application, either send a `SIGTERM` to the process
 def get_producer() -> Producer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L520)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L522)
 
 Create and return a pre-configured Producer instance.
 The Producer is initialized with params passed to Application.
@@ -7311,7 +7313,7 @@ with app.get_producer() as producer:
 def get_consumer() -> Consumer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L551)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L553)
 
 Create and return a pre-configured Consumer instance.
 The Consumer is initialized with params passed to Application.
@@ -7352,7 +7354,7 @@ with app.get_consumer() as consumer:
 def clear_state()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L595)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L597)
 
 Clear the state of the application.
 
@@ -7364,7 +7366,7 @@ Clear the state of the application.
 def run(dataframe: StreamingDataFrame)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L674)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/app.py#L676)
 
 Start processing data from Kafka using provided `StreamingDataFrame`
 
@@ -7404,7 +7406,7 @@ app.run(dataframe=df)
 class RowConsumer(Consumer, RowConsumerProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowconsumer.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/rowconsumer.py#L59)
 
 <a id="quixstreams.rowconsumer.RowConsumer.__init__"></a>
 
@@ -7422,7 +7424,7 @@ def __init__(broker_address: str,
              on_error: Optional[ConsumerErrorCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowconsumer.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/rowconsumer.py#L60)
 
 A consumer class that is capable of deserializing Kafka messages to Rows
 
@@ -7466,7 +7468,7 @@ def subscribe(topics: List[Topic],
               on_lost: Optional[RebalancingCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowconsumer.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/rowconsumer.py#L115)
 
 Set subscription to supplied list of topics.
 
@@ -7495,7 +7497,7 @@ for example, may fail.
 def poll_row(timeout: float = None) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowconsumer.py#L149)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/rowconsumer.py#L149)
 
 Consumes a single message and deserialize it to Row or a list of Rows.
 

--- a/docs/api-reference/quixstreams.md
+++ b/docs/api-reference/quixstreams.md
@@ -14,7 +14,7 @@
 def configure_logging(loglevel: Optional[LogLevel]) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/logging.py#L24)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/logging.py#L24)
 
 Configure "quixstreams" logger.
 
@@ -52,7 +52,7 @@ True if logging config has been updated, otherwise False.
 class TopicCreationConfigs()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L51)
 
 <a id="quixstreams.platforms.quix.config.TopicCreationConfigs.name"></a>
 
@@ -68,7 +68,7 @@ Required when not created by a Quix App.
 def strip_workspace_id_prefix(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L60)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -91,7 +91,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(workspace_id: str, s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L72)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L72)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -114,7 +114,7 @@ the string with workspace_id prepended
 class QuixKafkaConfigsBuilder()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L84)
 
 Retrieves all the necessary information from the Quix API and builds all the
 objects required to connect a confluent-kafka client to the Quix Platform.
@@ -138,7 +138,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
              workspace_cert_path: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L100)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L100)
 
 **Arguments**:
 
@@ -154,7 +154,7 @@ def __init__(quix_portal_api_service: Optional[QuixPortalApiService] = None,
 def strip_workspace_id_prefix(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L179)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L179)
 
 Remove the workspace ID from a given string if it starts with it,
 
@@ -176,7 +176,7 @@ the string with workspace_id prefix removed
 def prepend_workspace_id(s: str) -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L189)
 
 Add the workspace ID as a prefix to a given string if it does not have it,
 
@@ -199,7 +199,7 @@ def search_for_workspace(
         workspace_name_or_id: Optional[str] = None) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L199)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L199)
 
 Search for a workspace given an expected workspace name or id.
 
@@ -219,7 +219,7 @@ the workspace data dict if search success, else None
 def get_workspace_info(known_workspace_topic: Optional[str] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L222)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L222)
 
 Queries for workspace data from the Quix API, regardless of instance cache,
 
@@ -237,7 +237,7 @@ and updates instance attributes from query result.
 def search_workspace_for_topic(workspace_id: str, topic: str) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L249)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L249)
 
 Search through all the topics in the given workspace id to see if there is a
 
@@ -260,7 +260,7 @@ the workspace_id if success, else None
 def search_for_topic_workspace(topic: str) -> Optional[dict]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L265)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L265)
 
 Find what workspace a topic belongs to.
 
@@ -284,7 +284,7 @@ def get_workspace_ssl_cert(
         extract_to_folder: Optional[Path] = None) -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L286)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L286)
 
 Gets and extracts zipped certificate from the API to provided folder if the
 
@@ -309,7 +309,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout_seconds: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L363)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L363)
 
 Create topics in a Quix cluster.
 
@@ -327,7 +327,7 @@ marked as "Ready" (and thus ready to produce to/consume from).
 def confirm_topics_exist(topics: Union[List[Topic], List[str]])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L412)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L412)
 
 Confirm whether the desired set of topics exists in the Quix workspace.
 
@@ -343,7 +343,7 @@ Confirm whether the desired set of topics exists in the Quix workspace.
 def get_confluent_broker_config(known_topic: Optional[str] = None) -> dict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L452)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L452)
 
 Get the full client config dictionary required to authenticate a confluent-kafka
 
@@ -372,7 +372,7 @@ def get_confluent_client_configs(
 ) -> Tuple[dict, List[str], Optional[str]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/config.py#L497)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/config.py#L497)
 
 Get all the values you need in order to use a confluent_kafka-based client
 
@@ -405,7 +405,7 @@ and consumer group name
 class QuixEnvironment()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L7)
 
 Class to access various Quix platform environment settings
 
@@ -418,7 +418,7 @@ Class to access various Quix platform environment settings
 def state_management_enabled() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L19)
 
 Check whether "State management" is enabled for the current deployment
 
@@ -435,7 +435,7 @@ True if state management is enabled, otherwise False
 def deployment_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L27)
 
 Return current Quix deployment id.
 
@@ -455,7 +455,7 @@ deployment id or None
 def workspace_id() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L39)
 
 Return Quix workspace id if set
 
@@ -472,7 +472,7 @@ workspace id or None
 def portal_api() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L47)
 
 Return Quix Portal API url if set
 
@@ -489,7 +489,7 @@ portal API URL or None
 def sdk_token() -> Optional[str]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L56)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L56)
 
 Return Quix SDK token if set
 
@@ -506,7 +506,7 @@ sdk token or None
 def state_dir() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/env.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/env.py#L64)
 
 Return application state directory on Quix.
 
@@ -526,7 +526,7 @@ path to state dir
 def check_state_management_enabled()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/checks.py#L11)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/checks.py#L11)
 
 Check if State Management feature is enabled for the current deployment on
 Quix platform.
@@ -540,7 +540,7 @@ If it's disabled, the exception will be raised.
 def check_state_dir(state_dir: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/checks.py#L28)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/checks.py#L28)
 
 Check if Application "state_dir" matches the state dir on Quix platform.
 
@@ -566,7 +566,7 @@ If it doesn't match, the warning will be logged.
 class QuixPortalApiService()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/api.py#L15)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/api.py#L15)
 
 A light wrapper around the Quix Portal Api. If used in the Quix Platform, it will
 use that workspaces auth token and portal endpoint, else you must provide it.
@@ -588,7 +588,7 @@ def get_workspace_certificate(
         workspace_id: Optional[str] = None) -> Optional[bytes]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/api.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/api.py#L92)
 
 Get a workspace TLS certificate if available.
 
@@ -614,7 +614,7 @@ certificate as bytes if present, or None
 class QuixTopicManager(TopicManager)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/topic_manager.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/topic_manager.py#L9)
 
 The source of all topic management with quixstreams.
 
@@ -636,7 +636,7 @@ def __init__(topic_admin: TopicAdmin,
              quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/platforms/quix/topic_manager.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/platforms/quix/topic_manager.py#L29)
 
 **Arguments**:
 
@@ -657,7 +657,7 @@ generated for you.
 class StreamingDataFrame(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L32)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L32)
 
 `StreamingDataFrame` is the main object you will use for ETL work.
 
@@ -713,7 +713,7 @@ def apply(func: Union[DataFrameFunc, DataFrameStatefulFunc],
           expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L109)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L109)
 
 Apply a function to transform the value and return a new value.
 
@@ -755,7 +755,7 @@ def update(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L152)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L152)
 
 Apply a function to mutate value in-place or to perform a side effect
 
@@ -797,7 +797,7 @@ def filter(func: Union[DataFrameFunc, DataFrameStatefulFunc],
            stateful: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L191)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L191)
 
 Filter value using provided function.
 
@@ -839,7 +839,7 @@ of type `State` to perform stateful operations.
 def contains(key: str) -> StreamingSeries
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L244)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L244)
 
 Check if the key is present in the Row value.
 
@@ -871,7 +871,7 @@ def to_topic(topic: Topic,
              key: Optional[Callable[[object], object]] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L267)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L267)
 
 Produce current value to a topic. You can optionally specify a new key.
 
@@ -913,7 +913,7 @@ By default, the current message key will be used.
 def compose() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L306)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L306)
 
 Compose all functions of this StreamingDataFrame into one big closure.
 
@@ -950,7 +950,7 @@ and returns a result of StreamingDataFrame
 def test(value: object, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L336)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L336)
 
 A shorthand to test `StreamingDataFrame` with provided value
 
@@ -978,7 +978,7 @@ def tumbling_window(duration_ms: Union[int, timedelta],
                     name: Optional[str] = None) -> TumblingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L354)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L354)
 
 Create a tumbling window transformation on this StreamingDataFrame.
 
@@ -987,7 +987,13 @@ Tumbling windows divide time into fixed-sized, non-overlapping windows.
 They allow to perform stateful aggregations like `sum`, `reduce`, etc.
 on top of the data and emit results downstream.
 
-The time windows always use the current event time.
+Notes:
+
+- Every window is grouped by the current Kafka message key.
+- Messages with `None` key will be ignored.
+- The time windows always use the current event time.
+
+
 
 Example Snippet:
 
@@ -1048,7 +1054,7 @@ def hopping_window(duration_ms: Union[int, timedelta],
                    name: Optional[str] = None) -> HoppingWindowDefinition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/dataframe.py#L423)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/dataframe.py#L429)
 
 Create a hopping window transformation on this StreamingDataFrame.
 
@@ -1058,7 +1064,11 @@ The overlap is controlled by the `step_ms` parameter.
 They allow to perform stateful aggregations like `sum`, `reduce`, etc.
 on top of the data and emit results downstream.
 
-The time windows always use the current event time.
+Notes:
+
+- Every window is grouped by the current Kafka message key.
+- Messages with `None` key will be ignored.
+- The time windows always use the current event time.
 
 Example Snippet:
 
@@ -1131,7 +1141,7 @@ like `sum`, `count`, etc. and applied to the StreamingDataFrame.
 class StreamingSeries(BaseStreaming)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L17)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L17)
 
 `StreamingSeries` are typically generated by `StreamingDataframes` when getting
 elements from, or performing certain operations on, a `StreamingDataframe`,
@@ -1189,7 +1199,7 @@ sdf = sdf[["column_a"] & (sdf["new_sum_field"] >= 10)]
 def from_func(cls, func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L77)
 
 Create a StreamingSeries from a function.
 
@@ -1211,7 +1221,7 @@ instance of `StreamingSeries`
 def apply(func: StreamCallable) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L91)
 
 Add a callable to the execution list for this series.
 
@@ -1256,7 +1266,7 @@ def compose(allow_filters: bool = True,
             allow_updates: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L125)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L125)
 
 Compose all functions of this StreamingSeries into one big closure.
 
@@ -1308,7 +1318,7 @@ and returns a result of `StreamingSeries`
 def test(value: Any, ctx: Optional[MessageContext] = None) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L172)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L172)
 
 A shorthand to test `StreamingSeries` with provided value
 
@@ -1334,7 +1344,7 @@ result of `StreamingSeries`
 def isin(other: Container) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L208)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L208)
 
 Check if series value is in "other".
 
@@ -1371,7 +1381,7 @@ new StreamingSeries
 def contains(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L235)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L235)
 
 Check if series value contains "other"
 
@@ -1408,7 +1418,7 @@ new StreamingSeries
 def is_(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L260)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L260)
 
 Check if series value refers to the same object as `other`
 
@@ -1442,7 +1452,7 @@ new StreamingSeries
 def isnot(other: Union[Self, object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L283)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L283)
 
 Check if series value does not refer to the same object as `other`
 
@@ -1477,7 +1487,7 @@ new StreamingSeries
 def isnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L307)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L307)
 
 Check if series value is None.
 
@@ -1508,7 +1518,7 @@ new StreamingSeries
 def notnull() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L330)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L330)
 
 Check if series value is not None.
 
@@ -1539,7 +1549,7 @@ new StreamingSeries
 def abs() -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/series.py#L353)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/series.py#L353)
 
 Get absolute value of the series value.
 
@@ -1575,7 +1585,7 @@ new StreamingSeries
 def ensure_milliseconds(delta: Union[int, timedelta]) -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/utils.py#L5)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/utils.py#L5)
 
 Convert timedelta to milliseconds.
 
@@ -1607,7 +1617,7 @@ timedelta value in milliseconds as `int`
 class FixedTimeWindowDefinition(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/definitions.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L20)
 
 <a id="quixstreams.dataframe.windows.definitions.FixedTimeWindowDefinition.sum"></a>
 
@@ -1617,7 +1627,7 @@ class FixedTimeWindowDefinition(abc.ABC)
 def sum() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/definitions.py#L68)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L68)
 
 Configure the window to aggregate data by summing up values within
 
@@ -1635,7 +1645,7 @@ an instance of `FixedTimeWindow` configured to perform sum aggregation.
 def count() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/definitions.py#L95)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L95)
 
 Configure the window to aggregate data by counting the number of values
 
@@ -1653,7 +1663,7 @@ an instance of `FixedTimeWindow` configured to perform record count.
 def mean() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/definitions.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L122)
 
 Configure the window to aggregate data by calculating the mean of the values
 
@@ -1673,7 +1683,7 @@ def reduce(reducer: Callable[[Any, Any], Any],
            initializer: Callable[[Any], Any]) -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/definitions.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L153)
 
 Configure the window to perform a custom aggregation using `reducer`
 
@@ -1722,7 +1732,7 @@ A window configured to perform custom reduce aggregation on the data.
 def max() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/definitions.py#L213)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L213)
 
 Configure a window to aggregate the maximum value within each window period.
 
@@ -1739,7 +1749,7 @@ value within each window period.
 def min() -> "FixedTimeWindow"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/definitions.py#L242)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/definitions.py#L242)
 
 Configure a window to aggregate the minimum value within each window period.
 
@@ -1764,7 +1774,7 @@ value within each window period.
 class FixedTimeWindow()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/time_based.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/time_based.py#L32)
 
 <a id="quixstreams.dataframe.windows.time_based.FixedTimeWindow.final"></a>
 
@@ -1774,7 +1784,7 @@ class FixedTimeWindow()
 def final(expand: bool = True) -> "StreamingDataFrame"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/time_based.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/time_based.py#L95)
 
 Apply the window aggregation and return results only when the windows are
 
@@ -1812,7 +1822,7 @@ Default - `True`
 def current(expand: bool = True) -> "StreamingDataFrame"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/time_based.py#L129)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/time_based.py#L132)
 
 Apply the window transformation to the StreamingDataFrame to return results
 
@@ -1850,7 +1860,7 @@ def get_window_ranges(timestamp_ms: int,
                       step_ms: Optional[int] = None) -> List[Tuple[int, int]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/dataframe/windows/base.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/dataframe/windows/base.py#L22)
 
 Get a list of window ranges for the given timestamp.
 
@@ -1880,7 +1890,7 @@ a list of (<start>, <end>) tuples
 class RowProducer(Producer, RowProducerProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/rowproducer.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowproducer.py#L25)
 
 A producer class that is capable of serializing Rows to bytes and send them to Kafka.
 
@@ -1918,7 +1928,7 @@ def produce_row(row: Row,
                 timestamp: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/rowproducer.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowproducer.py#L66)
 
 Serialize Row to bytes according to the Topic serialization settings
 
@@ -1942,7 +1952,7 @@ If this method fails, it will trigger the provided "on_error" callback.
 def poll(timeout: float = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/rowproducer.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowproducer.py#L103)
 
 Polls the producer for events and calls `on_delivery` callbacks.
 
@@ -1964,7 +1974,7 @@ If poll fails, it will trigger the provided "on_error" callback
 class StreamFunction(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/functions.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L27)
 
 A base class for all the streaming operations in Quix Streams.
 
@@ -1982,7 +1992,7 @@ It provides two methods that return closures to be called on the input values:
 def func() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/functions.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L44)
 
 The original function
 
@@ -1995,7 +2005,7 @@ The original function
 def get_executor() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/functions.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L51)
 
 Returns a wrapper to be called on a single value.
 
@@ -2008,7 +2018,7 @@ Returns a wrapper to be called on a single value.
 def get_executor_expanded() -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/functions.py#L57)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L57)
 
 Returns a wrapper to be called on a list of expanded values.
 
@@ -2020,7 +2030,7 @@ Returns a wrapper to be called on a list of expanded values.
 class ApplyFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/functions.py#L63)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L63)
 
 Wrap a function into "Apply" function.
 
@@ -2035,7 +2045,7 @@ and its result will always be passed downstream.
 class ApplyExpandFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/functions.py#L86)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L86)
 
 Wrap a function into "Apply" function and expand the returned iterable
 into separate values downstream.
@@ -2051,7 +2061,7 @@ If the returned value is not `Iterable`, `TypeError` will be raised.
 class FilterFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/functions.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L115)
 
 Wraps a function into a "Filter" function.
 The result of a Filter function is interpreted as boolean.
@@ -2067,7 +2077,7 @@ value is filtered out.
 class UpdateFunction(StreamFunction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/functions.py#L147)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L147)
 
 Wrap a function into an "Update" function.
 
@@ -2087,7 +2097,7 @@ def compose(functions: List[StreamFunction],
             allow_expands: bool = True) -> StreamCallable
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/functions.py#L176)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L176)
 
 Composes a list of functions and its parents into a single
 
@@ -2121,7 +2131,7 @@ def composer(outer_func: StreamCallable,
              inner_func: StreamCallable) -> Callable[[T], R]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/functions.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/functions.py#L228)
 
 A function that wraps two other functions into a closure.
 
@@ -2147,7 +2157,7 @@ a function with one argument (value)
 class Stream()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/stream.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L22)
 
 <a id="quixstreams.core.stream.stream.Stream.__init__"></a>
 
@@ -2158,7 +2168,7 @@ def __init__(func: Optional[StreamFunction] = None,
              parent: Optional[Self] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/stream.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L23)
 
 A base class for all streaming operations.
 
@@ -2201,7 +2211,7 @@ Default - "Apply(lambda v: v)".
 def add_filter(func: Callable[[T], R]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/stream.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L79)
 
 Add a function to filter values from the Stream.
 
@@ -2225,7 +2235,7 @@ a new `Stream` derived from the current one
 def add_apply(func: Callable[[T], R], expand: bool = False) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/stream.py#L92)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L92)
 
 Add an "apply" function to the Stream.
 
@@ -2251,7 +2261,7 @@ a new `Stream` derived from the current one
 def add_update(func: Callable[[T], object]) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/stream.py#L109)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L109)
 
 Add an "update" function to the Stream, that will mutate the input value.
 
@@ -2274,7 +2284,7 @@ a new Stream derived from the current one
 def diff(other: "Stream") -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/stream.py#L121)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L121)
 
 Takes the difference between Streams `self` and `other` based on their last
 
@@ -2306,7 +2316,7 @@ new `Stream` instance including all the Streams from the diff
 def tree() -> List[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/stream.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L150)
 
 Return a list of all parent Streams including the node itself.
 
@@ -2326,7 +2336,7 @@ def compose(allow_filters: bool = True,
             allow_expands: bool = True) -> Callable[[T], R]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/core/stream/stream.py#L164)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/core/stream/stream.py#L164)
 
 Compose a list of functions from this `Stream` and its parents into one
 
@@ -2368,7 +2378,7 @@ the stream has functions with "expand=True" in the tree. Default - True.
 def dict_values(d: object) -> List
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/utils/dicts.py#L4)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/utils/dicts.py#L4)
 
 Recursively unpacks a set of nested dicts to get a flattened list of leaves,
 
@@ -2396,7 +2406,7 @@ a list with all the leaves of the various contained dicts
 def dumps(value: Any) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/utils/json.py#L8)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/utils/json.py#L8)
 
 Serialize to JSON using `orjson` package.
 
@@ -2416,7 +2426,7 @@ bytes
 def loads(value: bytes) -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/utils/json.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/utils/json.py#L18)
 
 Deserialize from JSON using `orjson` package.
 
@@ -2448,7 +2458,7 @@ object
 class TimestampType(enum.IntEnum)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/timestamps.py#L8)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/timestamps.py#L8)
 
 <a id="quixstreams.models.timestamps.TimestampType.TIMESTAMP_NOT_AVAILABLE"></a>
 
@@ -2476,7 +2486,7 @@ broker receive time
 class MessageTimestamp()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/timestamps.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/timestamps.py#L14)
 
 Represents a timestamp of incoming Kafka message.
 
@@ -2492,7 +2502,7 @@ it should not be mutated during message processing.
 def create(cls, timestamp_type: int, milliseconds: int) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/timestamps.py#L41)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/timestamps.py#L41)
 
 Create a Timestamp object based on data
 
@@ -2529,7 +2539,7 @@ Timestamp object
 class MessageContext()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/messagecontext.py#L7)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/messagecontext.py#L7)
 
 An object with Kafka message properties.
 
@@ -2548,7 +2558,7 @@ it should not be mutated during message processing.
 class ConfluentKafkaMessageProto(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/types.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/types.py#L12)
 
 An interface of `confluent_kafka.Message`.
 
@@ -2573,7 +2583,7 @@ see https://github.com/confluentinc/confluent-kafka-python/issues/1535.
 class IgnoreMessage(exceptions.QuixException)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/exceptions.py#L51)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/exceptions.py#L51)
 
 Raise this exception from Deserializer.__call__ in order to ignore the processing
 of the particular message.
@@ -2590,7 +2600,7 @@ of the particular message.
 class QuixDeserializer(JSONDeserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L70)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L70)
 
 Handles Deserialization for any Quix-formatted topic.
 
@@ -2605,7 +2615,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L77)
 
 **Arguments**:
 
@@ -2623,7 +2633,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L97)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L97)
 
 Each Quix message might contain data for multiple Rows.
 This property informs the downstream processors about that, so they can
@@ -2638,7 +2648,7 @@ def deserialize(model_key: str, value: Union[List[Mapping],
                                              Mapping]) -> Iterable[Mapping]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L150)
 
 Deserialization function for particular data types (Timeseries or EventData).
 
@@ -2659,7 +2669,7 @@ Iterable of dicts
 class QuixSerializer(JSONSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L266)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L266)
 
 <a id="quixstreams.models.serializers.quix.QuixSerializer.__init__"></a>
 
@@ -2670,7 +2680,7 @@ def __init__(as_legacy: bool = True,
              dumps: Callable[[Any], Union[str, bytes]] = default_dumps)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L270)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L270)
 
 Serializer that returns data in json format.
 
@@ -2688,7 +2698,7 @@ Default - :py:func:`quixstreams.utils.json.dumps`
 class QuixTimeseriesSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L313)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L313)
 
 Serialize data to JSON formatted according to Quix Timeseries format.
 
@@ -2720,7 +2730,7 @@ Output:
 class QuixEventsSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L401)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L401)
 
 Serialize data to JSON formatted according to Quix EventData format.
 The input value is expected to be a dictionary with the following keys:
@@ -2761,7 +2771,7 @@ Output:
 class BytesDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L44)
 
 A deserializer to bypass bytes without any changes
 
@@ -2773,7 +2783,7 @@ A deserializer to bypass bytes without any changes
 class BytesSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L55)
 
 A serializer to bypass bytes without any changes
 
@@ -2785,7 +2795,7 @@ A serializer to bypass bytes without any changes
 class StringDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L64)
 
 <a id="quixstreams.models.serializers.simple_types.StringDeserializer.__init__"></a>
 
@@ -2795,7 +2805,7 @@ class StringDeserializer(Deserializer)
 def __init__(column_name: Optional[str] = None, codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L65)
 
 Deserializes bytes to strings using the specified encoding.
 
@@ -2812,7 +2822,7 @@ A wrapper around `confluent_kafka.serialization.StringDeserializer`.
 class IntegerDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L84)
 
 Deserializes bytes to integers.
 
@@ -2826,7 +2836,7 @@ A wrapper around `confluent_kafka.serialization.IntegerDeserializer`.
 class DoubleDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L103)
 
 Deserializes float to IEEE 764 binary64.
 
@@ -2840,7 +2850,7 @@ A wrapper around `confluent_kafka.serialization.DoubleDeserializer`.
 class StringSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L122)
 
 <a id="quixstreams.models.serializers.simple_types.StringSerializer.__init__"></a>
 
@@ -2850,7 +2860,7 @@ class StringSerializer(Serializer)
 def __init__(codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L123)
 
 Serializes strings to bytes using the specified encoding.
 
@@ -2866,7 +2876,7 @@ Serializes strings to bytes using the specified encoding.
 class IntegerSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L135)
 
 Serializes integers to bytes
 
@@ -2878,7 +2888,7 @@ Serializes integers to bytes
 class DoubleSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L148)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L148)
 
 Serializes floats to bytes
 
@@ -2894,7 +2904,7 @@ Serializes floats to bytes
 class JSONSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/json.py#L13)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/json.py#L13)
 
 <a id="quixstreams.models.serializers.json.JSONSerializer.__init__"></a>
 
@@ -2904,7 +2914,7 @@ class JSONSerializer(Serializer)
 def __init__(dumps: Callable[[Any], Union[str, bytes]] = default_dumps)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/json.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/json.py#L14)
 
 Serializer that returns data in json format.
 
@@ -2921,7 +2931,7 @@ Default - :py:func:`quixstreams.utils.json.dumps`
 class JSONDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/json.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/json.py#L35)
 
 <a id="quixstreams.models.serializers.json.JSONDeserializer.__init__"></a>
 
@@ -2932,7 +2942,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/json.py#L36)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/json.py#L36)
 
 Deserializer that parses data from JSON
 
@@ -2955,7 +2965,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 class SerializationContext()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/base.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L22)
 
 Provides additional context for message serialization/deserialization.
 
@@ -2969,7 +2979,7 @@ Every `Serializer` and `Deserializer` receives an instance of `SerializationCont
 def to_confluent_ctx(field: MessageField) -> _SerializationContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/base.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L35)
 
 Convert `SerializationContext` to `confluent_kafka.SerializationContext`
 
@@ -2991,7 +3001,7 @@ instance of `confluent_kafka.serialization.SerializationContext`
 class Deserializer(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/base.py#L47)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L47)
 
 <a id="quixstreams.models.serializers.base.Deserializer.__init__"></a>
 
@@ -3001,7 +3011,7 @@ class Deserializer(abc.ABC)
 def __init__(column_name: Optional[str] = None, *args, **kwargs)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/base.py#L48)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L48)
 
 A base class for all Deserializers
 
@@ -3019,7 +3029,7 @@ dictionary with `column_name` as a key.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/base.py#L58)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L58)
 
 Return True if the deserialized message should be considered as Iterable
 and each item in it should be processed as a separate message.
@@ -3032,7 +3042,7 @@ and each item in it should be processed as a separate message.
 class Serializer(abc.ABC)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/base.py#L75)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L75)
 
 A base class for all Serializers
 
@@ -3045,7 +3055,7 @@ A base class for all Serializers
 def extra_headers() -> MessageHeadersMapping
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/base.py#L81)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/base.py#L81)
 
 Informs producer to set additional headers
 
@@ -3074,7 +3084,7 @@ dict with headers
 class Row()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/rows.py#L11)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/rows.py#L11)
 
 Row is a dict-like interface on top of the message data + some Kafka props
 
@@ -3086,7 +3096,7 @@ Row is a dict-like interface on top of the message data + some Kafka props
 def keys() -> KeysView
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/rows.py#L73)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/rows.py#L73)
 
 Also allows unpacking row.value via **row
 
@@ -3098,7 +3108,7 @@ Also allows unpacking row.value via **row
 def clone(value: dict) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/rows.py#L85)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/rows.py#L85)
 
 Manually clone the Row; doing it this way is much faster than doing a deepcopy
 on the entire Row object.
@@ -3119,7 +3129,7 @@ on the entire Row object.
 def convert_topic_list(topics: List[Topic]) -> List[ConfluentTopic]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/admin.py#L23)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L23)
 
 Converts `Topic`s to `ConfluentTopic`s as required for Confluent's
 
@@ -3141,7 +3151,7 @@ list of confluent_kafka `ConfluentTopic`s
 class TopicAdmin()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/admin.py#L46)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L46)
 
 For performing "admin"-level operations on a Kafka cluster, mostly around topics.
 
@@ -3155,7 +3165,7 @@ Primarily used to create and inspect topic configurations.
 def __init__(broker_address: str, extra_config: Optional[Mapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/admin.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L53)
 
 **Arguments**:
 
@@ -3170,7 +3180,7 @@ def __init__(broker_address: str, extra_config: Optional[Mapping] = None)
 def list_topics() -> Dict[str, ConfluentTopicMetadata]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/admin.py#L74)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L74)
 
 Get a list of topics and their metadata from a Kafka cluster
 
@@ -3186,7 +3196,7 @@ a dict of topic names and their metadata objects
 def inspect_topics(topic_names: List[str]) -> Dict[str, Optional[TopicConfig]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/admin.py#L83)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L83)
 
 A simplified way of getting the topic configurations of the provided topics
 
@@ -3210,7 +3220,7 @@ def create_topics(topics: List[Topic],
                   finalize_timeout: int = 60)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/admin.py#L156)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/admin.py#L156)
 
 Create the given list of topics and confirm they are ready.
 
@@ -3236,7 +3246,7 @@ fail (it ignores issues for a topic already existing).
 class TopicConfig()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/topic.py#L43)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L43)
 
 Represents all kafka-level configuration for a kafka topic.
 
@@ -3250,7 +3260,7 @@ Generally used by Topic and any topic creation procedures.
 class Topic()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/topic.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L84)
 
 A representation of a Kafka topic and its expected data format via
 designated key and value serializers/deserializers.
@@ -3274,7 +3284,7 @@ def __init__(
         timestamp_extractor: Optional[TimestampExtractor] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/topic.py#L94)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L94)
 
 Can specify serialization that should be used when consuming/producing
 
@@ -3331,7 +3341,7 @@ topic = Topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/topic.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L158)
 
 Topic name
 
@@ -3343,7 +3353,7 @@ Topic name
 def row_serialize(row: Row, key: Optional[Any] = None) -> KafkaMessage
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/topic.py#L168)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L168)
 
 Serialize Row to a Kafka message structure
 
@@ -3365,7 +3375,7 @@ def row_deserialize(
         message: ConfluentKafkaMessageProto) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/topic.py#L191)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/topic.py#L191)
 
 Deserialize incoming Kafka message to a Row.
 
@@ -3393,7 +3403,7 @@ Row, list of Rows or None if the message is ignored.
 def affirm_ready_for_create(topics: List[Topic])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/manager.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L19)
 
 Validate a list of topics is ready for creation attempt
 
@@ -3409,7 +3419,7 @@ Validate a list of topics is ready for creation attempt
 class TopicManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/manager.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L29)
 
 The source of all topic management with quixstreams.
 
@@ -3427,7 +3437,7 @@ See methods for details.
 def __init__(topic_admin: TopicAdmin, create_timeout: int = 60)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/manager.py#L48)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L48)
 
 **Arguments**:
 
@@ -3443,7 +3453,7 @@ def __init__(topic_admin: TopicAdmin, create_timeout: int = 60)
 def changelog_topics() -> Dict[str, Dict[str, Topic]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/manager.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L71)
 
 Note: `Topic`s are the changelogs.
 
@@ -3459,7 +3469,7 @@ def topic_config(num_partitions: Optional[int] = None,
                  extra_config: Optional[dict] = None) -> TopicConfig
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/manager.py#L121)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L121)
 
 Convenience method for generating a `TopicConfig` with default settings
 
@@ -3487,7 +3497,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/manager.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L142)
 
 A convenience method for generating a `Topic`. Will use default config options
 
@@ -3517,7 +3527,7 @@ def changelog_topic(topic_name: str, store_name: str,
                     consumer_group: str) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/manager.py#L191)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L191)
 
 Performs all the logic necessary to generate a changelog topic based on a
 
@@ -3556,7 +3566,7 @@ generate changelog topics. To turn off changelogs, init an Application with
 def create_topics(topics: List[Topic])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/manager.py#L262)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L262)
 
 Creates topics via an explicit list of provided `Topics`.
 
@@ -3575,7 +3585,7 @@ Exists as a way to manually specify what topics to create; otherwise,
 def create_all_topics()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/manager.py#L277)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L277)
 
 A convenience method to create all Topic objects stored on this TopicManager.
 
@@ -3587,7 +3597,7 @@ A convenience method to create all Topic objects stored on this TopicManager.
 def validate_all_topics()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/topics/manager.py#L283)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/topics/manager.py#L283)
 
 Validates all topics exist and changelogs have correct topic and rep factor.
 
@@ -3605,7 +3615,7 @@ Issues are pooled and raised as an Exception once inspections are complete.
 class WindowedRocksDBStore(RocksDBStore)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/store.py#L10)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/store.py#L10)
 
 RocksDB-based windowed state store.
 
@@ -3625,7 +3635,7 @@ def __init__(
         options: Optional[RocksDBOptionsType] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/store.py#L18)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/store.py#L18)
 
 **Arguments**:
 
@@ -3648,7 +3658,7 @@ if using changelogs
 class WindowedRocksDBStorePartition(RocksDBStorePartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/partition.py#L24)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/partition.py#L24)
 
 A base class to access windowed state in RocksDB.
 
@@ -3678,7 +3688,7 @@ stores the expiration index to delete expired windows.
 class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/transaction.py#L21)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/transaction.py#L21)
 
 <a id="quixstreams.state.rocksdb.windowed.transaction.WindowedRocksDBPartitionTransaction.expire_windows"></a>
 
@@ -3689,7 +3699,7 @@ def expire_windows(duration_ms: int,
                    grace_ms: int = 0) -> List[Tuple[Tuple[int, int], Any]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/transaction.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/transaction.py#L79)
 
 Get a list of expired windows from RocksDB considering latest timestamp,
 
@@ -3727,7 +3737,7 @@ sorted list of tuples in format `((start, end), value)`
 def parse_window_key(key: bytes) -> Tuple[bytes, int, int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/serialization.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/serialization.py#L12)
 
 Parse the window key from Rocksdb into (message_key, start, end) structure.
 
@@ -3750,7 +3760,7 @@ a tuple with message key, start timestamp, end timestamp
 def encode_window_key(start_ms: int, end_ms: int) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/serialization.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/serialization.py#L39)
 
 Encode window start and end timestamps into bytes of the following format:
 
@@ -3775,7 +3785,7 @@ window timestamps as bytes
 def encode_window_prefix(prefix: bytes, start_ms: int) -> bytes
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/serialization.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/serialization.py#L53)
 
 Encode window prefix and start time to iterate over keys in RocksDB
 
@@ -3803,7 +3813,7 @@ bytes
 class WindowedTransactionState(WindowedState)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/state.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L9)
 
 <a id="quixstreams.state.rocksdb.windowed.state.WindowedTransactionState.__init__"></a>
 
@@ -3813,7 +3823,7 @@ class WindowedTransactionState(WindowedState)
 def __init__(transaction: "WindowedRocksDBPartitionTransaction")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/state.py#L12)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L12)
 
 A windowed state to be provided into `StreamingDataFrame` window functions.
 
@@ -3831,7 +3841,7 @@ def get_window(start_ms: int,
                default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/state.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L20)
 
 Get the value of the window defined by `start` and `end` timestamps
 
@@ -3855,7 +3865,7 @@ value or None if the key is not found and `default` is not provided
 def update_window(start_ms: int, end_ms: int, value: Any, timestamp_ms: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/state.py#L36)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L36)
 
 Set a value for the window.
 
@@ -3877,7 +3887,7 @@ using the provided `timestamp`.
 def get_latest_timestamp() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/state.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L53)
 
 Get the latest observed timestamp for the current state partition.
 
@@ -3897,7 +3907,7 @@ def expire_windows(duration_ms: int,
                    grace_ms: int = 0) -> List[Tuple[Tuple[int, int], Any]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/windowed/state.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/windowed/state.py#L65)
 
 Get a list of expired windows from RocksDB considering the current
 latest timestamp, window duration and grace period.
@@ -3919,7 +3929,7 @@ calling this method multiple times will yield different results for the same
 class RocksDBOptions(RocksDBOptionsType)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/options.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/options.py#L25)
 
 RocksDB database options.
 
@@ -3964,7 +3974,7 @@ Please see `rocksdict.Options` for a complete description of other options.
 def to_options() -> rocksdict.Options
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/options.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/options.py#L53)
 
 Convert parameters to `rocksdict.Options`
 
@@ -3984,7 +3994,7 @@ instance of `rocksdict.Options`
 class RocksDBStore(Store)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/store.py#L19)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L19)
 
 RocksDB-based state store.
 
@@ -4004,7 +4014,7 @@ def __init__(
         options: Optional[options_type] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/store.py#L29)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L29)
 
 **Arguments**:
 
@@ -4024,7 +4034,7 @@ if using changelogs
 def topic() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/store.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L53)
 
 Store topic name
 
@@ -4037,7 +4047,7 @@ Store topic name
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/store.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L60)
 
 Store name
 
@@ -4050,7 +4060,7 @@ Store name
 def partitions() -> Dict[int, RocksDBStorePartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/store.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L67)
 
 Mapping of assigned store partitions
 
@@ -4062,7 +4072,7 @@ Mapping of assigned store partitions
 def assign_partition(partition: int) -> RocksDBStorePartition
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/store.py#L80)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L80)
 
 Open and assign store partition.
 
@@ -4085,7 +4095,7 @@ instance of`RocksDBStorePartition`
 def revoke_partition(partition: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/store.py#L117)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L117)
 
 Revoke and close the assigned store partition.
 
@@ -4103,7 +4113,7 @@ If the partition is not assigned, it will log the message and return.
 def start_partition_transaction(partition: int) -> RocksDBPartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/store.py#L138)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L138)
 
 Start a new partition transaction.
 
@@ -4126,7 +4136,7 @@ instance of `RocksDBPartitionTransaction`
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/store.py#L160)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/store.py#L160)
 
 Close the store and revoke all assigned partitions
 
@@ -4142,7 +4152,7 @@ Close the store and revoke all assigned partitions
 class RocksDBStorePartition(StorePartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L40)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L40)
 
 A base class to access state in RocksDB.
 
@@ -4170,7 +4180,7 @@ it will retry according to `open_max_retries` and `open_retry_backoff` options.
 def begin() -> RocksDBPartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L80)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L80)
 
 Create a new `RocksDBTransaction` object.
 
@@ -4189,7 +4199,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L106)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L106)
 
 Updates state from a given changelog message.
 
@@ -4205,7 +4215,7 @@ Updates state from a given changelog message.
 def set_changelog_offset(changelog_offset: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L130)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L130)
 
 Set the changelog offset based on a message (usually an "offset-only" message).
 
@@ -4225,7 +4235,7 @@ def produce_to_changelog(key: bytes,
                          headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L140)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L140)
 
 Produce a message to the StorePartitions respective changelog.
 
@@ -4237,7 +4247,7 @@ Produce a message to the StorePartitions respective changelog.
 def write(batch: WriteBatch)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L151)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L151)
 
 Write `WriteBatch` to RocksDB
 
@@ -4255,7 +4265,7 @@ def get(key: bytes,
         cf_name: str = "default") -> Union[None, bytes, Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L158)
 
 Get a key from RocksDB.
 
@@ -4277,7 +4287,7 @@ a value if the key is present in the DB. Otherwise, `default`
 def exists(key: bytes, cf_name: str = "default") -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L172)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L172)
 
 Check if a key is present in the DB.
 
@@ -4298,7 +4308,7 @@ Check if a key is present in the DB.
 def get_processed_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L183)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L183)
 
 Get last processed offset for the given partition
 
@@ -4314,7 +4324,7 @@ offset or `None` if there's no processed offset yet
 def get_changelog_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L195)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L195)
 
 Get offset that the changelog is up-to-date with.
 
@@ -4330,7 +4340,7 @@ offset or `None` if there's no processed offset yet
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L205)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L205)
 
 Close the underlying RocksDB
 
@@ -4343,7 +4353,7 @@ Close the underlying RocksDB
 def path() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L220)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L220)
 
 Absolute path to RocksDB database folder
 
@@ -4360,7 +4370,7 @@ file path
 def destroy(cls, path: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L228)
 
 Delete underlying RocksDB database
 
@@ -4378,7 +4388,7 @@ The database must be closed first.
 def get_column_family_handle(cf_name: str) -> ColumnFamily
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L238)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L238)
 
 Get a column family handle to pass to it WriteBatch.
 
@@ -4401,7 +4411,7 @@ instance of `rocksdict.ColumnFamily`
 def get_column_family(cf_name: str) -> Rdict
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/partition.py#L259)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/partition.py#L259)
 
 Get a column family instance.
 
@@ -4431,7 +4441,7 @@ instance of `rocksdict.Rdict` for the given column family
 class RocksDBPartitionTransaction(PartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/transaction.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L71)
 
 A transaction class to perform simple key-value operations like
 "get", "set", "delete" and "exists" on a single RocksDB partition.
@@ -4470,7 +4480,7 @@ def __init__(partition: "RocksDBStorePartition", dumps: DumpsFunc,
              loads: LoadsFunc)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/transaction.py#L114)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L114)
 
 **Arguments**:
 
@@ -4488,7 +4498,7 @@ the underlying RocksDB
 def with_prefix(prefix: Any = b"") -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/transaction.py#L141)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L141)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -4518,7 +4528,7 @@ def get(key: Any,
         cf_name: str = "default") -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/transaction.py#L170)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L170)
 
 Get a key from the store.
 
@@ -4547,7 +4557,7 @@ value or `default`
 def set(key: Any, value: Any, cf_name: str = "default")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/transaction.py#L205)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L205)
 
 Set a key to the store.
 
@@ -4568,7 +4578,7 @@ It first updates the key in the update cache.
 def delete(key: Any, cf_name: str = "default")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/transaction.py#L230)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L230)
 
 Delete a key from the store.
 
@@ -4588,7 +4598,7 @@ It first deletes the key from the update cache.
 def exists(key: Any, cf_name: str = "default") -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/transaction.py#L253)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L253)
 
 Check if a key exists in the store.
 
@@ -4612,7 +4622,7 @@ It first looks up the key in the update cache.
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/transaction.py#L275)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L275)
 
 Check if the transaction is completed.
 
@@ -4634,7 +4644,7 @@ The completed transaction should not be re-used.
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/transaction.py#L289)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L289)
 
 Check if the transaction has failed.
 
@@ -4654,7 +4664,7 @@ and
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/rocksdb/transaction.py#L318)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/rocksdb/transaction.py#L318)
 
 Flush the recent updates to the database and empty the update cache.
 
@@ -4700,7 +4710,7 @@ cannot be used anymore.
 class RecoveryPartition()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L20)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L20)
 
 A changelog topic partition mapped to a respective `StorePartition` with helper
 methods to determine its current recovery status.
@@ -4716,7 +4726,7 @@ Since `StorePartition`s do recovery directly, it also handles recovery transacti
 def offset() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L41)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L41)
 
 Get the changelog offset from the underlying `StorePartition`.
 
@@ -4733,7 +4743,7 @@ changelog offset (int)
 def needs_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L50)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L50)
 
 Determine whether recovery is necessary for underlying `StorePartition`.
 
@@ -4746,7 +4756,7 @@ Determine whether recovery is necessary for underlying `StorePartition`.
 def needs_offset_update()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L59)
 
 Determine if an offset update is required.
 
@@ -4760,7 +4770,7 @@ Usually checked during assign if recovery was not required.
 def update_offset()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L67)
 
 Update only the changelog offset of a StorePartition.
 
@@ -4773,7 +4783,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L87)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L87)
 
 Recover the StorePartition using a message read from its respective changelog.
 
@@ -4789,7 +4799,7 @@ Recover the StorePartition using a message read from its respective changelog.
 def set_watermarks(lowwater: int, highwater: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L99)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L99)
 
 Set the changelog watermarks as gathered from Consumer.get_watermark_offsets()
 
@@ -4806,7 +4816,7 @@ Set the changelog watermarks as gathered from Consumer.get_watermark_offsets()
 class ChangelogProducerFactory()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L110)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L110)
 
 Generates ChangelogProducers, which produce changelog messages to a StorePartition.
 
@@ -4818,7 +4828,7 @@ Generates ChangelogProducers, which produce changelog messages to a StorePartiti
 def __init__(changelog_name: str, producer: RowProducer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L115)
 
 **Arguments**:
 
@@ -4837,7 +4847,7 @@ a ChangelogWriter instance
 def get_partition_producer(partition_num)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L125)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L125)
 
 Generate a ChangelogProducer for producing to a specific partition number
 
@@ -4855,7 +4865,7 @@ Generate a ChangelogProducer for producing to a specific partition number
 class ChangelogProducer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L137)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L137)
 
 Generated for a `StorePartition` to produce state changes to its respective
 kafka changelog partition.
@@ -4868,7 +4878,7 @@ kafka changelog partition.
 def __init__(changelog_name: str, partition_num: int, producer: RowProducer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L143)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L143)
 
 **Arguments**:
 
@@ -4886,7 +4896,7 @@ def produce(key: bytes,
             headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L153)
 
 Produce a message to a changelog topic partition.
 
@@ -4904,7 +4914,7 @@ Produce a message to a changelog topic partition.
 class RecoveryManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L178)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L178)
 
 Manages all consumer-related aspects of recovery, including:
     - assigning/revoking, pausing/resuming topic partitions (especially changelogs)
@@ -4924,7 +4934,7 @@ Recovery is attempted from the `Application` after any new partition assignment.
 def has_assignments() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L197)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L197)
 
 Whether the Application has assigned RecoveryPartitions
 
@@ -4941,7 +4951,7 @@ has assignments, as bool
 def recovering() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L206)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L206)
 
 Whether the Application is currently recovering
 
@@ -4957,7 +4967,7 @@ is recovering, as bool
 def register_changelog(topic_name: str, store_name: str, consumer_group: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L214)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L214)
 
 Register a changelog Topic with the TopicManager.
 
@@ -4975,7 +4985,7 @@ Register a changelog Topic with the TopicManager.
 def do_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L228)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L228)
 
 If there are any active RecoveryPartitions, do a recovery procedure.
 
@@ -4990,7 +5000,7 @@ def assign_partition(topic_name: str, partition_num: int,
                      store_partitions: Dict[str, StorePartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L274)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L274)
 
 Assigns `StorePartition`s (as `RecoveryPartition`s) ONLY IF recovery required.
 
@@ -5004,7 +5014,7 @@ Pauses active consumer partitions as needed.
 def revoke_partition(partition_num: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/recovery.py#L336)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/recovery.py#L336)
 
 revoke ALL StorePartitions (across all Stores) for a given partition number
 
@@ -5028,7 +5038,7 @@ revoke ALL StorePartitions (across all Stores) for a given partition number
 class Store(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L14)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L14)
 
 Abstract state store.
 
@@ -5044,7 +5054,7 @@ partitions' transactions.
 def topic() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L25)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L25)
 
 Topic name
 
@@ -5057,7 +5067,7 @@ Topic name
 def name() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L32)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L32)
 
 Store name
 
@@ -5070,7 +5080,7 @@ Store name
 def partitions() -> Dict[int, "StorePartition"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L39)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L39)
 
 Mapping of assigned store partitions
 
@@ -5086,7 +5096,7 @@ dict of "{partition: <StorePartition>}"
 def assign_partition(partition: int) -> "StorePartition"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L46)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L46)
 
 Assign new store partition
 
@@ -5106,7 +5116,7 @@ instance of `StorePartition`
 def revoke_partition(partition: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L55)
 
 Revoke assigned store partition
 
@@ -5123,7 +5133,7 @@ def start_partition_transaction(
         partition: int) -> Optional["PartitionTransaction"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L63)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L63)
 
 Start a new partition transaction.
 
@@ -5145,7 +5155,7 @@ instance of `PartitionTransaction`
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L74)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L74)
 
 Close store and revoke all store partitions
 
@@ -5157,7 +5167,7 @@ Close store and revoke all store partitions
 class StorePartition(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L87)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L87)
 
 A base class to access state in the underlying storage.
 It represents a single instance of some storage (e.g. a single database for
@@ -5172,7 +5182,7 @@ the persistent storage).
 def path() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L96)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L96)
 
 Absolute path to RocksDB database folder
 
@@ -5184,7 +5194,7 @@ Absolute path to RocksDB database folder
 def begin() -> "PartitionTransaction"
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L102)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L102)
 
 State new `PartitionTransaction`
 
@@ -5197,7 +5207,7 @@ def recover_from_changelog_message(
         changelog_message: ConfluentKafkaMessageProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L107)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L107)
 
 Updates state from a given changelog message.
 
@@ -5215,7 +5225,7 @@ def produce_to_changelog(key: bytes,
                          headers: Optional[MessageHeadersMapping] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L117)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L117)
 
 Produce a message to the StorePartitions respective changelog.
 
@@ -5227,7 +5237,7 @@ Produce a message to the StorePartitions respective changelog.
 def get_processed_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L128)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L128)
 
 Get last processed offset for the given partition
 
@@ -5243,7 +5253,7 @@ offset or `None` if there's no processed offset yet
 def get_changelog_offset() -> Optional[int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L135)
 
 Get offset that the changelog is up-to-date with.
 
@@ -5259,7 +5269,7 @@ offset or `None` if there's no processed offset yet
 def set_changelog_offset(changelog_offset: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L142)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L142)
 
 Set the changelog offset based on a message (usually an "offset-only" message).
 
@@ -5277,7 +5287,7 @@ Used during recovery.
 class State(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L153)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L153)
 
 Primary interface for working with key-value state data from `StreamingDataFrame`
 
@@ -5289,7 +5299,7 @@ Primary interface for working with key-value state data from `StreamingDataFrame
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L158)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L158)
 
 Get the value for key if key is present in the state, else default
 
@@ -5310,7 +5320,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L168)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L168)
 
 Set value for the key.
 
@@ -5327,7 +5337,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L176)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L176)
 
 Delete value for the key.
 
@@ -5345,7 +5355,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L185)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L185)
 
 Check if the key exists in state.
 
@@ -5365,7 +5375,7 @@ True if key exists, False otherwise
 class PartitionTransaction(State)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L194)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L194)
 
 A transaction class to perform simple key-value operations like
 "get", "set", "delete" and "exists" on a single storage partition.
@@ -5379,7 +5389,7 @@ A transaction class to perform simple key-value operations like
 def state() -> State
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L201)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L201)
 
 An instance of State to be provided to `StreamingDataFrame` functions
 
@@ -5393,7 +5403,7 @@ An instance of State to be provided to `StreamingDataFrame` functions
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L209)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L209)
 
 Return `True` if transaction failed to update data at some point.
 
@@ -5412,7 +5422,7 @@ bool
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L219)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L219)
 
 Return `True` if transaction is completed.
 
@@ -5431,7 +5441,7 @@ bool
 def with_prefix(prefix: Any = b"") -> Iterator[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L229)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L229)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -5454,7 +5464,7 @@ context manager
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L240)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L240)
 
 Flush the recent updates and last processed offset to the storage.
 
@@ -5470,7 +5480,7 @@ Flush the recent updates and last processed offset to the storage.
 class WindowedState(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L253)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L253)
 
 A windowed state to be provided into `StreamingDataFrame` window functions.
 
@@ -5484,7 +5494,7 @@ def get_window(start_ms: int,
                default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L258)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L258)
 
 Get the value of the window defined by `start` and `end` timestamps
 
@@ -5508,7 +5518,7 @@ value or None if the key is not found and `default` is not provided
 def update_window(start_ms: int, end_ms: int, value: Any, timestamp_ms: int)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L272)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L272)
 
 Set a value for the window.
 
@@ -5530,7 +5540,7 @@ using the provided `timestamp`.
 def get_latest_timestamp() -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L286)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L286)
 
 Get the latest observed timestamp for the current state partition.
 
@@ -5549,7 +5559,7 @@ latest observed event timestamp in milliseconds
 def expire_windows(duration_ms: int, grace_ms: int = 0)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L297)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L297)
 
 Get a list of expired windows from RocksDB considering the current
 
@@ -5572,7 +5582,7 @@ calling this method multiple times will yield different results for the same
 class WindowedPartitionTransaction(WindowedState)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L312)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L312)
 
 <a id="quixstreams.state.types.WindowedPartitionTransaction.failed"></a>
 
@@ -5583,7 +5593,7 @@ class WindowedPartitionTransaction(WindowedState)
 def failed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L318)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L318)
 
 Return `True` if transaction failed to update data at some point.
 
@@ -5602,7 +5612,7 @@ bool
 def completed() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L328)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L328)
 
 Return `True` if transaction is completed.
 
@@ -5620,7 +5630,7 @@ bool
 def with_prefix(prefix: Any = b"") -> Iterator[Self]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L337)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L337)
 
 A context manager set the prefix for all keys in the scope.
 
@@ -5643,7 +5653,7 @@ context manager
 def maybe_flush(offset: Optional[int] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L348)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L348)
 
 Flush the recent updates and last processed offset to the storage.
 
@@ -5659,7 +5669,7 @@ Flush the recent updates and last processed offset to the storage.
 class PartitionRecoveryTransaction(Protocol)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L361)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L361)
 
 A class for managing recovery for a StorePartition from a changelog message
 
@@ -5671,7 +5681,7 @@ A class for managing recovery for a StorePartition from a changelog message
 def flush()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/types.py#L369)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/types.py#L369)
 
 Flush the recovery update and last processed offset to the storage.
 
@@ -5691,7 +5701,7 @@ Flush the recovery update and last processed offset to the storage.
 class StateStoreManager()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L31)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L31)
 
 Class for managing state stores and partitions.
 
@@ -5709,7 +5719,7 @@ StateStoreManager is responsible for:
 def stores() -> Dict[str, Dict[str, Store]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L71)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L71)
 
 Map of registered state stores
 
@@ -5726,7 +5736,7 @@ dict in format {topic: {store_name: store}}
 def recovery_required() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L79)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L79)
 
 Whether recovery needs to be done.
 
@@ -5739,7 +5749,7 @@ Whether recovery needs to be done.
 def using_changelogs() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L88)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L88)
 
 Whether the StateStoreManager is using changelog topics
 
@@ -5755,7 +5765,7 @@ using changelogs, as bool
 def do_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L96)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L96)
 
 Perform a state recovery, if necessary.
 
@@ -5767,7 +5777,7 @@ Perform a state recovery, if necessary.
 def stop_recovery()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L102)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L102)
 
 Stop recovery (called during app shutdown).
 
@@ -5780,7 +5790,7 @@ def get_store(topic: str,
               store_name: str = _DEFAULT_STATE_STORE_NAME) -> Store
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L108)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L108)
 
 Get a store for given name and topic
 
@@ -5802,7 +5812,7 @@ def register_store(topic_name: str,
                    store_name: str = _DEFAULT_STATE_STORE_NAME)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L141)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L141)
 
 Register a state store to be managed by StateStoreManager.
 
@@ -5824,7 +5834,7 @@ Each store can be registered only once for each topic.
 def register_windowed_store(topic_name: str, store_name: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L166)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L166)
 
 Register a windowed state store to be managed by StateStoreManager.
 
@@ -5846,7 +5856,7 @@ Each window store can be registered only once for each topic.
 def clear_stores()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L189)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L189)
 
 Delete all state stores managed by StateStoreManager.
 
@@ -5858,7 +5868,7 @@ Delete all state stores managed by StateStoreManager.
 def on_partition_assign(tp: TopicPartition) -> List[StorePartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L204)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L204)
 
 Assign store partitions for each registered store for the given `TopicPartition`
 
@@ -5880,7 +5890,7 @@ list of assigned `StorePartition`
 def on_partition_revoke(tp: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L223)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L223)
 
 Revoke store partitions for each registered store for the given `TopicPartition`
 
@@ -5896,7 +5906,7 @@ Revoke store partitions for each registered store for the given `TopicPartition`
 def on_partition_lost(tp: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L235)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L235)
 
 Revoke and close store partitions for each registered store for the given
 
@@ -5914,7 +5924,7 @@ Revoke and close store partitions for each registered store for the given
 def init()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L244)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L244)
 
 Initialize `StateStoreManager` and create a store directory
 
@@ -5927,7 +5937,7 @@ Initialize `StateStoreManager` and create a store directory
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L251)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L251)
 
 Close all registered stores
 
@@ -5940,7 +5950,7 @@ def get_store_transaction(
         store_name: str = _DEFAULT_STATE_STORE_NAME) -> PartitionTransaction
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L259)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L259)
 
 Get active `PartitionTransaction` for the store
 
@@ -5958,7 +5968,7 @@ def start_store_transaction(topic: str, partition: int,
                             offset: int) -> Iterator["_MultiStoreTransaction"]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/manager.py#L274)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/manager.py#L274)
 
 Starting the multi-store transaction for the Kafka message.
 
@@ -5987,7 +5997,7 @@ before the end of the current one will fail.
 class TransactionState(State)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/state.py#L6)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L6)
 
 <a id="quixstreams.state.state.TransactionState.__init__"></a>
 
@@ -5997,7 +6007,7 @@ class TransactionState(State)
 def __init__(transaction: PartitionTransaction)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/state.py#L9)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L9)
 
 Simple key-value state to be provided into `StreamingDataFrame` functions
 
@@ -6013,7 +6023,7 @@ Simple key-value state to be provided into `StreamingDataFrame` functions
 def get(key: Any, default: Any = None) -> Optional[Any]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/state.py#L17)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L17)
 
 Get the value for key if key is present in the state, else default
 
@@ -6034,7 +6044,7 @@ value or None if the key is not found and `default` is not provided
 def set(key: Any, value: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/state.py#L27)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L27)
 
 Set value for the key.
 
@@ -6051,7 +6061,7 @@ Set value for the key.
 def delete(key: Any)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/state.py#L35)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L35)
 
 Delete value for the key.
 
@@ -6069,7 +6079,7 @@ This function always returns `None`, even if value is not found.
 def exists(key: Any) -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/state/state.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/state/state.py#L44)
 
 Check if the key exists in state.
 
@@ -6097,7 +6107,7 @@ True if key exists, False otherwise
 class PartitionAssignmentError(QuixException)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/exceptions/assignment.py#L6)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/exceptions/assignment.py#L6)
 
 Error happened during partition rebalancing.
 Raised from `on_assign`, `on_revoke` and `on_lost` callbacks
@@ -6118,7 +6128,7 @@ Raised from `on_assign`, `on_revoke` and `on_lost` callbacks
 def set_message_context(context: Optional[MessageContext])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/context.py#L22)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L22)
 
 Set a MessageContext for the current message in the given `contextvars.Context`
 
@@ -6155,7 +6165,7 @@ sdf = sdf.update(lambda value: alter_context(value))
 def message_context() -> MessageContext
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/context.py#L53)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L53)
 
 Get a MessageContext for the current message, which houses most of the message
 
@@ -6190,7 +6200,7 @@ instance of `MessageContext`
 def message_key() -> Any
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/context.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/context.py#L84)
 
 Get the current message's key.
 
@@ -6226,7 +6236,7 @@ a deserialized message key
 class Producer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/producer.py#L54)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/producer.py#L54)
 
 <a id="quixstreams.kafka.producer.Producer.__init__"></a>
 
@@ -6238,7 +6248,7 @@ def __init__(broker_address: str,
              extra_config: Optional[dict] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/producer.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/producer.py#L55)
 
 A wrapper around `confluent_kafka.Producer`.
 
@@ -6274,7 +6284,7 @@ def produce(topic: str,
             buffer_error_max_tries: int = 3)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/producer.py#L94)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/producer.py#L94)
 
 Produce message to topic.
 
@@ -6303,7 +6313,7 @@ Pass `0` to not retry after `BufferError`.
 def poll(timeout: float = 0)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/producer.py#L152)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/producer.py#L152)
 
 Polls the producer for events and calls `on_delivery` callbacks.
 
@@ -6320,7 +6330,7 @@ Polls the producer for events and calls `on_delivery` callbacks.
 def flush(timeout: Optional[float] = None) -> int
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/producer.py#L160)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/producer.py#L160)
 
 Wait for all messages in the Producer queue to be delivered.
 
@@ -6345,7 +6355,7 @@ number of messages delivered
 class Consumer()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L66)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L66)
 
 <a id="quixstreams.kafka.consumer.Consumer.__init__"></a>
 
@@ -6362,7 +6372,7 @@ def __init__(broker_address: str,
              extra_config: Optional[dict] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L67)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L67)
 
 A wrapper around `confluent_kafka.Consumer`.
 
@@ -6400,7 +6410,7 @@ Note: values passed as arguments override values in `extra_config`.
 def poll(timeout: Optional[float] = None) -> Optional[Message]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L126)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L126)
 
 Consumes a single message, calls callbacks and returns events.
 
@@ -6435,7 +6445,7 @@ def subscribe(topics: List[str],
               on_lost: Optional[RebalancingCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L144)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L144)
 
 Set subscription to supplied list of topics
 
@@ -6473,7 +6483,7 @@ for example, may fail.
 def unsubscribe()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L238)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L238)
 
 Remove current subscription.
 
@@ -6491,7 +6501,7 @@ def store_offsets(message: Optional[Message] = None,
                   offsets: Optional[List[TopicPartition]] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L246)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L246)
 
 .. py:function:: store_offsets([message=None], [offsets=None])
 
@@ -6522,7 +6532,7 @@ def commit(message: Optional[Message] = None,
            asynchronous: bool = True) -> Optional[List[TopicPartition]]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L280)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L280)
 
 Commit a message or a list of offsets.
 
@@ -6556,7 +6566,7 @@ def committed(partitions: List[TopicPartition],
               timeout: Optional[float] = None) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L320)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L320)
 
 .. py:function:: committed(partitions, [timeout=None])
 
@@ -6587,7 +6597,7 @@ def get_watermark_offsets(partition: TopicPartition,
                           cached: bool = False) -> Tuple[int, int]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L340)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L340)
 
 Retrieve low and high offsets for the specified partition.
 
@@ -6620,7 +6630,7 @@ def list_topics(topic: Optional[str] = None,
                 timeout: Optional[float] = None) -> ClusterMetadata
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L366)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L366)
 
 .. py:function:: list_topics([topic=None], [timeout=-1])
 
@@ -6649,7 +6659,7 @@ None or -1 is infinite. Default: None
 def memberid() -> str
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L389)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L389)
 
 Return this client's broker-assigned group member id.
 
@@ -6670,7 +6680,7 @@ def offsets_for_times(partitions: List[TopicPartition],
                       timeout: Optional[float] = None) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L402)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L402)
 
 Look up offsets by timestamp for the specified partitions.
 
@@ -6697,7 +6707,7 @@ last message in the partition, a value of -1 will be returned.
 def pause(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L428)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L428)
 
 Pause consumption for the provided list of partitions.
 
@@ -6721,7 +6731,7 @@ Does NOT affect the result of Consumer.assignment().
 def resume(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L442)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L442)
 
 .. py:function:: resume(partitions)
 
@@ -6743,7 +6753,7 @@ Resume consumption for the provided list of partitions.
 def position(partitions: List[TopicPartition]) -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L454)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L454)
 
 Retrieve current positions (offsets) for the specified partitions.
 
@@ -6770,7 +6780,7 @@ the last consumed message + 1.
 def seek(partition: TopicPartition)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L468)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L468)
 
 Set consume position for partition to offset.
 
@@ -6798,7 +6808,7 @@ pass the offset in an `assign()` call.
 def assignment() -> List[TopicPartition]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L485)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L485)
 
 Returns the current partition assignment.
 
@@ -6819,7 +6829,7 @@ Returns the current partition assignment.
 def set_sasl_credentials(username: str, password: str)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L498)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L498)
 
 Sets the SASL credentials used for this client.
 These credentials will overwrite the old ones, and will be used the next
@@ -6836,7 +6846,7 @@ This method is applicable only to SASL PLAIN and SCRAM mechanisms.
 def incremental_assign(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L510)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L510)
 
 Assign new partitions.
 
@@ -6854,7 +6864,7 @@ Any additional partitions besides the ones passed during the `Consumer`
 def incremental_unassign(partitions: List[TopicPartition])
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L522)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L522)
 
 Revoke partitions.
 
@@ -6868,7 +6878,7 @@ Can be called outside an on_revoke callback.
 def close()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/kafka/consumer.py#L530)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/kafka/consumer.py#L530)
 
 Close down and terminate the Kafka Consumer.
 
@@ -6894,7 +6904,7 @@ see `poll()` for more info.
 class Application()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L52)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L52)
 
 The main Application class.
 
@@ -6958,7 +6968,7 @@ def __init__(broker_address: str,
              topic_manager: Optional[TopicManager] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L91)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L91)
 
 **Arguments**:
 
@@ -7035,7 +7045,7 @@ def Quix(cls,
          topic_manager: Optional[QuixTopicManager] = None) -> Self
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L232)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L232)
 
 Initialize an Application to work with Quix platform,
 
@@ -7139,7 +7149,7 @@ def topic(name: str,
           timestamp_extractor: Optional[TimestampExtractor] = None) -> Topic
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L390)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L390)
 
 Create a topic definition.
 
@@ -7210,7 +7220,7 @@ topic = app.topic("input-topic", timestamp_extractor=custom_ts_extractor)
 def dataframe(topic: Topic) -> StreamingDataFrame
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L470)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L470)
 
 A simple helper method that generates a `StreamingDataFrame`, which is used
 
@@ -7252,7 +7262,7 @@ to be used as an input topic.
 def stop()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L506)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L506)
 
 Stop the internal poll loop and the message processing.
 
@@ -7270,7 +7280,7 @@ To otherwise stop an application, either send a `SIGTERM` to the process
 def get_producer() -> Producer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L520)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L520)
 
 Create and return a pre-configured Producer instance.
 The Producer is initialized with params passed to Application.
@@ -7301,7 +7311,7 @@ with app.get_producer() as producer:
 def get_consumer() -> Consumer
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L551)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L551)
 
 Create and return a pre-configured Consumer instance.
 The Consumer is initialized with params passed to Application.
@@ -7342,7 +7352,7 @@ with app.get_consumer() as consumer:
 def clear_state()
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L595)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L595)
 
 Clear the state of the application.
 
@@ -7354,7 +7364,7 @@ Clear the state of the application.
 def run(dataframe: StreamingDataFrame)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/app.py#L674)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/app.py#L674)
 
 Start processing data from Kafka using provided `StreamingDataFrame`
 
@@ -7394,7 +7404,7 @@ app.run(dataframe=df)
 class RowConsumer(Consumer, RowConsumerProto)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/rowconsumer.py#L59)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowconsumer.py#L59)
 
 <a id="quixstreams.rowconsumer.RowConsumer.__init__"></a>
 
@@ -7412,7 +7422,7 @@ def __init__(broker_address: str,
              on_error: Optional[ConsumerErrorCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/rowconsumer.py#L60)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowconsumer.py#L60)
 
 A consumer class that is capable of deserializing Kafka messages to Rows
 
@@ -7456,7 +7466,7 @@ def subscribe(topics: List[Topic],
               on_lost: Optional[RebalancingCallback] = None)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/rowconsumer.py#L115)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowconsumer.py#L115)
 
 Set subscription to supplied list of topics.
 
@@ -7485,7 +7495,7 @@ for example, may fail.
 def poll_row(timeout: float = None) -> Union[Row, List[Row], None]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/rowconsumer.py#L149)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/rowconsumer.py#L149)
 
 Consumes a single message and deserialize it to Row or a list of Rows.
 

--- a/docs/api-reference/topics-serdes.md
+++ b/docs/api-reference/topics-serdes.md
@@ -14,7 +14,7 @@
 class QuixDeserializer(JSONDeserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L70)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L70)
 
 Handles Deserialization for any Quix-formatted topic.
 
@@ -31,7 +31,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L77)
 
 
 <br>
@@ -53,7 +53,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L97)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L97)
 
 Each Quix message might contain data for multiple Rows.
 This property informs the downstream processors about that, so they can
@@ -70,7 +70,7 @@ def deserialize(model_key: str, value: Union[List[Mapping],
                                              Mapping]) -> Iterable[Mapping]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L150)
 
 Deserialization function for particular data types (Timeseries or EventData).
 
@@ -95,7 +95,7 @@ Iterable of dicts
 class QuixTimeseriesSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L313)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L313)
 
 Serialize data to JSON formatted according to Quix Timeseries format.
 
@@ -127,7 +127,7 @@ Output:
 class QuixEventsSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/quix.py#L401)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L401)
 
 Serialize data to JSON formatted according to Quix EventData format.
 The input value is expected to be a dictionary with the following keys:
@@ -168,7 +168,7 @@ Output:
 class BytesDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L44)
 
 A deserializer to bypass bytes without any changes
 
@@ -180,7 +180,7 @@ A deserializer to bypass bytes without any changes
 class BytesSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L55)
 
 A serializer to bypass bytes without any changes
 
@@ -192,7 +192,7 @@ A serializer to bypass bytes without any changes
 class StringDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L64)
 
 <a id="quixstreams.models.serializers.simple_types.StringDeserializer.__init__"></a>
 
@@ -204,7 +204,7 @@ class StringDeserializer(Deserializer)
 def __init__(column_name: Optional[str] = None, codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L65)
 
 Deserializes bytes to strings using the specified encoding.
 
@@ -223,7 +223,7 @@ A wrapper around `confluent_kafka.serialization.StringDeserializer`.
 class IntegerDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L84)
 
 Deserializes bytes to integers.
 
@@ -237,7 +237,7 @@ A wrapper around `confluent_kafka.serialization.IntegerDeserializer`.
 class DoubleDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L103)
 
 Deserializes float to IEEE 764 binary64.
 
@@ -251,7 +251,7 @@ A wrapper around `confluent_kafka.serialization.DoubleDeserializer`.
 class StringSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L122)
 
 <a id="quixstreams.models.serializers.simple_types.StringSerializer.__init__"></a>
 
@@ -263,7 +263,7 @@ class StringSerializer(Serializer)
 def __init__(codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L123)
 
 Serializes strings to bytes using the specified encoding.
 
@@ -281,7 +281,7 @@ Serializes strings to bytes using the specified encoding.
 class IntegerSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L135)
 
 Serializes integers to bytes
 
@@ -293,7 +293,7 @@ Serializes integers to bytes
 class DoubleSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/6e3708282d2d86cc3c10e09bbb5d7fb95b89fc8b/quixstreams/models/serializers/simple_types.py#L148)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L148)
 
 Serializes floats to bytes
 

--- a/docs/api-reference/topics-serdes.md
+++ b/docs/api-reference/topics-serdes.md
@@ -14,7 +14,7 @@
 class QuixDeserializer(JSONDeserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L70)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L73)
 
 Handles Deserialization for any Quix-formatted topic.
 
@@ -31,7 +31,7 @@ def __init__(column_name: Optional[str] = None,
              loads: Callable[[Union[bytes, bytearray]], Any] = default_loads)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L77)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L80)
 
 
 <br>
@@ -53,7 +53,7 @@ Default - :py:func:`quixstreams.utils.json.loads`.
 def split_values() -> bool
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L97)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L100)
 
 Each Quix message might contain data for multiple Rows.
 This property informs the downstream processors about that, so they can
@@ -70,7 +70,7 @@ def deserialize(model_key: str, value: Union[List[Mapping],
                                              Mapping]) -> Iterable[Mapping]
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L150)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L153)
 
 Deserialization function for particular data types (Timeseries or EventData).
 
@@ -95,7 +95,7 @@ Iterable of dicts
 class QuixTimeseriesSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L313)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L321)
 
 Serialize data to JSON formatted according to Quix Timeseries format.
 
@@ -127,7 +127,7 @@ Output:
 class QuixEventsSerializer(QuixSerializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/quix.py#L401)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/quix.py#L409)
 
 Serialize data to JSON formatted according to Quix EventData format.
 The input value is expected to be a dictionary with the following keys:
@@ -168,7 +168,7 @@ Output:
 class BytesDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L44)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L44)
 
 A deserializer to bypass bytes without any changes
 
@@ -180,7 +180,7 @@ A deserializer to bypass bytes without any changes
 class BytesSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L55)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L55)
 
 A serializer to bypass bytes without any changes
 
@@ -192,7 +192,7 @@ A serializer to bypass bytes without any changes
 class StringDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L64)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L64)
 
 <a id="quixstreams.models.serializers.simple_types.StringDeserializer.__init__"></a>
 
@@ -204,7 +204,7 @@ class StringDeserializer(Deserializer)
 def __init__(column_name: Optional[str] = None, codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L65)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L65)
 
 Deserializes bytes to strings using the specified encoding.
 
@@ -223,7 +223,7 @@ A wrapper around `confluent_kafka.serialization.StringDeserializer`.
 class IntegerDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L84)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L84)
 
 Deserializes bytes to integers.
 
@@ -237,7 +237,7 @@ A wrapper around `confluent_kafka.serialization.IntegerDeserializer`.
 class DoubleDeserializer(Deserializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L103)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L103)
 
 Deserializes float to IEEE 764 binary64.
 
@@ -251,7 +251,7 @@ A wrapper around `confluent_kafka.serialization.DoubleDeserializer`.
 class StringSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L122)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L122)
 
 <a id="quixstreams.models.serializers.simple_types.StringSerializer.__init__"></a>
 
@@ -263,7 +263,7 @@ class StringSerializer(Serializer)
 def __init__(codec: str = "utf_8")
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L123)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L123)
 
 Serializes strings to bytes using the specified encoding.
 
@@ -281,7 +281,7 @@ Serializes strings to bytes using the specified encoding.
 class IntegerSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L135)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L135)
 
 Serializes integers to bytes
 
@@ -293,7 +293,7 @@ Serializes integers to bytes
 class DoubleSerializer(Serializer)
 ```
 
-[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/397250828c3d95de066100529dc0c9d73dee7495/quixstreams/models/serializers/simple_types.py#L148)
+[[VIEW SOURCE]](https://github.com/quixio/quix-streams/blob/000d0523cbe1825500b111f1d8124507f67732ac/quixstreams/models/serializers/simple_types.py#L148)
 
 Serializes floats to bytes
 

--- a/docs/windowing.md
+++ b/docs/windowing.md
@@ -190,7 +190,8 @@ topic = app.topic("input-topic", timestamp_extractor=custom_ts_extractor)
 Here are some general concepts about how windowed aggregations are implemented in Quix Streams:
 
 - Only time-based windows are supported. 
-- Every window is grouped by the current Kafka message key. 
+- Every window is grouped by the current Kafka message key.
+- Messages with `None` key will be ignored.
 - The minimal window unit is a **millisecond**. More fine-grained values (e.g. microseconds) will be rounded towards the closest millisecond number.
 
 

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -364,7 +364,13 @@ class StreamingDataFrame(BaseStreaming):
         They allow to perform stateful aggregations like `sum`, `reduce`, etc.
         on top of the data and emit results downstream.
 
-        The time windows always use the current event time.
+        Notes:
+
+        - Every window is grouped by the current Kafka message key.
+        - Messages with `None` key will be ignored.
+        - The time windows always use the current event time.
+
+
 
         Example Snippet:
 
@@ -435,7 +441,11 @@ class StreamingDataFrame(BaseStreaming):
         They allow to perform stateful aggregations like `sum`, `reduce`, etc.
         on top of the data and emit results downstream.
 
-        The time windows always use the current event time.
+        Notes:
+
+        - Every window is grouped by the current Kafka message key.
+        - Messages with `None` key will be ignored.
+        - The time windows always use the current event time.
 
         Example Snippet:
 

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -206,8 +206,8 @@ def _as_windowed(
         if key is None:
             ctx = message_context()
             logger.warning(
-                f"Skipping window processing for a message because the key is None. "
-                f"Message offset: {ctx.offset}, partition: {ctx.partition}."
+                f"Skipping window processing for a message because the key is None, "
+                f"partition='{ctx.topic}[{ctx.partition}]' offset='{ctx.offset}'."
             )
             return _noop()
         with transaction.with_prefix(prefix=key):

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -203,7 +203,7 @@ def _as_windowed(
             state_manager.get_store_transaction(store_name=store_name),
         )
         key = message_key()
-        if not key:
+        if key is None:
             ctx = message_context()
             logger.warning(
                 f"Skipping window processing for a message because the key is None. "

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -1,3 +1,4 @@
+import logging
 import functools
 from typing import Any, Optional, List, TYPE_CHECKING, cast, Tuple
 
@@ -20,6 +21,8 @@ from .base import (
 
 if TYPE_CHECKING:
     from quixstreams.dataframe.dataframe import StreamingDataFrame, DataFrameFunc
+
+logger = logging.getLogger(__name__)
 
 
 def _default_merge_func(state_value: Any) -> Any:
@@ -180,6 +183,16 @@ class FixedTimeWindow:
         return self._dataframe.apply(func=func, expand=expand)
 
 
+def _noop() -> Any:
+    """
+    No-operation function for skipping messages due to None keys.
+
+    Messages with None keys are ignored because keys are essential for performing
+    accurate and meaningful windowed aggregation.
+    """
+    return []
+
+
 def _as_windowed(
     func: WindowedDataFrameFunc, state_manager: StateStoreManager, store_name: str
 ) -> "DataFrameFunc":
@@ -190,6 +203,13 @@ def _as_windowed(
             state_manager.get_store_transaction(store_name=store_name),
         )
         key = message_key()
+        if not key:
+            ctx = message_context()
+            logger.warning(
+                f"Skipping window processing for a message because the key is None. "
+                f"Message offset: {ctx.offset}, partition: {ctx.partition}."
+            )
+            return _noop()
         with transaction.with_prefix(prefix=key):
             return func(value, transaction.state)
 

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -825,9 +825,13 @@ class TestStreamingDataFrameTumblingWindow:
         ]
 
     def test_tumbling_window_none_key_messages(
-        self, dataframe_factory, state_manager, message_context_factory
+        self,
+        dataframe_factory,
+        state_manager,
+        message_context_factory,
+        topic_manager_topic_factory,
     ):
-        topic = Topic("test")
+        topic = topic_manager_topic_factory(name="test")
 
         sdf = dataframe_factory(topic, state_manager=state_manager)
         sdf = sdf.tumbling_window(duration_ms=10).sum().current()
@@ -1064,9 +1068,13 @@ class TestStreamingDataFrameHoppingWindow:
         ]
 
     def test_hopping_window_none_key_messages(
-        self, dataframe_factory, state_manager, message_context_factory
+        self,
+        dataframe_factory,
+        state_manager,
+        message_context_factory,
+        topic_manager_topic_factory,
     ):
-        topic = Topic("test")
+        topic = topic_manager_topic_factory(name="test")
 
         sdf = dataframe_factory(topic, state_manager=state_manager)
         sdf = sdf.hopping_window(duration_ms=10, step_ms=5).sum().current()

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -7,7 +7,7 @@ from quixstreams import MessageContext, State
 from quixstreams.core.stream import Filtered
 from quixstreams.dataframe.exceptions import InvalidOperation
 from quixstreams.dataframe.windows import WindowResult
-from quixstreams.models import MessageTimestamp
+from quixstreams.models import MessageTimestamp, Topic
 from tests.utils import TopicPartitionStub
 
 
@@ -824,6 +824,40 @@ class TestStreamingDataFrameTumblingWindow:
             WindowResult(value=2, start=20, end=30),
         ]
 
+    def test_tumbling_window_none_key_messages(
+        self, dataframe_factory, state_manager, message_context_factory
+    ):
+        topic = Topic("test")
+
+        sdf = dataframe_factory(topic, state_manager=state_manager)
+        sdf = sdf.tumbling_window(duration_ms=10).sum().current()
+
+        state_manager.on_partition_assign(
+            tp=TopicPartitionStub(topic=topic.name, partition=0)
+        )
+        messages = [
+            # Create window [0,10)
+            (1, message_context_factory(key="test", timestamp_ms=1)),
+            # Message with None key, expected to be ignored
+            (10, message_context_factory(key=None, timestamp_ms=100)),
+            # Update window [0,10)
+            (2, message_context_factory(key="test", timestamp_ms=2)),
+        ]
+
+        results = []
+        for value, ctx in messages:
+            with state_manager.start_store_transaction(
+                topic=ctx.topic, partition=ctx.partition, offset=ctx.offset
+            ):
+                results += sdf.test(value=value, ctx=ctx)
+
+        assert len(results) == 2
+        # Ensure that the windows are returned with correct values and order
+        assert results == [
+            WindowResult(value=1, start=0, end=10),
+            WindowResult(value=3, start=0, end=10),
+        ]
+
 
 class TestStreamingDataFrameHoppingWindow:
     def test_hopping_window_define_from_milliseconds(
@@ -1027,4 +1061,38 @@ class TestStreamingDataFrameHoppingWindow:
             WindowResult(value=3, start=0, end=10),
             WindowResult(value=5, start=5, end=15),
             WindowResult(value=3, start=10, end=20),
+        ]
+
+    def test_hopping_window_none_key_messages(
+        self, dataframe_factory, state_manager, message_context_factory
+    ):
+        topic = Topic("test")
+
+        sdf = dataframe_factory(topic, state_manager=state_manager)
+        sdf = sdf.hopping_window(duration_ms=10, step_ms=5).sum().current()
+
+        state_manager.on_partition_assign(
+            tp=TopicPartitionStub(topic=topic.name, partition=0)
+        )
+        messages = [
+            # Create window [0,10)
+            (1, message_context_factory(key="test", timestamp_ms=1)),
+            # Message with None key, expected to be ignored
+            (10, message_context_factory(key=None, timestamp_ms=100)),
+            # Update window [0,10)
+            (2, message_context_factory(key="test", timestamp_ms=2)),
+        ]
+
+        results = []
+        for value, ctx in messages:
+            with state_manager.start_store_transaction(
+                topic=ctx.topic, partition=ctx.partition, offset=ctx.offset
+            ):
+                results += sdf.test(value=value, ctx=ctx)
+
+        assert len(results) == 2
+        # Ensure that the windows are returned with correct values and order
+        assert results == [
+            WindowResult(value=1, start=0, end=10),
+            WindowResult(value=3, start=0, end=10),
         ]


### PR DESCRIPTION
#### Allow events with `null` keys overall in StreamingDataFrame.
* `null` is still a value, plus users can change the key to something else

#### Skip events with `null` keys in Windows and log warnings:
* Messages with the `null` keys can be sent to random partitions (depending on the partitioner).
* Therefore the result of the window with the `null` key can be a random value because of it
* If the events have `null` keys, they must be re-keyed before processing them in the window.