### PR TITLE
Remove /tests from Dependabot directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,6 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directories:
-      - "/"
-      - "/tests"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
It seems that Dependabot automatically finds all requirements files in subdirectories.