### PR TITLE
Schema Registry 1: Serialization Context

### DIFF
--- a/quixstreams/models/serializers/base.py
+++ b/quixstreams/models/serializers/base.py
@@ -2,7 +2,6 @@ import abc
 from typing import Optional, Any, Union
 from typing_extensions import TypeAlias, Literal
 
-
 from confluent_kafka.serialization import (
     SerializationContext as _SerializationContext,
     MessageField,
@@ -12,6 +11,7 @@ from ..types import MessageHeadersTuples, MessageHeadersMapping
 
 __all__ = (
     "SerializationContext",
+    "MessageField",
     "Deserializer",
     "Serializer",
     "SerializerType",
@@ -19,29 +19,24 @@ __all__ = (
 )
 
 
-class SerializationContext:
+class SerializationContext(_SerializationContext):
     """
     Provides additional context for message serialization/deserialization.
 
     Every `Serializer` and `Deserializer` receives an instance of `SerializationContext`
     """
 
-    __slots__ = ("topic", "headers")
+    __slots__ = ("topic", "field", "headers")
 
-    def __init__(self, topic: str, headers: Optional[MessageHeadersTuples] = None):
+    def __init__(
+        self,
+        topic: str,
+        field: MessageField,
+        headers: Optional[MessageHeadersTuples] = None,
+    ) -> None:
         self.topic = topic
+        self.field = field
         self.headers = headers
-
-    def to_confluent_ctx(self, field: MessageField) -> _SerializationContext:
-        """
-        Convert `SerializationContext` to `confluent_kafka.SerializationContext`
-        in order to re-use serialization already provided by `confluent_kafka` library.
-        :param field: instance of `confluent_kafka.serialization.MessageField`
-        :return: instance of `confluent_kafka.serialization.SerializationContext`
-        """
-        return _SerializationContext(
-            field=field, topic=self.topic, headers=self.headers
-        )
 
 
 class Deserializer(abc.ABC):

--- a/quixstreams/models/topics/topic.py
+++ b/quixstreams/models/topics/topic.py
@@ -191,7 +191,7 @@ class Topic:
             value_deserialized = (
                 None
                 if value_bytes is None
-                else self._value_deserializer(value=message.value(), ctx=ctx)
+                else self._value_deserializer(value=value_bytes, ctx=ctx)
             )
         except IgnoreMessage:
             # Ignore message completely if deserializer raised IgnoreValueError.

--- a/quixstreams/models/topics/topic.py
+++ b/quixstreams/models/topics/topic.py
@@ -204,7 +204,7 @@ class Topic:
             return
 
         timestamp_type, timestamp_ms = message.timestamp()
-        ctx = MessageContext(
+        message_context = MessageContext(
             topic=message.topic(),
             partition=message.partition(),
             offset=message.offset(),
@@ -227,7 +227,7 @@ class Topic:
                         key=key_deserialized,
                         timestamp=timestamp_ms,
                         headers=headers,
-                        context=ctx,
+                        context=message_context,
                     )
                 )
             return rows
@@ -242,7 +242,7 @@ class Topic:
             timestamp=timestamp_ms,
             key=key_deserialized,
             headers=headers,
-            context=ctx,
+            context=message_context,
         )
 
     def serialize(

--- a/tests/test_quixstreams/test_models/test_serializers.py
+++ b/tests/test_quixstreams/test_models/test_serializers.py
@@ -17,6 +17,7 @@ from quixstreams.models import (
     Deserializer,
     DoubleDeserializer,
     StringDeserializer,
+    MessageField,
 )
 from quixstreams.models.serializers.protobuf import (
     ProtobufSerializer,
@@ -38,7 +39,7 @@ AVRO_TEST_SCHEMA = {
 }
 
 
-dummy_context = SerializationContext(topic="topic")
+dummy_context = SerializationContext(topic="topic", field=MessageField.VALUE)
 
 JSONSCHEMA_TEST_SCHEMA = {
     "type": "object",


### PR DESCRIPTION
This change is required in the context of upcoming Schema Registry support. The SerializationContext.field attribute is expected for the default subject name strategy.

More on subject name strategies:
https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#subject-name-strategy

This may be considered a breaking change for two reasons:

1. The new SerializationContext.field attribute is required. There is no way to resolve a default value; it must be passed from a higher scope.
2. The SerializationContext.to_confluent_ctx method has been removed. Since we must accept the field attribute, maintaining this method no longer makes sense.