### PR TITLE
Sliding Windows 1: get_windows generator

### DIFF
--- a/quixstreams/state/rocksdb/windowed/partition.py
+++ b/quixstreams/state/rocksdb/windowed/partition.py
@@ -46,10 +46,14 @@ class WindowedRocksDBStorePartition(RocksDBStorePartition):
         self._ensure_column_family(LATEST_EXPIRED_WINDOW_CF_NAME)
 
     def iter_items(
-        self, from_key: bytes, read_opt: ReadOptions, cf_name: str = "default"
+        self,
+        from_key: bytes,
+        read_opt: ReadOptions,
+        cf_name: str = "default",
+        backwards: bool = False,
     ) -> RdictItems:
         cf = self.get_column_family(cf_name=cf_name)
-        return cf.items(from_key=from_key, read_opt=read_opt)
+        return cf.items(backwards=backwards, from_key=from_key, read_opt=read_opt)
 
     def begin(self) -> "WindowedRocksDBPartitionTransaction":
         return WindowedRocksDBPartitionTransaction(

--- a/quixstreams/state/rocksdb/windowed/state.py
+++ b/quixstreams/state/rocksdb/windowed/state.py
@@ -83,3 +83,12 @@ class WindowedTransactionState(WindowedState):
         return self._transaction.expire_windows(
             duration_ms=duration_ms, grace_ms=grace_ms, prefix=self._prefix
         )
+
+    def get_windows(
+        self, start_from_ms: int, start_to_ms: int
+    ) -> List[Tuple[Tuple[int, int], Any]]:
+        return self._transaction.get_windows(
+            start_from_ms=start_from_ms,
+            start_to_ms=start_to_ms,
+            prefix=self._prefix,
+        )

--- a/quixstreams/state/rocksdb/windowed/state.py
+++ b/quixstreams/state/rocksdb/windowed/state.py
@@ -85,10 +85,11 @@ class WindowedTransactionState(WindowedState):
         )
 
     def get_windows(
-        self, start_from_ms: int, start_to_ms: int
+        self, start_from_ms: int, start_to_ms: int, backwards: bool = False
     ) -> List[Tuple[Tuple[int, int], Any]]:
         return self._transaction.get_windows(
             start_from_ms=start_from_ms,
             start_to_ms=start_to_ms,
             prefix=self._prefix,
+            backwards=backwards,
         )

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -139,7 +139,7 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
 
         # Use the latest expired timestamp to limit the iteration over
         # only those windows that have not been expired before
