### PR TITLE
hotfix bug around undefined workspace id for Quix API class

### DIFF
--- a/quixstreams/platforms/quix/config.py
+++ b/quixstreams/platforms/quix/config.py
@@ -11,6 +11,7 @@ from requests import HTTPError
 from quixstreams.exceptions import QuixException
 from quixstreams.models.topics import Topic
 from .api import QuixPortalApiService
+from .exceptions import UndefinedQuixWorkspaceId
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,7 @@ class QuixKafkaConfigsBuilder:
 
         try:
             self._workspace_id = workspace_id or self.api.default_workspace_id
-        except self.api.UndefinedQuixWorkspaceId:
+        except UndefinedQuixWorkspaceId:
             self._workspace_id = None
             logger.warning(
                 "No workspace ID was provided directly or found via environment; "

--- a/tests/test_quixstreams/test_platforms/test_quix/test_config.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/test_config.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, call, create_autospec
 import pytest
 from requests import HTTPError, Response
 
+from quixstreams.platforms.quix.api import QuixPortalApiService
 from quixstreams.platforms.quix.config import (
     QUIX_CONNECTIONS_MAX_IDLE_MS,
     QUIX_METADATA_MAX_AGE_MS,
@@ -14,6 +15,10 @@ from quixstreams.platforms.quix.config import (
 
 
 class TestQuixKafkaConfigsBuilder:
+    def test_no_workspace_id_warning(self, quix_kafka_config_factory, caplog):
+        quix_kafka_config_factory(api_class=QuixPortalApiService(auth_token="12345"))
+        assert "No workspace ID was provided" in caplog.text
+
     def test_search_for_workspace_id(self, quix_kafka_config_factory):
         api_data_stub = {"workspaceId": "myworkspace12345", "name": "my workspace"}
         cfg_factory = quix_kafka_config_factory(


### PR DESCRIPTION
Bug was result of removing Exceptions from the class to the general `exception.py` file