### PR TITLE
Feature/sql

### DIFF
--- a/examples/bank_example/json_version/consumer.py
+++ b/examples/bank_example/json_version/consumer.py
@@ -21,7 +21,6 @@ def count_transactions(value: dict, state: State):
     :param value: message value
     :param state: instance of State store
     """
-    state = {}
     total = state.get("total_transactions", 0)
     total += 1
     state.set("total_transactions", total)
@@ -43,9 +42,10 @@ def uppercase_source(value: dict):
 
 
 # Define your application and settings
+import random
 app = Application(
     broker_address=environ["BROKER_ADDRESS"],
-    consumer_group="json__purchase_notifier",
+    consumer_group="json__purchase_notifier"+str(random.randint(0,10000)),
     auto_offset_reset="earliest",
 )
 
@@ -58,11 +58,15 @@ output_topic = app.topic("json__user_notifications", value_serializer="json")
 # Create a StreamingDataFrame and start building your processing pipeline
 sdf = app.dataframe(input_topic)
 
-# Filter only messages with "account_class" == "Gold" and "transaction_amount" >= 1000
-sdf = sdf[(sdf["account_class"] == "Gold") & (sdf["transaction_amount"].abs() >= 1000)]
+sdf = sdf.sql("""
+SELECT account_id, transaction_amount, transaction_source FROM __self 
+WHERE account_class == 'Gold' AND transaction_amount >= 1000
+""")
 
-# Drop all fields except the ones we need
-sdf = sdf[["account_id", "transaction_amount", "transaction_source"]]
+## Filter only messages with "account_class" == "Gold" and "transaction_amount" >= 1000
+#sdf = sdf[(sdf["account_class"] == "Gold") & (sdf["transaction_amount"].abs() >= 1000)]
+## Drop all fields except the ones we need
+#sdf = sdf[["account_id", "transaction_amount", "transaction_source"]]
 
 # Update the total number of transactions in state and save result to the message
 sdf["total_transactions"] = sdf.apply(count_transactions, stateful=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ line_length = 88
 [tool.pytest.ini_options]
 minversion = "6.0"
 # Ignore manual tests by and some loggers by default
-addopts = "--log-disable=urllib3.connectionpool --log-disable=parso --log-disable=docker"
+# addopts = "--log-disable=urllib3.connectionpool --log-disable=parso --log-disable=docker"
 
 # Print debug logs to the console in tests
 log_cli = true

--- a/quixstreams/dataframe/sql.py
+++ b/quixstreams/dataframe/sql.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from datetime import timedelta, datetime
 from functools import singledispatchmethod
 from typing import Dict
 
@@ -7,12 +8,20 @@ from sqlglot import exp, planner, optimizer
 from sqlglot.errors import ExecuteError
 from sqlglot.executor.env import ENV
 from sqlglot.executor.python import Python
+from sqlglot.expressions import Table, Alias, Column
 from sqlglot.optimizer import build_scope
 
 from sqlglot.planner import Plan
 from sqlglot import parse_one
 
 logger = logging.getLogger(__name__)
+
+# TODO: create a new SQL dialect instead of hacking these in
+# Potentially Apache Calcite?
+WINDOW_TYPES = {
+    "TUMBLE": "tumbling_window",
+    "HOP": "hopping_window",
+}
 
 
 class StreamingSQLExecutor:
@@ -26,7 +35,7 @@ class StreamingSQLExecutor:
         self.query = query
         self.node = parse_one(query)
         self.generator = Python().generator(identify=True, comments=False)
-        self.env = {**ENV, **(env or {}), "scope": {}}
+        self.env = {**ENV, **(env or {}), "COUNT": _sql_count, "scope": {}}
 
     def add_to_stream(self, tables: Dict, table_schemas: Dict[str, Dict] = None):
         # Slightly long-winded so that we don't include CTEs here
@@ -65,9 +74,13 @@ class StreamingSQLExecutor:
                     for dep in node.dependencies
                     for name, table in contexts[dep].items()
                 }
-                if node.source.name in contexts:
+                context = {**context, **tables}
+                if type(node.source) is Table and node.source.name in contexts:
                     # add the source table to the context for the node if relevant
                     context[node.source.name] = contexts[node.source.name]
+
+                if node.type_name == "Aggregate":
+                    return self.step(node, context)[node.id]
                 contexts[node] = self.step(node, context)
                 finished.add(node)
 
@@ -82,13 +95,14 @@ class StreamingSQLExecutor:
                 raise ExecuteError(f"Step '{node.id}' failed: {e}") from e
 
         root = plan.root
-        return contexts[root][root.name]
+        return contexts[root][root.id]
 
     @singledispatchmethod
     def step(self, node, context):
         raise NotImplementedError
 
-    def step(self, step: planner.Scan, context):
+    @step.register(planner.Scan)
+    def scan(self, step: planner.Scan, context):
         source = step.source.name
         dataframe = context[source]
 
@@ -97,9 +111,9 @@ class StreamingSQLExecutor:
 
         if not step.projections and not step.condition:
             # ~ no op
-            return {step.name: context[source]}
+            return {step.id: context[source]}
 
-        return {step.name: self._project_and_filter(step, dataframe)}
+        return {step.id: self._project_and_filter(step, dataframe)}
 
     def _project_and_filter(self, step, dataframe):
         condition = self.generate(step.condition)
@@ -120,12 +134,66 @@ class StreamingSQLExecutor:
     def static(self):
         raise NotImplementedError
 
+    @step.register(planner.Aggregate)
+    def aggregate(self, step: planner.Aggregate, context):
+        dataframe = context[step.source]
+        group_by = self.generate_tuple(step.group.values())
+        aggregations = self.generate_tuple(step.aggregations)
+        operands = self.generate_tuple(step.operands)
+
+        # if this is an aggregation we should always have a window to group by
+        _window = [g for g in step.group.values() if g.alias_or_name in WINDOW_TYPES]
+        assert len(_window) == 1
+        window = _window[0]
+        _interval = window.args["expressions"][1]
+        interval = timedelta(**{_interval.unit.this.lower() + "s": int(_interval.this.this)})
+
+        def initializer(value: dict) -> dict:
+            return {
+                ag.alias: eval(agg, {**self.env, "scope":
+                    {
+                        "__self": {ag.args["this"].this.name: [value[ag.args["this"].this.name]]},
+                    }}) for ag, agg in zip(step.aggregations, aggregations)
+            }
+
+        def reducer(aggregated: dict, value: dict) -> dict:
+            return {
+                ag.alias: eval(agg, {**self.env, "scope":
+                    {
+                        "__self": {ag.args["this"].this.name: [aggregated[ag.alias], value[ag.args["this"].this.name]]},
+                    }}) for ag, agg in zip(step.aggregations, aggregations)
+            }
+
+        dataframe = (
+            getattr(dataframe, WINDOW_TYPES[window.alias_or_name])(duration_ms=interval)
+            .reduce(reducer=reducer, initializer=initializer)
+            .current()
+        )
+
+        for projection in step.projections:
+            if type(projection) == Alias:
+                to = projection.alias
+                from_ = projection.this.alias_or_name.lower().split(window.alias_or_name.lower() + "_")[1]
+            elif type(projection) == Column:
+                continue
+            else:
+                raise Exception("Other projections on aggregations not supported")
+
+        def reshape(value):
+            return {
+                to: datetime.fromtimestamp(value[from_] / 1000.0).isoformat(),
+                **value["value"]
+            }
+
+        dataframe = dataframe.apply(reshape)
+
+        # TODO: handle additional non-window groups. i.e. window + another column (e.g. user_id)
+
+        return {step.id: dataframe}
+
     # def step(self, node: planner.Join, context):
     #     # TODO: requires API that works on multiple dataframes statefully
     #     # Also needs windows first
-
-    # def step(self, node: planner.Aggregate, df):
-    #     # TODO: we can do this with stateful processing but need windows first
 
     # def step(self, node: planner.Sort, context):
     #     # TODO: we can do this with stateful processing but need windows first
@@ -145,3 +213,9 @@ class StreamingSQLExecutor:
         if not expressions:
             return tuple()
         return tuple(self.generate(expression) for expression in expressions)
+
+# The default COUNT function doesn't work incrementally
+def _sql_count(args):
+    if len(args) == 1:
+        return 1  # initialize
+    return args[0] + 1

--- a/quixstreams/dataframe/sql.py
+++ b/quixstreams/dataframe/sql.py
@@ -1,0 +1,147 @@
+import logging
+import math
+from functools import singledispatchmethod
+from typing import Dict
+
+from sqlglot import exp, planner, optimizer
+from sqlglot.errors import ExecuteError
+from sqlglot.executor.env import ENV
+from sqlglot.executor.python import Python
+from sqlglot.optimizer import build_scope
+
+from sqlglot.planner import Plan
+from sqlglot import parse_one
+
+logger = logging.getLogger(__name__)
+
+
+class StreamingSQLExecutor:
+    """
+    Very simple start means:
+    - only one dataframe & stream supported - this means no joins
+    - no state - this means no windows or aggregations
+    """
+
+    def __init__(self, query: str, env=None):
+        self.query = query
+        self.node = parse_one(query)
+        self.generator = Python().generator(identify=True, comments=False)
+        self.env = {**ENV, **(env or {}), "scope": {}}
+
+    def add_to_stream(self, tables: Dict, table_schemas: Dict[str, Dict] = None):
+        # Slightly long-winded so that we don't include CTEs here
+        required_tables = set(
+            source.name or source.alias
+            for scope in build_scope(self.node).traverse()
+            for alias, (node, source) in scope.selected_sources.items()
+            if isinstance(source, exp.Table)
+        )
+        if not required_tables.issubset(tables):
+            raise ValueError(f"Missing tables: {required_tables - set(tables)}")
+
+        node = self.node
+        if table_schemas:
+            node = optimizer.optimize(self.node, schema=table_schemas, leave_tables_isolated=True)
+        elif not required_tables.issubset(table_schemas or {}):
+            logger.warning(f"Some table schemas missing {required_tables - set(tables)}. "
+                           f"Not all SQL operations can be optimised or validated ahead of time.")
+            # But we still apply this as it makes the plan execution simpler
+            node = optimizer.optimize(self.node, leave_tables_isolated=True)
+
+        return self._execute(plan=Plan(node), tables={t: tables[t] for t in required_tables})
+
+    def _execute(self, plan, tables):
+        finished = set()
+        queue = set(plan.leaves)
+        # contexts is a mapping from a node to the result of executing that node
+        # the result of executing a node is a table
+        contexts = {**tables}
+
+        while queue:
+            node = queue.pop()
+            try:
+                context = {
+                    name: table
+                    for dep in node.dependencies
+                    for name, table in contexts[dep].items()
+                }
+                if node.source.name in contexts:
+                    # add the source table to the context for the node if relevant
+                    context[node.source.name] = contexts[node.source.name]
+                contexts[node] = self.step(node, context)
+                finished.add(node)
+
+                for dep in node.dependents:
+                    if all(d in contexts for d in dep.dependencies):
+                        queue.add(dep)
+
+                for dep in node.dependencies:
+                    if all(d in finished for d in dep.dependents):
+                        contexts.pop(dep)
+            except Exception as e:
+                raise ExecuteError(f"Step '{node.id}' failed: {e}") from e
+
+        root = plan.root
+        return contexts[root][root.name]
+
+    @singledispatchmethod
+    def step(self, node, context):
+        raise NotImplementedError
+
+    def step(self, step: planner.Scan, context):
+        source = step.source.name
+        dataframe = context[source]
+
+        if step.limit != math.inf:
+            raise NotImplementedError("LIMIT not supported")
+
+        if not step.projections and not step.condition:
+            # ~ no op
+            return {step.name: context[source]}
+
+        return {step.name: self._project_and_filter(step, dataframe)}
+
+    def _project_and_filter(self, step, dataframe):
+        condition = self.generate(step.condition)
+        projections = self.generate_tuple(step.projections)
+        if condition:
+            dataframe = dataframe.filter(
+                lambda value: eval(condition, {**self.env, "scope": {"__self": value, None: value}})
+            )
+        if projections:
+            dataframe = dataframe.apply(
+                lambda value: (
+                    {step.projections[i].this.this.this: eval(
+                        projections[i], {**self.env, "scope": {"__self": value, None: value}}
+                    ) for i in range(len(step.projections))}
+                ))
+        return dataframe
+
+    def static(self):
+        raise NotImplementedError
+
+    # def step(self, node: planner.Join, context):
+    #     # TODO: requires API that works on multiple dataframes statefully
+    #     # Also needs windows first
+
+    # def step(self, node: planner.Aggregate, df):
+    #     # TODO: we can do this with stateful processing but need windows first
+
+    # def step(self, node: planner.Sort, context):
+    #     # TODO: we can do this with stateful processing but need windows first
+
+    # def step(self, step: planner.SetOperation, context):
+    #     # TODO: requires API that works on multiple dataframes statefully
+    #     # Also needs windows first
+
+    def generate(self, expression) -> str:
+        """Convert a SQL expression into literal Python code and compile it into bytecode."""
+        if not expression:
+            return None
+        return self.generator.generate(expression)
+
+    def generate_tuple(self, expressions):
+        """Convert an array of SQL expressions into tuple of Python byte code."""
+        if not expressions:
+            return tuple()
+        return tuple(self.generate(expression) for expression in expressions)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.28
 rocksdict>=0.3, <0.4
 typing_extensions>=4.8,<4.9
 orjson>=3.9,<4
+sqlglot~=22.2.2.dev18


### PR DESCRIPTION
# Proposed Feature

New API `dataframe.sql(query: str)`.

## Status

This is extremely POC that just about scrapes some tests. Don't actually use it please.

## How it works

1. Use sqlglot to parse and create an execution plan (which is a DAG)
2. Traverse the DAG from leaves up, collecting dependencies where needed
3. Convert in-line SQL expressions into a fake SQL "dialect" that is actually just python.
4. Attach those expressions to the dataframe using the existing `apply`, `filter` and `*_window` APIs

## What would do next?

There's lots of logic that is (for ease) done in `step 4.` but should probably be done with a custom grammar and probably some custom planning too.

Needs a tonne of tests. Ideally a stricter subset of SQL to support to make that clear.

**Schemas** - Query optimization is much easier with schemas.

**Schema Registry** - You could probably do a really cool table definition <--> schema registry. Haven't thought it through.

**Joins** - this is one of the most useful things to be able to do...

**Window control with watermarking, allowed lateness etc.**

**UDFs (?)** I don't actually think this is a super compelling because you can just chain SQL with python anyway. The only neat usecase could be aggregations.

## Performance

Haven't tested but almost certainly terrible. Would need some effort put into planner as mentioned above and then you could get very close to hand coded python (and *potentially* better as you could do things execution that might not come naturally when writing procedural code.