-        expired_windows = self._get_windows(
+        expired_windows = self.get_windows(
             start_from_ms=start_from,
             start_to_ms=start_to,
             prefix=prefix,
@@ -164,7 +164,7 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
         key_bytes = key if isinstance(key, bytes) else serialize(key, dumps=self._dumps)
         return prefix + PREFIX_SEPARATOR + key_bytes
 
-    def _get_windows(
+    def get_windows(
         self, start_from_ms: int, start_to_ms: int, prefix: bytes
     ) -> List[Tuple[Tuple[int, int], Any]]:
         """

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, List, Tuple, TYPE_CHECKING, cast
+from typing import Any, Generator, Optional, List, Tuple, TYPE_CHECKING, cast
 
 from rocksdict import ReadOptions
 
@@ -139,10 +139,12 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
 
         # Use the latest expired timestamp to limit the iteration over
         # only those windows that have not been expired before
-        expired_windows = self.get_windows(
-            start_from_ms=start_from,
-            start_to_ms=start_to,
-            prefix=prefix,
+        expired_windows = list(
+            self.get_windows(
+                start_from_ms=start_from,
+                start_to_ms=start_to,
+                prefix=prefix,
+            )
         )
         if expired_windows:
             # Save the start of the latest expired window to the expiration index
@@ -166,7 +168,7 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
 
     def get_windows(
         self, start_from_ms: int, start_to_ms: int, prefix: bytes
-    ) -> List[Tuple[Tuple[int, int], Any]]:
+    ) -> Generator[Tuple[Tuple[int, int], Any], None, None]:
         """
         Get all windows starting between "start_from" and "start_to"
         within the given prefix.
@@ -177,7 +179,7 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
 
         :param start_from_ms: minimal window start time, exclusive
         :param start_to_ms: maximum window start time, inclusive
-        :return: sorted list of tuples in format `((start, end), value)`
+        :return: generator yielding sorted tuples in format `((start, end), value)`
         """
 
         # Iterate over rocksdb within the given prefix and (start_form, start_to)
@@ -194,22 +196,54 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
         read_opt.set_iterate_lower_bound(seek_from_key)
         read_opt.set_iterate_upper_bound(seek_to_key)
 
-        windows = {}
-        for key, value in self._partition.iter_items(
+        db_windows = self._partition.iter_items(
             read_opt=read_opt, from_key=seek_from_key
-        ):
-            message_key, start, end = parse_window_key(key)
-            if start_from_ms < start <= start_to_ms:
-                windows[(start, end)] = self._deserialize_value(value)
+        )
 
-        for window_key, window_value in (
-            self._update_cache["default"].get(prefix, {}).items()
-        ):
-            message_key, start, end = parse_window_key(window_key)
-            if window_value is DELETED:
-                windows.pop((start, end), None)
-                continue
-            elif start_from_ms < start <= start_to_ms:
-                windows[(start, end)] = self._deserialize_value(window_value)
+        # If the cache is empty then take this shortcut to yield only db windows
+        if not (cache := self._update_cache["default"].get(prefix, {})):
+            for db_key, db_value in db_windows:
+                _, start, end = parse_window_key(db_key)
+                if start_from_ms < start <= start_to_ms:
+                    yield (start, end), self._deserialize_value(db_value)
+            return
 
-        return sorted(windows.items())
+        cached_windows = sorted(cache.items(), reverse=True)
+        cached_key, cached_value = cached_windows.pop()
+
+        for db_key, db_value in db_windows:
+            yield_db_window = True
+            if cached_key:
+                # Yield all cached windows with lower or equal timestamp
+                while cached_key <= db_key:
+                    if cached_value is not DELETED:
+                        _, start, end = parse_window_key(cached_key)
+                        if start_from_ms < start <= start_to_ms:
+                            yield (start, end), self._deserialize_value(cached_value)
+
+                    # Cached window with equal timestamp takes precedence
+                    # so do not yield db window
+                    yield_db_window = cached_key != db_key
+
+                    try:
+                        cached_key, cached_value = cached_windows.pop()
+                    except IndexError:
+                        cached_key, cached_value = None, None
+                        break
+
+            if yield_db_window:
+                _, start, end = parse_window_key(db_key)
+                if start_from_ms < start <= start_to_ms:
+                    yield (start, end), self._deserialize_value(db_value)
+
+        # Yield remaining cached windows
+        while cached_key:
+            if cached_value is not DELETED:
+                _, start, end = parse_window_key(cached_key)
+                if start_from_ms < start <= start_to_ms:
+                    yield (start, end), self._deserialize_value(cached_value)
+
+            try:
+                cached_key, cached_value = cached_windows.pop()
+            except IndexError:
+                return

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -1,4 +1,4 @@
-from typing import Any, Generator, Optional, List, Tuple, TYPE_CHECKING, cast
+from typing import Any, Generator, Optional, Tuple, TYPE_CHECKING, cast
 
 from rocksdict import ReadOptions
 
@@ -104,7 +104,7 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
 
     def expire_windows(
         self, duration_ms: int, prefix: bytes, grace_ms: int = 0
-    ) -> List[Tuple[Tuple[int, int], Any]]:
+    ) -> Generator[Tuple[Tuple[int, int], Any], None, None]:
         """
         Get a list of expired windows from RocksDB considering latest timestamp,
         window size and grace period.
@@ -139,27 +139,27 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
 
         # Use the latest expired timestamp to limit the iteration over
         # only those windows that have not been expired before
-        expired_windows = list(
-            self.get_windows(
-                start_from_ms=start_from,
-                start_to_ms=start_to,
-                prefix=prefix,
-            )
+        expired_windows = self.get_windows(
+            start_from_ms=start_from,
+            start_to_ms=start_to,
+            prefix=prefix,
         )
-        if expired_windows:
-            # Save the start of the latest expired window to the expiration index
-            latest_window = expired_windows[-1]
-            last_expired__gt = latest_window[0][0]
+
+        last_expired__gt = None
+        for (start, end), aggregated in expired_windows:
+            last_expired__gt = start
+            # Delete expired window from the state
+            self.delete_window(start, end, prefix=prefix)
+            yield (start, end), aggregated
+
+        # Save the start of the latest expired window to the expiration index
+        if last_expired__gt:
             self.set(
                 key=LATEST_EXPIRED_WINDOW_TIMESTAMP_KEY,
                 value=last_expired__gt,
                 prefix=prefix,
                 cf_name=LATEST_EXPIRED_WINDOW_CF_NAME,
             )
-            # Delete expired windows from the state
-            for (start, end), _ in expired_windows:
-                self.delete_window(start, end, prefix=prefix)
-        return expired_windows
 
     def _serialize_key(self, key: Any, prefix: bytes) -> bytes:
         # Allow bytes keys in WindowedStore

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -173,12 +173,12 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
         Get all windows starting between "start_from" and "start_to"
         within the given prefix.
 
-
         This function also checks the update cache in case some updates have not
         been committed to RocksDB yet.
 
         :param start_from_ms: minimal window start time, exclusive
         :param start_to_ms: maximum window start time, inclusive
+        :param prefix: a key prefix
         :return: generator yielding sorted tuples in format `((start, end), value)`
         """
 

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -363,6 +363,12 @@ class WindowedState(Protocol):
         """
         ...
 
+    def get_windows(
+        self, start_from_ms: int, start_to_ms: int
+    ) -> List[Tuple[Tuple[int, int], Any]]:
+        # TODO: docstring
+        ...
+
 
 class WindowedPartitionTransaction(Protocol):
 
@@ -473,6 +479,12 @@ class WindowedPartitionTransaction(Protocol):
         :param prefix: a key prefix
         :param grace_ms: grace period in milliseconds. Default - "0"
         """
+        ...
+
+    def get_windows(
+        self, start_from_ms: int, start_to_ms: int, prefix: bytes
+    ) -> List[Tuple[Tuple[int, int], Any]]:
+        # TODO: docstring
         ...
 
     def flush(

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -364,7 +364,7 @@ class WindowedState(Protocol):
         ...
 
     def get_windows(
-        self, start_from_ms: int, start_to_ms: int
+        self, start_from_ms: int, start_to_ms: int, backwards: bool = False
     ) -> List[Tuple[Tuple[int, int], Any]]:
         # TODO: docstring
         ...

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
@@ -1,28 +1,40 @@
-class TestWindowedRocksDBPartitionTransactionState:
-    def test_update_window(self, windowed_rocksdb_store_factory):
-        store = windowed_rocksdb_store_factory()
-        store.assign_partition(0)
-        prefix = b"__key__"
+from contextlib import contextmanager
+
+import pytest
+
+
+@pytest.fixture
+def store(windowed_rocksdb_store_factory):
+    store = windowed_rocksdb_store_factory()
+    store.assign_partition(0)
+    return store
+
+
+@pytest.fixture
+def transaction_state(store):
+    @contextmanager
+    def _transaction_state():
         with store.start_partition_transaction(0) as tx:
-            state = tx.as_state(prefix=prefix)
+            yield tx.as_state(prefix=b"__key__")
+
+    return _transaction_state
+
+
+class TestWindowedRocksDBPartitionTransactionState:
+    def test_update_window(self, transaction_state):
+        with transaction_state() as state:
             state.update_window(start_ms=0, end_ms=10, value=1, timestamp_ms=2)
             assert state.get_window(start_ms=0, end_ms=10) == 1
 
-        with store.start_partition_transaction(0) as tx:
-            state = tx.as_state(prefix=prefix)
+        with transaction_state() as state:
             assert state.get_window(start_ms=0, end_ms=10) == 1
 
-    def test_expire_windows(self, windowed_rocksdb_store_factory):
-        store = windowed_rocksdb_store_factory()
-        store.assign_partition(0)
-        prefix = b"__key__"
-        with store.start_partition_transaction(0) as tx:
-            state = tx.as_state(prefix=prefix)
+    def test_expire_windows(self, transaction_state):
+        with transaction_state() as state:
             state.update_window(start_ms=0, end_ms=10, value=1, timestamp_ms=2)
             state.update_window(start_ms=10, end_ms=20, value=2, timestamp_ms=10)
 
-        with store.start_partition_transaction(0) as tx:
-            state = tx.as_state(prefix=prefix)
+        with transaction_state() as state:
             state.update_window(start_ms=20, end_ms=30, value=3, timestamp_ms=20)
             expired = state.expire_windows(duration_ms=10)
             # "expire_windows" must update the expiration index so that the same
@@ -35,8 +47,7 @@ class TestWindowedRocksDBPartitionTransactionState:
             ((10, 20), 2),
         ]
 
-        with store.start_partition_transaction(0) as tx:
-            state = tx.as_state(prefix=prefix)
+        with transaction_state() as state:
             assert state.get_window(start_ms=0, end_ms=10) is None
             assert state.get_window(start_ms=10, end_ms=20) is None
             assert state.get_window(start_ms=20, end_ms=30) == 3

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
@@ -20,48 +20,49 @@ def transaction_state(store):
     return _transaction_state
 
 
-class TestWindowedRocksDBPartitionTransactionState:
-    def test_update_window(self, transaction_state):
-        with transaction_state() as state:
-            state.update_window(start_ms=0, end_ms=10, value=1, timestamp_ms=2)
-            assert state.get_window(start_ms=0, end_ms=10) == 1
+def test_update_window(transaction_state):
+    with transaction_state() as state:
+        state.update_window(start_ms=0, end_ms=10, value=1, timestamp_ms=2)
+        assert state.get_window(start_ms=0, end_ms=10) == 1
 
-        with transaction_state() as state:
-            assert state.get_window(start_ms=0, end_ms=10) == 1
+    with transaction_state() as state:
+        assert state.get_window(start_ms=0, end_ms=10) == 1
 
-    def test_expire_windows(self, transaction_state):
-        with transaction_state() as state:
-            state.update_window(start_ms=0, end_ms=10, value=1, timestamp_ms=2)
-            state.update_window(start_ms=10, end_ms=20, value=2, timestamp_ms=10)
 
-        with transaction_state() as state:
-            state.update_window(start_ms=20, end_ms=30, value=3, timestamp_ms=20)
-            expired = state.expire_windows(duration_ms=10)
-            # "expire_windows" must update the expiration index so that the same
-            # windows are not expired twice
-            assert not state.expire_windows(duration_ms=10)
+def test_expire_windows(transaction_state):
+    with transaction_state() as state:
+        state.update_window(start_ms=0, end_ms=10, value=1, timestamp_ms=2)
+        state.update_window(start_ms=10, end_ms=20, value=2, timestamp_ms=10)
 
-        assert len(expired) == 2
-        assert expired == [
-            ((0, 10), 1),
-            ((10, 20), 2),
-        ]
+    with transaction_state() as state:
+        state.update_window(start_ms=20, end_ms=30, value=3, timestamp_ms=20)
+        expired = state.expire_windows(duration_ms=10)
+        # "expire_windows" must update the expiration index so that the same
+        # windows are not expired twice
+        assert not state.expire_windows(duration_ms=10)
 
-        with transaction_state() as state:
-            assert state.get_window(start_ms=0, end_ms=10) is None
-            assert state.get_window(start_ms=10, end_ms=20) is None
-            assert state.get_window(start_ms=20, end_ms=30) == 3
+    assert len(expired) == 2
+    assert expired == [
+        ((0, 10), 1),
+        ((10, 20), 2),
+    ]
 
-    def test_get_latest_timestamp(self, windowed_rocksdb_store_factory):
-        store = windowed_rocksdb_store_factory()
-        partition = store.assign_partition(0)
-        timestamp = 123
-        prefix = b"__key__"
-        with partition.begin() as tx:
-            state = tx.as_state(prefix)
-            state.update_window(0, 10, value=1, timestamp_ms=timestamp)
-        store.revoke_partition(0)
+    with transaction_state() as state:
+        assert state.get_window(start_ms=0, end_ms=10) is None
+        assert state.get_window(start_ms=10, end_ms=20) is None
+        assert state.get_window(start_ms=20, end_ms=30) == 3
 
-        partition = store.assign_partition(0)
-        with partition.begin() as tx:
-            assert tx.get_latest_timestamp() == timestamp
+
+def test_get_latest_timestamp(windowed_rocksdb_store_factory):
+    store = windowed_rocksdb_store_factory()
+    partition = store.assign_partition(0)
+    timestamp = 123
+    prefix = b"__key__"
+    with partition.begin() as tx:
+        state = tx.as_state(prefix)
+        state.update_window(0, 10, value=1, timestamp_ms=timestamp)
+    store.revoke_partition(0)
+
+    partition = store.assign_partition(0)
+    with partition.begin() as tx:
+        assert tx.get_latest_timestamp() == timestamp

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
@@ -36,10 +36,10 @@ def test_expire_windows(transaction_state):
 
     with transaction_state() as state:
         state.update_window(start_ms=20, end_ms=30, value=3, timestamp_ms=20)
-        expired = state.expire_windows(duration_ms=10)
+        expired = list(state.expire_windows(duration_ms=10))
         # "expire_windows" must update the expiration index so that the same
         # windows are not expired twice
-        assert not state.expire_windows(duration_ms=10)
+        assert not list(state.expire_windows(duration_ms=10))
 
     assert len(expired) == 2
     assert expired == [
@@ -62,7 +62,7 @@ def test_same_keys_in_db_and_update_cache(transaction_state):
         state.update_window(start_ms=0, end_ms=10, value=3, timestamp_ms=8)
 
         state.update_window(start_ms=10, end_ms=20, value=2, timestamp_ms=10)
-        expired = state.expire_windows(duration_ms=10)
+        expired = list(state.expire_windows(duration_ms=10))
 
         # Value from the cache takes precedence over the value in the db
         assert expired == [((0, 10), 3)]

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
@@ -81,3 +81,94 @@ def test_get_latest_timestamp(windowed_rocksdb_store_factory):
     partition = store.assign_partition(0)
     with partition.begin() as tx:
         assert tx.get_latest_timestamp() == timestamp
+
+
+@pytest.mark.parametrize(
+    "db_windows, cached_windows, deleted_windows, get_windows_args, expected_windows",
+    [
+        pytest.param(
+            [
+                dict(start_ms=2, end_ms=12, value=3, timestamp_ms=3),
+                dict(start_ms=0, end_ms=10, value=1, timestamp_ms=1),
+                dict(start_ms=1, end_ms=11, value=2, timestamp_ms=2),
+            ],
+            [],
+            [],
+            dict(start_from_ms=-1, start_to_ms=2),
+            [((0, 10), 1), ((1, 11), 2), ((2, 12), 3)],
+            id="messages-in-db",
+        ),
+        pytest.param(
+            [],
+            [
+                dict(start_ms=2, end_ms=12, value=3, timestamp_ms=3),
+                dict(start_ms=0, end_ms=10, value=1, timestamp_ms=1),
+                dict(start_ms=1, end_ms=11, value=2, timestamp_ms=2),
+            ],
+            [],
+            dict(start_from_ms=-1, start_to_ms=2),
+            [((0, 10), 1), ((1, 11), 2), ((2, 12), 3)],
+            id="messages-in-cache",
+        ),
+        pytest.param(
+            [
+                dict(start_ms=2, end_ms=12, value=3, timestamp_ms=3),
+                dict(start_ms=0, end_ms=10, value=1, timestamp_ms=1),
+            ],
+            [
+                dict(start_ms=1, end_ms=11, value=2, timestamp_ms=2),
+            ],
+            [],
+            dict(start_from_ms=-1, start_to_ms=2),
+            [((0, 10), 1), ((1, 11), 2), ((2, 12), 3)],
+            id="messages-both-in-db-and-in-cache",
+        ),
+        pytest.param(
+            [
+                dict(start_ms=2, end_ms=12, value=3, timestamp_ms=3),
+                dict(start_ms=0, end_ms=10, value=1, timestamp_ms=1),
+                dict(start_ms=3, end_ms=13, value=4, timestamp_ms=4),
+            ],
+            [
+                dict(start_ms=1, end_ms=11, value=2, timestamp_ms=2),
+                dict(start_ms=0, end_ms=10, value=5, timestamp_ms=1),
+            ],
+            [],
+            dict(start_from_ms=-1, start_to_ms=3),
+            [((0, 10), 5), ((1, 11), 2), ((2, 12), 3), ((3, 13), 4)],
+            id="cache-message-overrides-db-message",
+        ),
+        pytest.param(
+            [
+                dict(start_ms=0, end_ms=10, value=1, timestamp_ms=1),
+                dict(start_ms=1, end_ms=11, value=2, timestamp_ms=2),
+                dict(start_ms=2, end_ms=12, value=3, timestamp_ms=3),
+            ],
+            [],
+            [dict(start_ms=0, end_ms=10)],
+            dict(start_from_ms=-1, start_to_ms=2),
+            [((1, 11), 2), ((2, 12), 3)],
+            id="ignore-deleted-windows",
+        ),
+    ],
+)
+def test_get_windows(
+    db_windows,
+    cached_windows,
+    deleted_windows,
+    get_windows_args,
+    expected_windows,
+    transaction_state,
+):
+    with transaction_state() as state:
+        for window in db_windows:
+            state.update_window(**window)
+
+    with transaction_state() as state:
+        for window in cached_windows:
+            state.update_window(**window)
+        for window in deleted_windows:
+            state._transaction.delete_window(**window, prefix=state._prefix)
+
+        windows = state.get_windows(**get_windows_args)
+        assert list(windows) == expected_windows

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
@@ -150,6 +150,41 @@ def test_get_latest_timestamp(windowed_rocksdb_store_factory):
             [((1, 11), 2), ((2, 12), 3)],
             id="ignore-deleted-windows",
         ),
+        # Useful for refactoring, to `timeit` against previous implementations.
+        # number_of_windows is set to a small number to not blow up test times in CI
+        # For development, bump it to something like 10000 or 100000
+        # and plug in timeit at the end of the test:
+        #
+        # from timeit import timeit
+        # func = lambda: list(state.get_windows(**get_windows_args))
+        # print("Execution time", timeit(func, number=100))
+        (number_of_windows := 100)
+        and pytest.param(
+            (
+                db_windows := [
+                    dict(start_ms=i, end_ms=i + 10, value=i, timestamp_ms=i + 1)
+                    for i in range(number_of_windows)
+                ]
+            ),
+            [
+                dict(start_ms=i, end_ms=i + 10, value=i, timestamp_ms=i + 1)
+                for i in range(0, number_of_windows, 2)
+            ],
+            (
+                deleted_windows := [
+                    dict(start_ms=i, end_ms=i + 10)
+                    for i in range(0, number_of_windows, 4)
+                ]
+            ),
+            dict(start_from_ms=-1, start_to_ms=number_of_windows),
+            [
+                ((window["start_ms"], window["end_ms"]), window["value"])
+                for window in db_windows
+                if {"start_ms": window["start_ms"], "end_ms": window["end_ms"]}
+                not in deleted_windows
+            ],
+            id="shitload-of-windows",
+        ),
     ],
 )
 def test_get_windows(

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
@@ -150,6 +150,70 @@ def test_get_latest_timestamp(windowed_rocksdb_store_factory):
             [((1, 11), 2), ((2, 12), 3)],
             id="ignore-deleted-windows",
         ),
+        pytest.param(
+            [
+                dict(start_ms=2, end_ms=12, value=3, timestamp_ms=3),
+                dict(start_ms=0, end_ms=10, value=1, timestamp_ms=1),
+                dict(start_ms=1, end_ms=11, value=2, timestamp_ms=2),
+            ],
+            [],
+            [],
+            dict(start_from_ms=-1, start_to_ms=2, backwards=True),
+            [((2, 12), 3), ((1, 11), 2), ((0, 10), 1)],
+            id="messages-in-db-backwards",
+        ),
+        pytest.param(
+            [],
+            [
+                dict(start_ms=2, end_ms=12, value=3, timestamp_ms=3),
+                dict(start_ms=0, end_ms=10, value=1, timestamp_ms=1),
+                dict(start_ms=1, end_ms=11, value=2, timestamp_ms=2),
+            ],
+            [],
+            dict(start_from_ms=-1, start_to_ms=2, backwards=True),
+            [((2, 12), 3), ((1, 11), 2), ((0, 10), 1)],
+            id="messages-in-cache-backwards",
+        ),
+        pytest.param(
+            [
+                dict(start_ms=2, end_ms=12, value=3, timestamp_ms=3),
+                dict(start_ms=0, end_ms=10, value=1, timestamp_ms=1),
+            ],
+            [
+                dict(start_ms=1, end_ms=11, value=2, timestamp_ms=2),
+            ],
+            [],
+            dict(start_from_ms=-1, start_to_ms=2, backwards=True),
+            [((2, 12), 3), ((1, 11), 2), ((0, 10), 1)],
+            id="messages-both-in-db-and-in-cache-backwards",
+        ),
+        pytest.param(
+            [
+                dict(start_ms=2, end_ms=12, value=3, timestamp_ms=3),
+                dict(start_ms=0, end_ms=10, value=1, timestamp_ms=1),
+                dict(start_ms=3, end_ms=13, value=4, timestamp_ms=4),
+            ],
+            [
+                dict(start_ms=1, end_ms=11, value=2, timestamp_ms=2),
+                dict(start_ms=0, end_ms=10, value=5, timestamp_ms=1),
+            ],
+            [],
+            dict(start_from_ms=-1, start_to_ms=3, backwards=True),
+            [((3, 13), 4), ((2, 12), 3), ((1, 11), 2), ((0, 10), 5)],
+            id="cache-message-overrides-db-message",
+        ),
+        pytest.param(
+            [
+                dict(start_ms=0, end_ms=10, value=1, timestamp_ms=1),
+                dict(start_ms=1, end_ms=11, value=2, timestamp_ms=2),
+                dict(start_ms=2, end_ms=12, value=3, timestamp_ms=3),
+            ],
+            [],
+            [dict(start_ms=0, end_ms=10)],
+            dict(start_from_ms=-1, start_to_ms=2, backwards=True),
+            [((2, 12), 3), ((1, 11), 2)],
+            id="ignore-deleted-windows",
+        ),
         # Useful for refactoring, to `timeit` against previous implementations.
         # number_of_windows is set to a small number to not blow up test times in CI
         # For development, bump it to something like 10000 or 100000

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_transaction.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_transaction.py
@@ -59,10 +59,10 @@ class TestWindowedRocksDBPartitionTransaction:
             tx.update_window(
                 start_ms=20, end_ms=30, value=3, timestamp_ms=20, prefix=prefix
             )
-            expired = tx.expire_windows(duration_ms=10, prefix=prefix)
+            expired = list(tx.expire_windows(duration_ms=10, prefix=prefix))
             # "expire_windows" must update the expiration index so that the same
             # windows are not expired twice
-            assert not tx.expire_windows(duration_ms=10, prefix=prefix)
+            assert not list(tx.expire_windows(duration_ms=10, prefix=prefix))
 
         assert len(expired) == 2
         assert expired == [
@@ -93,10 +93,10 @@ class TestWindowedRocksDBPartitionTransaction:
             tx.update_window(
                 start_ms=20, end_ms=30, value=3, timestamp_ms=20, prefix=prefix
             )
-            expired = tx.expire_windows(duration_ms=10, prefix=prefix)
+            expired = list(tx.expire_windows(duration_ms=10, prefix=prefix))
             # "expire_windows" must update the expiration index so that the same
             # windows are not expired twice
-            assert not tx.expire_windows(duration_ms=10, prefix=prefix)
+            assert not list(tx.expire_windows(duration_ms=10, prefix=prefix))
             assert len(expired) == 2
             assert expired == [
                 ((0, 10), 1),
@@ -122,7 +122,7 @@ class TestWindowedRocksDBPartitionTransaction:
             tx.update_window(
                 start_ms=3, end_ms=13, value=1, timestamp_ms=3, prefix=prefix
             )
-            assert not tx.expire_windows(duration_ms=10, prefix=prefix)
+            assert not list(tx.expire_windows(duration_ms=10, prefix=prefix))
 
     def test_expire_windows_with_grace_expired(self, windowed_rocksdb_store_factory):
         store = windowed_rocksdb_store_factory()
@@ -137,7 +137,7 @@ class TestWindowedRocksDBPartitionTransaction:
             tx.update_window(
                 start_ms=15, end_ms=25, value=1, timestamp_ms=15, prefix=prefix
             )
-            expired = tx.expire_windows(duration_ms=10, grace_ms=5, prefix=prefix)
+            expired = list(tx.expire_windows(duration_ms=10, grace_ms=5, prefix=prefix))
 
         assert len(expired) == 1
         assert expired == [((0, 10), 1)]
@@ -155,7 +155,7 @@ class TestWindowedRocksDBPartitionTransaction:
             tx.update_window(
                 start_ms=13, end_ms=23, value=1, timestamp_ms=13, prefix=prefix
             )
-            expired = tx.expire_windows(duration_ms=10, grace_ms=5, prefix=prefix)
+            expired = list(tx.expire_windows(duration_ms=10, grace_ms=5, prefix=prefix))
 
         assert not expired
 
@@ -231,7 +231,7 @@ class TestWindowedRocksDBPartitionTransaction:
             )
             # "expire_windows" must update the expiration index so that the same
             # windows are not expired twice
-            assert not tx.expire_windows(duration_ms=10, prefix=prefix)
+            assert not list(tx.expire_windows(duration_ms=10, prefix=prefix))
 
     def test_expire_windows_multiple_windows(self, windowed_rocksdb_store_factory):
         store = windowed_rocksdb_store_factory()
@@ -254,7 +254,7 @@ class TestWindowedRocksDBPartitionTransaction:
             )
             # "expire_windows" must update the expiration index so that the same
             # windows are not expired twice
-            expired = tx.expire_windows(duration_ms=10, prefix=prefix)
+            expired = list(tx.expire_windows(duration_ms=10, prefix=prefix))
 
         assert len(expired) == 3
         assert expired[0] == ((0, 10), 1)


### PR DESCRIPTION
Refactor WindowedRocksDBPartitionTransaction.get_windows
* Make it a public method
* Make it a generator instead of returning a list
* Performance improved by approx. 35%