### PR TITLE
Fix Dependabot by dropping supprt for requirements-dev.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,3 @@ updates:
       - "/tests"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "pip"
-    directory: "/"
-    file: "requirements-dev.txt"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Dependabot fails with this:

Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'pip' has overlapping directories.