### PR TITLE
Optimize get_window_ranges function

### DIFF
--- a/quixstreams/dataframe/windows/base.py
+++ b/quixstreams/dataframe/windows/base.py
@@ -1,4 +1,5 @@
-from typing import Any, Optional, Callable, Tuple, List
+from collections import deque
+from typing import Any, Deque, Optional, Callable, Tuple
 
 from typing_extensions import TypedDict
 
@@ -17,7 +18,7 @@ WindowMergeFunc = Callable[[Any], Any]
 
 def get_window_ranges(
     timestamp_ms: int, duration_ms: int, step_ms: Optional[int] = None
-) -> List[Tuple[int, int]]:
+) -> Deque[Tuple[int, int]]:
     """
     Get a list of window ranges for the given timestamp.
     :param timestamp_ms: timestamp in milliseconds
@@ -28,14 +29,14 @@ def get_window_ranges(
     if not step_ms:
         step_ms = duration_ms
 
-    window_ranges = []
+    window_ranges = deque()
     current_window_start = timestamp_ms - (timestamp_ms % step_ms)
 
     while (
         current_window_start > timestamp_ms - duration_ms and current_window_start >= 0
     ):
         window_end = current_window_start + duration_ms
-        window_ranges.insert(0, (current_window_start, window_end))
+        window_ranges.appendleft((current_window_start, window_end))
         current_window_start -= step_ms
 
     return window_ranges

--- a/tests/test_quixstreams/test_dataframe/test_windows/test_base.py
+++ b/tests/test_quixstreams/test_dataframe/test_windows/test_base.py
@@ -16,12 +16,10 @@ class TestGetWindowRanges:
         ],
     )
     def test_get_window_ranges_with_step(self, timestamp, duration, step, expected):
-        assert (
-            get_window_ranges(
-                timestamp_ms=timestamp, duration_ms=duration, step_ms=step
-            )
-            == expected
+        result = get_window_ranges(
+            timestamp_ms=timestamp, duration_ms=duration, step_ms=step
         )
+        assert list(result) == expected
 
     @pytest.mark.parametrize(
         "timestamp, duration, expected",
@@ -31,4 +29,5 @@ class TestGetWindowRanges:
         ],
     )
     def test_get_window_ranges_no_step(self, timestamp, duration, expected):
-        assert get_window_ranges(timestamp, duration) == expected
+        result = get_window_ranges(timestamp, duration)
+        assert list(result) == expected


### PR DESCRIPTION
deque.appendleft is roughly 10x faster than list.insert(0, ...)

Code snippet to test it

```python
import timeit
from collections import deque

# Function to test list.insert(0, ...)
def list_insert():
    my_list = []
    for _ in range(10000):
        my_list.insert(0, 1)

# Function to test deque.appendleft(1)
def deque_appendleft():
    my_deque = deque()
    for _ in range(10000):
        my_deque.appendleft(1)

# Timing the list.insert(0, ...) operation
list_insert_time = timeit.timeit(list_insert, number=100)

# Timing the deque.appendleft operation
deque_appendleft_time = timeit.timeit(deque_appendleft, number=100)

print(f"list.insert(0, ...): {list_insert_time:.6f} seconds")
print(f"deque.appendleft(): {deque_appendleft_time:.6f} seconds")
```

Results:
```
list.insert(0, ...): 1.535651 seconds
deque.appendleft(): 0.015165 seconds
```