### PR TITLE
Ci tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python: [ 3.8 ]
+        python: [3.8, 3.12]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: 'CI'
 
 on:
-  push:
   pull_request:
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Python ${{ matrix.python }}
+      - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.8


### PR DESCRIPTION
* We want to test against the lowest and highest supported Python versions.
* Don't trigger the pipeline on push events, this is rather redundant and PR pipelines are enough.
   Note: PR sync (push new commits) will still trigger the pipeline.
* Minor cleanup in lint job