### PR TITLE
Example Bugfix: Do not override state input on each update

### DIFF
--- a/examples/bank_example/json_version/consumer.py
+++ b/examples/bank_example/json_version/consumer.py
@@ -21,7 +21,6 @@ def count_transactions(value: dict, state: State):
     :param value: message value
     :param state: instance of State store
     """
-    state = {}
     total = state.get("total_transactions", 0)
     total += 1
     state.set("total_transactions", total)


### PR DESCRIPTION
Think this might have been added accidentally in a previous commit.

It breaks the example (its not the correct type and it gets re-initialised every update).