### PR TITLE
Optimize tree() method of Stream class to reduce time complexity

### DIFF
--- a/quixstreams/core/stream/stream.py
+++ b/quixstreams/core/stream/stream.py
@@ -234,14 +234,19 @@ class Stream:
         """
         Return a list of all parent Streams including the node itself.
 
-        The tree is ordered from child to parent (current node comes first).
+        The tree is ordered from parent to child (current node comes last).
         :return: a list of `Stream` objects
         """
+
         tree_ = [self]
         node = self
         while node.parent:
-            tree_.insert(0, node.parent)
+            tree_.append(node.parent)
             node = node.parent
+
+        # Reverse to get expected ordering.
+        tree_.reverse()
+
         return tree_
 
     def compose_returning(self) -> ReturningExecutor:


### PR DESCRIPTION
Modified the `tree()` method to build the list in reverse order and then reverse it at the end, making the operation more efficient.

Earlier version did an insert(0, ...) operation on the list for each parent, which can have a worst-case time complexity of O(n**2) due to shifting of list elements for each call.

Modified implementation has an O(n) time complexity, with no additional space complexity, and maintains the same node ordering and behavior as the original tree() method.

The function docstring also needed a correction which has been incorporated into this fix.

Related Issue #399 