### PR TITLE
Extend SerializationContext with field attribute

### DIFF
--- a/quixstreams/models/serializers/base.py
+++ b/quixstreams/models/serializers/base.py
@@ -2,7 +2,6 @@ import abc
 from typing import Optional, Any, Union
 from typing_extensions import TypeAlias, Literal
 
-
 from confluent_kafka.serialization import (
     SerializationContext as _SerializationContext,
     MessageField,
@@ -16,32 +15,28 @@ __all__ = (
     "Serializer",
     "SerializerType",
     "DeserializerType",
+    "MessageField",
 )
 
 
-class SerializationContext:
+class SerializationContext(_SerializationContext):
     """
     Provides additional context for message serialization/deserialization.
 
     Every `Serializer` and `Deserializer` receives an instance of `SerializationContext`
     """
 
-    __slots__ = ("topic", "headers")
+    __slots__ = ("topic", "field", "headers")
 
-    def __init__(self, topic: str, headers: Optional[MessageHeadersTuples] = None):
+    def __init__(
+        self,
+        topic: str,
+        field: MessageField,
+        headers: Optional[MessageHeadersTuples] = None,
+    ) -> None:
         self.topic = topic
+        self.field = field
         self.headers = headers
-
-    def to_confluent_ctx(self, field: MessageField) -> _SerializationContext:
-        """
-        Convert `SerializationContext` to `confluent_kafka.SerializationContext`
-        in order to re-use serialization already provided by `confluent_kafka` library.
-        :param field: instance of `confluent_kafka.serialization.MessageField`
-        :return: instance of `confluent_kafka.serialization.SerializationContext`
-        """
-        return _SerializationContext(
-            field=field, topic=self.topic, headers=self.headers
-        )
 
 
 class Deserializer(abc.ABC):

--- a/quixstreams/models/topics/topic.py
+++ b/quixstreams/models/topics/topic.py
@@ -191,7 +191,7 @@ class Topic:
             value_deserialized = (
                 None
                 if value_bytes is None
-                else self._value_deserializer(value=message.value(), ctx=ctx)
+                else self._value_deserializer(value=value_bytes, ctx=ctx)
             )
         except IgnoreMessage:
             # Ignore message completely if deserializer raised IgnoreValueError.

--- a/quixstreams/models/topics/topic.py
+++ b/quixstreams/models/topics/topic.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+from functools import partial
 from typing import List, Any, Callable, Union
 from typing import Optional
 
@@ -19,6 +20,7 @@ from quixstreams.models.serializers import (
     DeserializerType,
     Serializer,
     Deserializer,
+    MessageField,
 )
 from quixstreams.models.timestamps import TimestampType
 from quixstreams.models.topics.utils import merge_headers
@@ -135,7 +137,6 @@ class Topic:
         :param key: message key to serialize
         :return: KafkaMessage object with serialized values
         """
-        ctx = SerializationContext(topic=self.name, headers=row.headers)
         if self._key_serializer is None:
             raise SerializerIsNotProvidedError(
                 f'Key serializer is not provided for topic "{self.name}"'
@@ -144,13 +145,16 @@ class Topic:
             raise SerializerIsNotProvidedError(
                 f'Value serializer is not provided for topic "{self.name}"'
             )
+
+        ctx = partial(SerializationContext, topic=self.name, headers=row.headers)
+
         # Try to serialize the key only if it's not None
         # If key is None then pass it as is
         # Otherwise, different serializers may serialize None differently
         if key is None:
             key_serialized = None
         else:
-            key_serialized = self._key_serializer(key, ctx=ctx)
+            key_serialized = self._key_serializer(key, ctx=ctx(field=MessageField.KEY))
 
         # Update message headers with headers supplied by the value serializer.
         extra_headers = self._value_serializer.extra_headers
@@ -158,7 +162,7 @@ class Topic:
 
         return KafkaMessage(
             key=key_serialized,
-            value=self._value_serializer(row.value, ctx=ctx),
+            value=self._value_serializer(row.value, ctx=ctx(field=MessageField.VALUE)),
             headers=headers,
         )
 
@@ -181,19 +185,21 @@ class Topic:
             )
 
         headers = message.headers()
-        ctx = SerializationContext(topic=message.topic(), headers=headers)
+        ctx = partial(SerializationContext, topic=message.topic(), headers=headers)
 
         if (key_bytes := message.key()) is None:
             key_deserialized = None
         else:
-            key_deserialized = self._key_deserializer(value=key_bytes, ctx=ctx)
+            key_deserialized = self._key_deserializer(
+                value=key_bytes, ctx=ctx(field=MessageField.KEY)
+            )
 
         if (value_bytes := message.value()) is None:
             value_deserialized = None
         else:
             try:
                 value_deserialized = self._value_deserializer(
-                    value=value_bytes, ctx=ctx
+                    value=value_bytes, ctx=ctx(field=MessageField.VALUE)
                 )
             except IgnoreMessage:
                 # Ignore message completely if deserializer raised IgnoreValueError.
@@ -254,15 +260,16 @@ class Topic:
         headers: Optional[Headers] = None,
         timestamp_ms: Optional[int] = None,
     ) -> KafkaMessage:
-        ctx = SerializationContext(topic=self.name, headers=headers)
+        ctx = partial(SerializationContext, topic=self.name, headers=headers)
+
         if self._key_serializer:
-            key = self._key_serializer(key, ctx=ctx)
+            key = self._key_serializer(key, ctx=ctx(field=MessageField.KEY))
         elif key is not None:
             raise SerializerIsNotProvidedError(
                 f'Key serializer is not provided for topic "{self.name}"'
             )
         if self._value_serializer:
-            value = self._value_serializer(value, ctx=ctx)
+            value = self._value_serializer(value, ctx=ctx(field=MessageField.VALUE))
         elif value is not None:
             raise SerializerIsNotProvidedError(
                 f'Value serializer is not provided for topic "{self.name}"'
@@ -275,17 +282,22 @@ class Topic:
         )
 
     def deserialize(self, message: ConfluentKafkaMessageProto):
-        ctx = SerializationContext(topic=message.topic(), headers=message.headers())
+        ctx = partial(
+            SerializationContext, topic=message.topic(), headers=message.headers()
+        )
+
         if (key := message.key()) is not None:
             if self._key_deserializer:
-                key = self._key_deserializer(key, ctx=ctx)
+                key = self._key_deserializer(key, ctx=ctx(field=MessageField.KEY))
             else:
                 raise DeserializerIsNotProvidedError(
                     f'Key deserializer is not provided for topic "{self.name}"'
                 )
         if (value := message.value()) is not None:
             if self._value_deserializer:
-                value = self._value_deserializer(value, ctx=ctx)
+                value = self._value_deserializer(
+                    value, ctx=ctx(field=MessageField.VALUE)
+                )
             else:
                 raise DeserializerIsNotProvidedError(
                     f'Value deserializer is not provided for topic "{self.name}"'

--- a/quixstreams/models/topics/topic.py
+++ b/quixstreams/models/topics/topic.py
@@ -204,7 +204,7 @@ class Topic:
             return
 
         timestamp_type, timestamp_ms = message.timestamp()
-        ctx = MessageContext(
+        message_context = MessageContext(
             topic=message.topic(),
             partition=message.partition(),
             offset=message.offset(),
@@ -227,7 +227,7 @@ class Topic:
                         key=key_deserialized,
                         timestamp=timestamp_ms,
                         headers=headers,
-                        context=ctx,
+                        context=message_context,
                     )
                 )
             return rows
@@ -242,7 +242,7 @@ class Topic:
             timestamp=timestamp_ms,
             key=key_deserialized,
             headers=headers,
-            context=ctx,
+            context=message_context,
         )
 
     def serialize(

--- a/tests/test_quixstreams/test_models/test_serializers.py
+++ b/tests/test_quixstreams/test_models/test_serializers.py
@@ -17,6 +17,7 @@ from quixstreams.models import (
     Deserializer,
     DoubleDeserializer,
     StringDeserializer,
+    MessageField,
 )
 from quixstreams.models.serializers.protobuf import (
     ProtobufSerializer,
@@ -38,7 +39,7 @@ AVRO_TEST_SCHEMA = {
 }
 
 
-dummy_context = SerializationContext(topic="topic")
+dummy_context = SerializationContext(topic="topic", field=MessageField.VALUE)
 
 JSONSCHEMA_TEST_SCHEMA = {
     "type": "object",


### PR DESCRIPTION
This change is required in the context of upcoming Schema Registry support. The SerializationContext.field attribute is expected for the default subject name strategy.

More on subject name strategies:
https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#subject-name-strategy

This may be considered a breaking change for two reasons:

1. The new `SerializationContext.field` attribute is required. There is no way to resolve a default value; it must be passed from a higher scope.
2. The `SerializationContext.to_confluent_ctx` method has been removed. Since we must accept the field attribute, maintaining this method no longer makes sense.