### PR TITLE
Experimental: Peek, Print, and in-place operations

### DIFF
--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -930,7 +930,6 @@ class StreamingDataFrame(BaseStreaming):
         row = Row(
             value=value, key=key, timestamp=timestamp, context=ctx, headers=headers
         )
-        print("PRODUCE!!!")
         self._producer.produce_row(row=row, topic=topic, key=key, timestamp=timestamp)
 
     def _register_store(self):


### PR DESCRIPTION
- Added `SDF.peek()`, which is basically a rename of  `SDF.update()`
- Added `SDF.print(metadata: bool)`, which prints the value, and optionally metadata
- Enables `SDF.print()`, `SDF.peek()` and `SDF.to_topic()` to be used without reassigning them (and you can chain them as normal)

```python
sdf = SDF()
sdf = sdf.apply(a_func)
sdf.peek(other_func)
sdf.print(metadata=True).to_topic(my_topic)
```