### PR TITLE
Add orjson.OPT_SERIALIZE_NUMPY to Handle Numpy Serialization in quixstreams

### DIFF
--- a/quixstreams/utils/json.py
+++ b/quixstreams/utils/json.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import orjson
 
-_ORJSON_OPTIONS = orjson.OPT_PASSTHROUGH_DATETIME | orjson.OPT_PASSTHROUGH_DATACLASS
+_ORJSON_OPTIONS = orjson.OPT_PASSTHROUGH_DATETIME | orjson.OPT_PASSTHROUGH_DATACLASS | orjson.OPT_SERIALIZE_NUMPY
 
 
 def dumps(value: Any) -> bytes:


### PR DESCRIPTION
Add ability to serialize numpy float values as part of the quixstreams dumps function by adding OPT_SERIALIZE_NUMPY to orjson options to fix serialization errors using numpy with custom reducers in windowing. Closes #372 