### PR TITLE
add drop feature

### DIFF
--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -970,6 +970,10 @@ class StreamingDataFrame(BaseStreaming):
         """
         Drop column(s) from the message value (value must support `del`, like a dict).
 
+        This operation occurs in-place, meaning reassignment is entirely OPTIONAL: the
+        original `StreamingDataFrame` is returned for chaining (`sdf.update().print()`).
+
+
         Example Snippet:
 
         ```python
@@ -977,7 +981,7 @@ class StreamingDataFrame(BaseStreaming):
         # This would transform {"x": 1, "y": 2, "z": 3} to {"z": 3}
 
         sdf = StreamingDataframe()
-        sdf = sdf.drop(["x", "y"])
+        sdf.drop(["x", "y"])
         ```
 
         :param columns: a single column name or a list of names, where names are `str`
@@ -994,8 +998,7 @@ class StreamingDataFrame(BaseStreaming):
             raise TypeError(
                 f"Expected a string or a list of strings, not {type(columns)}"
             )
-        stream = self.stream.add_update(lambda value: _drop(value, columns))
-        return self.__dataframe_clone__(stream)
+        return self._add_update(lambda value: _drop(value, columns), metadata=False)
 
     def _produce(
         self,

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -984,6 +984,8 @@ class StreamingDataFrame(BaseStreaming):
         :return: a new StreamingDataFrame instance
         """
         if isinstance(columns, list):
+            if not columns:
+                return self
             if not all(isinstance(s, str) for s in columns):
                 raise TypeError(f"column list must contain strings only")
         elif isinstance(columns, str):

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -390,6 +390,29 @@ class TestStreamingDataFrame:
 
         assert expected in capsys.readouterr().out
 
+    @pytest.mark.parametrize(
+        "columns, expected",
+        [
+            ("col_a", {"col_b": 2, "col_c": 3}),
+            (["col_a"], {"col_b": 2, "col_c": 3}),
+            (["col_a", "col_b"], {"col_c": 3}),
+        ],
+    )
+    def test_drop(self, dataframe_factory, columns, expected):
+        value = {"col_a": 1, "col_b": 2, "col_c": 3}
+        key, timestamp, headers = b"key", 0, []
+        sdf = dataframe_factory()
+        sdf = sdf.drop(columns)
+        assert sdf.test(value=value, key=key, timestamp=timestamp, headers=headers)[
+            0
+        ] == (expected, key, timestamp, headers)
+
+    @pytest.mark.parametrize("columns", [["col_a", 3], b"col_d", {"col_a"}])
+    def test_drop_invalid_columns(self, dataframe_factory, columns):
+        sdf = dataframe_factory()
+        with pytest.raises(TypeError):
+            sdf.drop(columns)
+
 
 class TestStreamingDataFrameApplyExpand:
     def test_apply_expand(self, dataframe_factory):

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -402,7 +402,7 @@ class TestStreamingDataFrame:
         value = {"col_a": 1, "col_b": 2, "col_c": 3}
         key, timestamp, headers = b"key", 0, []
         sdf = dataframe_factory()
-        sdf = sdf.drop(columns)
+        sdf.drop(columns)
         assert sdf.test(value=value, key=key, timestamp=timestamp, headers=headers)[
             0
         ] == (expected, key, timestamp, headers)

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -413,6 +413,16 @@ class TestStreamingDataFrame:
         with pytest.raises(TypeError):
             sdf.drop(columns)
 
+    def test_drop_empty_list(self, dataframe_factory):
+        """
+        Dropping an empty list is ignored entirely.
+        """
+        sdf = dataframe_factory()
+        pre_drop_stream = sdf.stream.tree()
+        sdf = sdf.drop([])
+        post_drop_stream = sdf.stream.tree()
+        assert pre_drop_stream == post_drop_stream
+
 
 class TestStreamingDataFrameApplyExpand:
     def test_apply_expand(self, dataframe_factory):


### PR DESCRIPTION
Add the ability to drop a column or list of columns from a `StreamingDataFrame` via:

 `SDF.drop("col_a")` or `SDF.drop(["col_a", "col_b"])`