### PR TITLE
Chore/quix topics management change

### DIFF
--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -647,8 +647,7 @@ class Application:
             Default: the source default
         """
         if not topic:
-            topic = source.default_topic()
-            self._topic_manager.register(topic)
+            topic = self._topic_manager.register(source.default_topic())
 
         producer = self._get_rowproducer(transactional=False)
         source.configure(topic, producer)

--- a/quixstreams/models/topics/topic.py
+++ b/quixstreams/models/topics/topic.py
@@ -117,26 +117,6 @@ class Topic:
         self._key_serializer = _get_serializer(key_serializer)
         self._timestamp_extractor = timestamp_extractor
 
-    def __clone__(
-        self,
-        name: str,
-        config: Optional[TopicConfig] = None,
-        value_deserializer: Optional[DeserializerType] = None,
-        key_deserializer: Optional[DeserializerType] = None,
-        value_serializer: Optional[SerializerType] = None,
-        key_serializer: Optional[SerializerType] = None,
-        timestamp_extractor: Optional[TimestampExtractor] = None,
-    ):
-        return self.__class__(
-            name=name,
-            config=config or self.config,
-            value_deserializer=value_deserializer or self._value_deserializer,
-            key_deserializer=key_deserializer or self._key_deserializer,
-            value_serializer=value_serializer or self._value_serializer,
-            key_serializer=key_serializer or self._key_serializer,
-            timestamp_extractor=timestamp_extractor or self._timestamp_extractor,
-        )
-
     def row_serialize(self, row: Row, key: Any) -> KafkaMessage:
         """
         Serialize Row to a Kafka message structure

--- a/quixstreams/models/topics/topic.py
+++ b/quixstreams/models/topics/topic.py
@@ -111,11 +111,31 @@ class Topic:
         """
         self.name = name
         self.config = config
-        self._key_serializer = _get_serializer(key_serializer)
+        self._value_deserializer = _get_deserializer(value_deserializer)
         self._key_deserializer = _get_deserializer(key_deserializer)
         self._value_serializer = _get_serializer(value_serializer)
-        self._value_deserializer = _get_deserializer(value_deserializer)
+        self._key_serializer = _get_serializer(key_serializer)
         self._timestamp_extractor = timestamp_extractor
+
+    def __clone__(
+        self,
+        name: str,
+        config: Optional[TopicConfig] = None,
+        value_deserializer: Optional[DeserializerType] = None,
+        key_deserializer: Optional[DeserializerType] = None,
+        value_serializer: Optional[SerializerType] = None,
+        key_serializer: Optional[SerializerType] = None,
+        timestamp_extractor: Optional[TimestampExtractor] = None,
+    ):
+        return self.__class__(
+            name=name,
+            config=config or self.config,
+            value_deserializer=value_deserializer or self._value_deserializer,
+            key_deserializer=key_deserializer or self._key_deserializer,
+            value_serializer=value_serializer or self._value_serializer,
+            key_serializer=key_serializer or self._key_serializer,
+            timestamp_extractor=timestamp_extractor or self._timestamp_extractor,
+        )
 
     def row_serialize(self, row: Row, key: Any) -> KafkaMessage:
         """

--- a/quixstreams/models/topics/topic.py
+++ b/quixstreams/models/topics/topic.py
@@ -117,6 +117,26 @@ class Topic:
         self._key_serializer = _get_serializer(key_serializer)
         self._timestamp_extractor = timestamp_extractor
 
+    def __clone__(
+        self,
+        name: str,
+        config: Optional[TopicConfig] = None,
+        value_deserializer: Optional[DeserializerType] = None,
+        key_deserializer: Optional[DeserializerType] = None,
+        value_serializer: Optional[SerializerType] = None,
+        key_serializer: Optional[SerializerType] = None,
+        timestamp_extractor: Optional[TimestampExtractor] = None,
+    ):
+        return self.__class__(
+            name=name,
+            config=config or self.config,
+            value_deserializer=value_deserializer or self._value_deserializer,
+            key_deserializer=key_deserializer or self._key_deserializer,
+            value_serializer=value_serializer or self._value_serializer,
+            key_serializer=key_serializer or self._key_serializer,
+            timestamp_extractor=timestamp_extractor or self._timestamp_extractor,
+        )
+
     def row_serialize(self, row: Row, key: Any) -> KafkaMessage:
         """
         Serialize Row to a Kafka message structure

--- a/quixstreams/platforms/quix/config.py
+++ b/quixstreams/platforms/quix/config.py
@@ -3,12 +3,12 @@ import dataclasses
 import logging
 import time
 from copy import deepcopy
-from typing import List, Optional, Set
+from typing import List, Optional
 
 from requests import HTTPError
 
 from quixstreams.kafka.configuration import ConnectionConfig
-from quixstreams.models.topics import Topic
+from quixstreams.models.topics import Topic, TopicConfig
 
 from .api import QuixPortalApiService
 from .exceptions import (
@@ -159,6 +159,29 @@ class QuixKafkaConfigsBuilder:
             "metadata.max.age.ms": QUIX_METADATA_MAX_AGE_MS,
         }
 
+    @classmethod
+    def convert_topic_response(cls, api_response: dict) -> Topic:
+        """
+        Converts a GET or POST ("create") topic API response to a Topic object
+
+        :param api_response: the dict response from a get or create topic call
+        :return: a corresponding Topic object
+        """
+        topic_config = api_response["configuration"]
+        return Topic(
+            name=api_response["id"],
+            config=TopicConfig(
+                num_partitions=topic_config["partitions"],
+                replication_factor=topic_config["replicationFactor"],
+                extra_config={
+                    "retention.ms": topic_config["retentionInMinutes"] * 60 * 1000,
+                    "retention.bytes": topic_config["retentionInBytes"],
+                    # TODO: uncomment or remove this once Emanuel confirms API behavior
+                    # "cleanup.policy": true_cfg["cleanupPolicy"],
+                },
+            ),
+        )
+
     def strip_workspace_id_prefix(self, s: str) -> str:
         """
         Remove the workspace ID from a given string if it starts with it.
@@ -301,11 +324,12 @@ class QuixKafkaConfigsBuilder:
             ):
                 return ws
 
-    def _create_topic(self, topic: Topic, timeout: Optional[float] = None):
+    def create_topic(self, topic: Topic, timeout: Optional[float] = None):
         """
-        The actual API call to create the topic
+        The actual API call to create the topic.
 
         :param topic: a Topic instance
+        :param timeout: response timeout (seconds); Default 30
         """
         cfg = topic.config
 
@@ -330,19 +354,14 @@ class QuixKafkaConfigsBuilder:
         )
         return resp
 
-    def create_topic_no_status_check(
+    def get_or_create_topic(
         self,
         topic: Topic,
         timeout: Optional[float] = None,
     ) -> dict:
         """
-        Create topics in a Quix cluster as part of initializing the Topic object to
-        obtain the true topic name.
-
-        If it already exists, will instead get the actual topic name.
-
-        Creation is done first to avoid issues around multiple apps attempting to
-        create a topic at the same time.
+        Get or create topics in a Quix cluster as part of initializing the Topic
+        object to obtain the true topic name.
 
         :param topic: a `Topic` object
         :param timeout: response timeout (seconds); Default 30
@@ -350,68 +369,27 @@ class QuixKafkaConfigsBuilder:
         """
         try:
             return self.get_topic(topic_name=topic.name, timeout=timeout)
-        except QuixApiRequestFailure as get_error:
-            if get_error.status_code == 404:
-                try:
-                    return self._create_topic(topic, timeout=timeout)
-                except QuixApiRequestFailure as create_error:
-                    if create_error.status_code == 404:
-                        # Multiple apps likely tried to create at the same time
-                        return self.get_topic(topic_name=topic.name, timeout=timeout)
-                    raise
+        except QuixApiRequestFailure:
+            # Topic likely does not exist (anything but success 404's; could inspect
+            # error string, but that creates a dependency on it never changing).
+            try:
+                return self.create_topic(topic, timeout=timeout)
+            except QuixApiRequestFailure:
+                # Multiple apps likely tried to create at the same time.
+                # If this fails, it will raise with all the API errors it encountered
+                return self.get_topic(topic_name=topic.name, timeout=timeout)
 
-    def _confirm_topic_ready_statuses(
-        self,
-        topics: Set[str],
-        timeout: Optional[float] = None,
-        finalize_timeout: Optional[float] = None,
-    ):
-        """
-        After the broker acknowledges the topics are created, they will be in a
-        "Creating", and will not be ready to consume from/produce to until they are
-        set to a status of "Ready". This will block until all topics passed are marked
-        as "Ready" or the timeout is hit.
-
-        :param topics: set of topic names
-        :param finalize_timeout: topic finalization timeout (seconds); Default 60
-        """
-        exceptions = {}
-        stop_time = time.time() + (
-            finalize_timeout if finalize_timeout else self._topic_create_timeout
-        )
-        while topics and time.time() < stop_time:
-            # Each topic seems to take 10-15 seconds each to finalize (at least in dev)
-            time.sleep(1)
-            for topic in (
-                checks := [
-                    t
-                    for t in self.get_topics(timeout=timeout)
-                    if t["id"] in topics.copy()
-                ]
-            ):
-                if topic["status"] == "Ready":
-                    logger.debug(f"Topic {topic['name']} creation finalized")
-                    topics.remove(topic["id"])
-                elif topic["status"] == "Error":
-                    logger.debug(f"Topic {topic['name']} encountered an error")
-                    exceptions[topic["name"]] = topic["lastError"]
-                    topics.remove(topic["id"])
-        if exceptions:
-            raise QuixCreateTopicFailure(f"Quix topic validation failed: {exceptions}")
-        if topics:
-            raise QuixCreateTopicTimeout(
-                f"Waiting for 'Ready' status timed out for Quix "
-                f"topics: {[t['name'] for t in checks if t['id'] in topics]}"
-            )
-
-    def confirm_topic_ready_statuses(
+    def wait_for_topic_ready_statuses(
         self,
         topics: List[Topic],
         timeout: Optional[float] = None,
         finalize_timeout: Optional[float] = None,
     ):
         """
-        Confirms all given topics have a status of "Ready".
+        After the broker acknowledges topics for creation, they will be in a
+        "Creating" status; they not usable until they are set to a status of "Ready".
+
+        This blocks until all topics are marked as "Ready" or the timeout is hit.
 
         :param topics: a list of `Topic` objects
         :param timeout: response timeout (seconds); Default 30
@@ -419,16 +397,30 @@ class QuixKafkaConfigsBuilder:
         marked as "Ready" (and thus ready to produce to/consume from).
         """
         logger.debug("Confirming all topics are ready in Quix Cloud...")
-        topic_ids = [topic.name for topic in topics]
-        self._confirm_topic_ready_statuses(
-            {
-                t["id"]
-                for t in self.get_topics(timeout=timeout)
-                if t["id"] in topic_ids and t["status"] != "Ready"
-            },
-            timeout=timeout,
-            finalize_timeout=finalize_timeout,
-        )
+        exceptions = {}
+        topic_ids = {topic.name for topic in topics}
+        stop_time = time.monotonic() + (finalize_timeout or self._topic_create_timeout)
+        while topic_ids and time.monotonic() < stop_time:
+            time.sleep(1)
+            for topic_resp in (
+                topic_resps := [
+                    t for t in self.get_topics(timeout=timeout) if t["id"] in topic_ids
+                ]
+            ):
+                if topic_resp["status"] == "Ready":
+                    logger.debug(f"Topic {topic_resp['name']} creation finalized")
+                    topic_ids.remove(topic_resp["id"])
+                elif topic_resp["status"] == "Error":
+                    logger.debug(f"Topic {topic_resp['name']} encountered an error")
+                    exceptions[topic_resp["name"]] = topic_resp["lastError"]
+                    topic_ids.remove(topic_resp["id"])
+        if exceptions:
+            raise QuixCreateTopicFailure(f"Quix topic validation failed: {exceptions}")
+        if topic_ids:
+            raise QuixCreateTopicTimeout(
+                f"Waiting for 'Ready' status timed out for Quix "
+                f"topics: {[t['name'] for t in topic_resps if t['id'] in topic_ids]}"
+            )
 
     def get_topic(self, topic_name: str, timeout: Optional[float] = None) -> dict:
         """

--- a/quixstreams/platforms/quix/config.py
+++ b/quixstreams/platforms/quix/config.py
@@ -176,7 +176,8 @@ class QuixKafkaConfigsBuilder:
                 extra_config={
                     "retention.ms": topic_config["retentionInMinutes"] * 60 * 1000,
                     "retention.bytes": topic_config["retentionInBytes"],
-                    "cleanup.policy": topic_config["cleanupPolicy"],
+                    # TODO: uncomment or remove this once Emanuel confirms API behavior
+                    # "cleanup.policy": true_cfg["cleanupPolicy"],
                 },
             ),
         )

--- a/quixstreams/platforms/quix/topic_manager.py
+++ b/quixstreams/platforms/quix/topic_manager.py
@@ -62,14 +62,15 @@ class QuixTopicManager(TopicManager):
         Additionally, sets the actual topic configuration since we now have it anyway.
         """
         quix_topic_info = self._quix_config_builder.get_or_create_topic(topic)
-        true_topic = self._quix_config_builder.convert_topic_response(quix_topic_info)
+        quix_topic = self._quix_config_builder.convert_topic_response(quix_topic_info)
         # allows us to include the configs not included in the API response
-        true_topic.config.extra_config = {
+        quix_topic.config.extra_config = {
             **topic.config.extra_config,
-            **true_topic.config.extra_config,
+            **quix_topic.config.extra_config,
         }
-        self._topic_id_to_name[true_topic.name] = quix_topic_info["name"]
-        return super()._finalize_topic(true_topic)
+        topic_out = topic.__clone__(name=quix_topic.name, config=quix_topic.config)
+        self._topic_id_to_name[topic_out.name] = quix_topic_info["name"]
+        return super()._finalize_topic(topic_out)
 
     def _create_topics(
         self, topics: List[Topic], timeout: float, create_timeout: float

--- a/quixstreams/platforms/quix/topic_manager.py
+++ b/quixstreams/platforms/quix/topic_manager.py
@@ -72,11 +72,12 @@ class QuixTopicManager(TopicManager):
                     **topic.config.extra_config,
                     "retention.ms": true_cfg["retentionInMinutes"] * 60 * 1000,
                     "retention.bytes": true_cfg["retentionInBytes"],
-                    "cleanup.policy": true_cfg["cleanupPolicy"],
+                    # TODO: uncomment or remove this once Emanuel confirms API behavior
+                    # "cleanup.policy": true_cfg["cleanupPolicy"],
                 },
             ),
         )
-        self._topic_id_to_name[true_topic.name] = topic.name
+        self._topic_id_to_name[true_topic.name] = quix_topic_info["name"]
         return super()._finalize_topic(true_topic)
 
     def _create_topics(

--- a/tests/test_quixstreams/fixtures.py
+++ b/tests/test_quixstreams/fixtures.py
@@ -396,9 +396,7 @@ def quix_mock_config_builder_factory(kafka_container):
                 "replicationFactor": topic.config.replication_factor,
                 "retentionInMinutes": 1,
                 "retentionInBytes": 1,
-                "cleanupPolicy": topic.config.extra_config.get(
-                    "cleanup.policy", "delete"
-                ),
+                "cleanupPolicy": "Delete",
             },
         }
 

--- a/tests/test_quixstreams/fixtures.py
+++ b/tests/test_quixstreams/fixtures.py
@@ -379,12 +379,16 @@ def quix_mock_config_builder_factory(kafka_container):
             strip_workspace_id_prefix(workspace_id, s) if workspace_id else s
         )
 
+        cfg_builder.convert_topic_response.side_effect = (
+            lambda topic: QuixKafkaConfigsBuilder.convert_topic_response(topic)
+        )
+
         # Mock the create API call and return this response.
         # Doing it this way keeps the old behavior where topics are only created
         # when the app is actually run (for tests, at least).
         # This does simulate an expected topic name with prepended WID which may not
         # always be true, but it's just to make testing easier.
-        cfg_builder.create_topic_no_status_check.side_effect = lambda topic: {
+        cfg_builder.get_or_create_topic.side_effect = lambda topic, timeout=None: {
             "id": f"{workspace_id}-{topic.name}",
             "name": topic.name,
             "configuration": {

--- a/tests/test_quixstreams/fixtures.py
+++ b/tests/test_quixstreams/fixtures.py
@@ -364,8 +364,11 @@ def quix_mock_config_builder_factory(kafka_container):
         if not workspace_id:
             workspace_id = "my_ws"
         cfg_builder = create_autospec(QuixKafkaConfigsBuilder)
-        cfg_builder._workspace_id = workspace_id
-        cfg_builder.workspace_id = workspace_id
+        patch.object(
+            cfg_builder,
+            "workspace_id",
+            new_callable=PropertyMock(return_value=workspace_id),
+        ).start()
 
         # Slight change to ws stuff in case you pass a blank workspace (which makes
         #  some things easier
@@ -375,10 +378,27 @@ def quix_mock_config_builder_factory(kafka_container):
         cfg_builder.strip_workspace_id_prefix.side_effect = lambda s: (
             strip_workspace_id_prefix(workspace_id, s) if workspace_id else s
         )
-        cfg_builder.get_topic.side_effect = lambda topic: {
-            "id": cfg_builder.prepend_workspace_id(topic)
+
+        # Mock the create API call and return this response.
+        # Doing it this way keeps the old behavior where topics are only created
+        # when the app is actually run (for tests, at least).
+        # This does simulate an expected topic name with prepended WID which may not
+        # always be true, but it's just to make testing easier.
+        cfg_builder.create_topic_no_status_check.side_effect = lambda topic: {
+            "id": f"{workspace_id}-{topic.name}",
+            "name": topic.name,
+            "configuration": {
+                "partitions": topic.config.num_partitions,
+                "replicationFactor": topic.config.replication_factor,
+                "retentionInMinutes": 1,
+                "retentionInBytes": 1,
+                "cleanupPolicy": topic.config.extra_config.get(
+                    "cleanup.policy", "delete"
+                ),
+            },
         }
 
+        # Connect to local test container rather than Quix
         connection = ConnectionConfig(bootstrap_servers=kafka_container.broker_address)
         cfg_builder.librdkafka_connection_config = connection
         cfg_builder.get_application_config.side_effect = lambda cg: (
@@ -413,6 +433,7 @@ def quix_topic_manager_factory(
         topic_manager = topic_manager_factory(
             topic_admin_=topic_admin, consumer_group=consumer_group
         )
+
         if not quix_config_builder:
             quix_config_builder = quix_mock_config_builder_factory(
                 workspace_id=workspace_id
@@ -422,13 +443,14 @@ def quix_topic_manager_factory(
             consumer_group=consumer_group,
             quix_config_builder=quix_config_builder,
         )
+
         # Patch the instance of QuixTopicManager to use Kafka Admin API
         # create topics instead of Quix Portal API
         patch.multiple(
             quix_topic_manager,
             default_num_partitions=1,
             default_replication_factor=1,
-            _create_topics=topic_manager._create_topics,
+            _create_topics=topic_manager.create_topics,
         ).start()
         return quix_topic_manager
 
@@ -465,8 +487,15 @@ def quix_app_factory(
         use_changelog_topics: bool = True,
         workspace_id: str = "my_ws",
         store_type: Optional[StoreTypes] = store_type,
+        topic_manager: Optional[QuixTopicManager] = None,
+        quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None,
     ) -> Application:
         state_dir = state_dir or (tmp_path / "state").absolute()
+        if bool(topic_manager) ^ bool(quix_config_builder):
+            raise ValueError(
+                "Should provide both QuixTopicManager AND QuixKafkaConfigBuilder with "
+                "corresponding workspace_id, or neither."
+            )
         return Application(
             consumer_group=random_consumer_group,
             state_dir=state_dir,
@@ -479,10 +508,10 @@ def quix_app_factory(
             on_message_processed=on_message_processed,
             auto_create_topics=auto_create_topics,
             use_changelog_topics=use_changelog_topics,
-            topic_manager=quix_topic_manager_factory(workspace_id=workspace_id),
-            quix_config_builder=quix_mock_config_builder_factory(
-                workspace_id=workspace_id
-            ),
+            topic_manager=topic_manager
+            or quix_topic_manager_factory(workspace_id=workspace_id),
+            quix_config_builder=quix_config_builder
+            or quix_mock_config_builder_factory(workspace_id=workspace_id),
         )
 
     with patch(

--- a/tests/test_quixstreams/test_app.py
+++ b/tests/test_quixstreams/test_app.py
@@ -1051,9 +1051,8 @@ class TestQuixApplication:
 @pytest.mark.parametrize("store_type", SUPPORTED_STORES, indirect=True)
 class TestQuixApplicationWithState:
     def test_quix_app_no_state_management_warning(
-        self, quix_app_factory, quix_mock_config_builder_factory, monkeypatch, executor
+        self, quix_app_factory, monkeypatch, executor
     ):
-        # TODO: ERROR!!
         """
         Ensure that Application.run() prints a warning if the app is stateful,
         runs on Quix (the "Quix__Deployment__Id" env var is set),

--- a/tests/test_quixstreams/test_platforms/test_quix/test_topic_manager.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/test_topic_manager.py
@@ -15,7 +15,7 @@ class TestQuixTopicManager:
         topic_id = "quix_topic_id"
 
         config_builder = quix_mock_config_builder_factory()
-        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+        config_builder.get_or_create_topic.side_effect = lambda _topic: {
             "id": topic_id,
             "name": _topic.name,
             "configuration": {
@@ -36,7 +36,7 @@ class TestQuixTopicManager:
         assert topic.name == topic_id
         assert topic_manager.topics[topic.name] == topic
         assert (
-            config_builder.create_topic_no_status_check.call_args_list[0].args[0].name
+            config_builder.get_or_create_topic.call_args_list[0].args[0].name
             == topic_name
         )
         assert topic.config.num_partitions == num_partitions
@@ -59,7 +59,7 @@ class TestQuixTopicManager:
             quix_config_builder=config_builder,
         )
 
-        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+        config_builder.get_or_create_topic.side_effect = lambda _topic: {
             "id": topic_id,
             "name": _topic.name,
             "configuration": {
@@ -73,7 +73,7 @@ class TestQuixTopicManager:
         topic = topic_manager.topic(topic_name)
         assert topic.name == topic_id
 
-        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+        config_builder.get_or_create_topic.side_effect = lambda _topic: {
             "id": changelog_id,
             "name": _topic.name,
             "configuration": {
@@ -90,13 +90,13 @@ class TestQuixTopicManager:
         assert changelog.name == changelog_id
         assert topic_manager.changelog_topics[topic.name][store_name] == changelog
         assert (
-            config_builder.create_topic_no_status_check.call_args_list[1].args[0].name
+            config_builder.get_or_create_topic.call_args_list[1].args[0].name
             == changelog_name
         )
         assert changelog.config.num_partitions == num_partitions
         assert changelog.config.replication_factor == rep_factor
 
-        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+        config_builder.get_or_create_topic.side_effect = lambda _topic: {
             "id": topic_id,
             "name": _topic.name,
             "configuration": {
@@ -110,7 +110,7 @@ class TestQuixTopicManager:
         topic = topic_manager.topic(topic_name)
         assert topic.name == topic_id
 
-        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+        config_builder.get_or_create_topic.side_effect = lambda _topic: {
             "id": changelog_id,
             "name": _topic.name,
             "configuration": {
@@ -127,7 +127,7 @@ class TestQuixTopicManager:
         assert changelog.name == changelog_id
         assert topic_manager.changelog_topics[topic.name][store_name] == changelog
         assert (
-            config_builder.create_topic_no_status_check.call_args_list[1].args[0].name
+            config_builder.get_or_create_topic.call_args_list[1].args[0].name
             == changelog_name
         )
         assert changelog.config.num_partitions == num_partitions
@@ -162,7 +162,7 @@ class TestQuixTopicManager:
             quix_config_builder=config_builder,
         )
 
-        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+        config_builder.get_or_create_topic.side_effect = lambda _topic: {
             "id": topic_id,
             "name": _topic.name,
             "configuration": {
@@ -176,7 +176,7 @@ class TestQuixTopicManager:
         topic = topic_manager.topic(topic_name)
         assert topic.name == topic_id
 
-        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+        config_builder.get_or_create_topic.side_effect = lambda _topic: {
             "id": repartition_id,
             "name": _topic.name,
             "configuration": {
@@ -191,7 +191,7 @@ class TestQuixTopicManager:
         assert repartition.name == repartition_id
         assert topic_manager.repartition_topics[repartition.name] == repartition
 
-        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+        config_builder.get_or_create_topic.side_effect = lambda _topic: {
             "id": changelog_topic_id,
             "name": _topic.name,
             "configuration": {
@@ -206,7 +206,7 @@ class TestQuixTopicManager:
         assert changelog.name == changelog_topic_id
         assert topic_manager.changelog_topics[repartition.name][store_name] == changelog
         assert (
-            config_builder.create_topic_no_status_check.call_args_list[2].args[0].name
+            config_builder.get_or_create_topic.call_args_list[2].args[0].name
             == changelog_name
         )
         assert changelog.config.num_partitions == num_partitions

--- a/tests/test_quixstreams/test_platforms/test_quix/test_topic_manager.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/test_topic_manager.py
@@ -1,136 +1,137 @@
 from unittest.mock import MagicMock
 
-from quixstreams.models import TopicAdmin, TopicConfig
+from quixstreams.models import TopicAdmin
 from quixstreams.platforms.quix import QuixTopicManager
 
 
 class TestQuixTopicManager:
-    def test_quix_topic_name_found(self, quix_mock_config_builder_factory):
+    def test_quix_topic(self, quix_mock_config_builder_factory):
         """
         Topic name should be "id" field from the Quix API get_topic result if found
         """
+        num_partitions = 5
+        rep_factor = 5
         topic_name = "my_topic"
-        workspace_id = "my_wid"
-        expected_name = "quix_topic_id"
+        topic_id = "quix_topic_id"
 
-        config_builder = quix_mock_config_builder_factory(workspace_id=workspace_id)
-        config_builder.get_topic.side_effect = lambda _: {"id": expected_name}
+        config_builder = quix_mock_config_builder_factory()
+        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+            "id": topic_id,
+            "name": _topic.name,
+            "configuration": {
+                "partitions": num_partitions,
+                "replicationFactor": rep_factor,
+                "retentionInMinutes": 1,
+                "retentionInBytes": 1,
+                "cleanupPolicy": "Delete",
+            },
+        }
 
         topic_manager = QuixTopicManager(
             topic_admin=MagicMock(spec_set=TopicAdmin),
             consumer_group="test_group",
             quix_config_builder=config_builder,
         )
-        # Check that topic name is prefixed by the workspace ID
-        # when only the "name" part is provided
-        assert topic_manager.topic(topic_name).name == expected_name
-
-        topic = topic_manager.topic(expected_name)
-        # Replication factor and num partitions should be None by default
-        assert topic.config.replication_factor is None
-        assert topic.config.num_partitions is None
-
-    def test_quix_topic_name_not_found(self, quix_mock_config_builder_factory):
-        """
-        Workspace-appended name is returned when config builder returns None
-        """
-        topic_name = "my_topic"
-        workspace_id = "my_wid"
-
-        config_builder = quix_mock_config_builder_factory(workspace_id=workspace_id)
-        config_builder.get_topic.side_effect = lambda _: None
-        expected_name = config_builder.prepend_workspace_id(topic_name)
-
-        topic_manager = QuixTopicManager(
-            topic_admin=MagicMock(spec_set=TopicAdmin),
-            consumer_group="test_group",
-            quix_config_builder=config_builder,
+        topic = topic_manager.topic(topic_name)
+        assert topic.name == topic_id
+        assert topic_manager.topics[topic.name] == topic
+        assert (
+            config_builder.create_topic_no_status_check.call_args_list[0].args[0].name
+            == topic_name
         )
+        assert topic.config.num_partitions == num_partitions
+        assert topic.config.replication_factor == rep_factor
 
-        # Check that topic name is prefixed by the workspace ID
-        # when only the "name" part is provided
-        assert topic_manager.topic(topic_name).name == expected_name
-
-        topic = topic_manager.topic(expected_name)
-        # Replication factor and num partitions should be None by default
-        assert topic.config.replication_factor is None
-        assert topic.config.num_partitions is None
-
-    def test_quix_topic_name(self, quix_mock_config_builder_factory):
-        """
-        Create a Topic object with same name regardless of workspace prefixes
-        in the topic name
-        """
-        topic_name = "my_topic"
-        workspace_id = "my_wid"
-        expected_topic_name = f"{workspace_id}-{topic_name}"
-
-        config_builder = quix_mock_config_builder_factory(workspace_id=workspace_id)
-        topic_manager = QuixTopicManager(
-            topic_admin=MagicMock(spec_set=TopicAdmin),
-            consumer_group="test_group",
-            quix_config_builder=config_builder,
-        )
-
-        assert topic_manager.topic(topic_name).name == expected_topic_name
-        assert topic_manager.topic(expected_topic_name).name == expected_topic_name
-
-    def test_quix_changelog_topic(self, quix_mock_config_builder_factory):
-        topic_name = "my_topic"
-        workspace_id = "my_wid"
+    def test_quix_internal_topic(self, quix_mock_config_builder_factory):
+        num_partitions = 5
+        rep_factor = 5
+        quix_api_prepend = "whatever"
         consumer_group = "my_group"
         store_name = "default"
-        expected = (
-            f"{workspace_id}-changelog__{consumer_group}--{topic_name}--{store_name}"
-        )
-
-        config_builder = quix_mock_config_builder_factory(workspace_id=workspace_id)
+        topic_name = "my_topic"
+        topic_id = f"{quix_api_prepend}-{topic_name}"
+        changelog_name = f"changelog__{consumer_group}--{topic_name}--{store_name}"
+        changelog_id = f"{quix_api_prepend}-{changelog_name}"
+        config_builder = quix_mock_config_builder_factory()
         topic_manager = QuixTopicManager(
             topic_admin=MagicMock(spec_set=TopicAdmin),
             consumer_group=consumer_group,
             quix_config_builder=config_builder,
         )
+
+        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+            "id": topic_id,
+            "name": _topic.name,
+            "configuration": {
+                "partitions": num_partitions,
+                "replicationFactor": rep_factor,
+                "retentionInMinutes": 1,
+                "retentionInBytes": 1,
+                "cleanupPolicy": "Delete",
+            },
+        }
         topic = topic_manager.topic(topic_name)
+        assert topic.name == topic_id
+
+        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+            "id": changelog_id,
+            "name": _topic.name,
+            "configuration": {
+                "partitions": topic.config.num_partitions,
+                "replicationFactor": topic.config.replication_factor,
+                "retentionInMinutes": 1,
+                "retentionInBytes": 1,
+                "cleanupPolicy": "Compact",
+            },
+        }
         changelog = topic_manager.changelog_topic(
-            topic_name=topic_name, store_name=store_name
+            topic_name=topic.name, store_name=store_name
         )
-
-        assert changelog.name == expected
+        assert changelog.name == changelog_id
         assert topic_manager.changelog_topics[topic.name][store_name] == changelog
-
-    def test_quix_changelog_topic_workspace_prepend(
-        self, quix_mock_config_builder_factory
-    ):
-        """
-        Changelog Topic name is the same regardless of workspace prefixes
-        in the topic name and/or consumer group
-
-        NOTE: the "topic_name" handed to TopicManager.changelog() should always contain
-        the prefix based on where it will be called, but it can handle if it doesn't.
-        """
-        topic_name = "my_topic"
-        workspace_id = "my_wid"
-        appended_topic_name = f"{workspace_id}-{topic_name}"
-        consumer_group = "my_group"
-        store_name = "default"
-        expected = (
-            f"{workspace_id}-changelog__{consumer_group}--{topic_name}--{store_name}"
+        assert (
+            config_builder.create_topic_no_status_check.call_args_list[1].args[0].name
+            == changelog_name
         )
+        assert changelog.config.num_partitions == num_partitions
+        assert changelog.config.replication_factor == rep_factor
 
-        config_builder = quix_mock_config_builder_factory(workspace_id=workspace_id)
-        topic_manager = QuixTopicManager(
-            topic_admin=MagicMock(spec_set=TopicAdmin),
-            consumer_group=f"{workspace_id}-{consumer_group}",
-            quix_config_builder=config_builder,
-        )
-        topic = topic_manager.topic(appended_topic_name)
+        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+            "id": topic_id,
+            "name": _topic.name,
+            "configuration": {
+                "partitions": num_partitions,
+                "replicationFactor": rep_factor,
+                "retentionInMinutes": 1,
+                "retentionInBytes": 1,
+                "cleanupPolicy": "Delete",
+            },
+        }
+        topic = topic_manager.topic(topic_name)
+        assert topic.name == topic_id
+
+        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+            "id": changelog_id,
+            "name": _topic.name,
+            "configuration": {
+                "partitions": topic.config.num_partitions,
+                "replicationFactor": topic.config.replication_factor,
+                "retentionInMinutes": 1,
+                "retentionInBytes": 1,
+                "cleanupPolicy": "Compact",
+            },
+        }
         changelog = topic_manager.changelog_topic(
-            topic_name=appended_topic_name, store_name=store_name
+            topic_name=topic.name, store_name=store_name
         )
-
-        assert changelog.name == expected
-        assert topic.name == appended_topic_name
+        assert changelog.name == changelog_id
         assert topic_manager.changelog_topics[topic.name][store_name] == changelog
+        assert (
+            config_builder.create_topic_no_status_check.call_args_list[1].args[0].name
+            == changelog_name
+        )
+        assert changelog.config.num_partitions == num_partitions
+        assert changelog.config.replication_factor == rep_factor
 
     def test_quix_changelog_nested_internal_topic_naming(
         self, quix_mock_config_builder_factory
@@ -139,41 +140,74 @@ class TestQuixTopicManager:
         Confirm expected formatting for an internal topic that spawns another internal
         topic (changelog)
         """
-        topic_name = "my_topic"
-        workspace_id = "my_wid"
-        store = "my_store"
+        num_partitions = 5
+        rep_factor = 5
+        quix_api_prepend = "whatever"
+        store_name = "my_store"
         consumer_group = "my_consumer_group"
         operation = "my_op"
-        expected_topic_name = (
-            f"{workspace_id}-changelog__{consumer_group}--"
-            f"repartition.{topic_name}.{operation}--{store}"
-        )
+        topic_name = "my_topic"
+        topic_id = f"{quix_api_prepend}-{topic_name}"
+        changelog_name = f"changelog__{consumer_group}--{topic_name}--{store_name}"
+        changelog_topic_id = f"{quix_api_prepend}-{changelog_name}"
+        repartition_name = f"repartition__{consumer_group}--{topic_name}--{operation}"
+        repartition_id = f"{quix_api_prepend}-{repartition_name}"
+        changelog_name = f"changelog__{consumer_group}--repartition.{topic_name}.{operation}--{store_name}"
+        changelog_topic_id = f"{quix_api_prepend}-{changelog_name}"
 
-        config_builder = quix_mock_config_builder_factory(workspace_id=workspace_id)
+        config_builder = quix_mock_config_builder_factory()
         topic_manager = QuixTopicManager(
             topic_admin=MagicMock(spec_set=TopicAdmin),
             consumer_group=consumer_group,
             quix_config_builder=config_builder,
         )
-        topic = topic_manager.topic(name=topic_name)
+
+        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+            "id": topic_id,
+            "name": _topic.name,
+            "configuration": {
+                "partitions": num_partitions,
+                "replicationFactor": rep_factor,
+                "retentionInMinutes": 1,
+                "retentionInBytes": 1,
+                "cleanupPolicy": "Delete",
+            },
+        }
+        topic = topic_manager.topic(topic_name)
+        assert topic.name == topic_id
+
+        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+            "id": repartition_id,
+            "name": _topic.name,
+            "configuration": {
+                "partitions": topic.config.num_partitions,
+                "replicationFactor": topic.config.replication_factor,
+                "retentionInMinutes": 1,
+                "retentionInBytes": 1,
+                "cleanupPolicy": "Compact",
+            },
+        }
         repartition = topic_manager.repartition_topic(operation, topic.name)
-        changelog = topic_manager.changelog_topic(repartition.name, store)
+        assert repartition.name == repartition_id
+        assert topic_manager.repartition_topics[repartition.name] == repartition
 
-        assert changelog.name == expected_topic_name
-
-    def test_quix_topic_custom_config(self, quix_mock_config_builder_factory):
-        topic_name = "my_topic"
-        workspace_id = "my_wid"
-
-        config_builder = quix_mock_config_builder_factory(workspace_id=workspace_id)
-        topic_manager = QuixTopicManager(
-            topic_admin=MagicMock(spec_set=TopicAdmin),
-            consumer_group="test_group",
-            quix_config_builder=config_builder,
+        config_builder.create_topic_no_status_check.side_effect = lambda _topic: {
+            "id": changelog_topic_id,
+            "name": _topic.name,
+            "configuration": {
+                "partitions": topic.config.num_partitions,
+                "replicationFactor": topic.config.replication_factor,
+                "retentionInMinutes": 1,
+                "retentionInBytes": 1,
+                "cleanupPolicy": "Compact",
+            },
+        }
+        changelog = topic_manager.changelog_topic(repartition.name, store_name)
+        assert changelog.name == changelog_topic_id
+        assert topic_manager.changelog_topics[repartition.name][store_name] == changelog
+        assert (
+            config_builder.create_topic_no_status_check.call_args_list[2].args[0].name
+            == changelog_name
         )
-
-        config = TopicConfig(num_partitions=2, replication_factor=2)
-        topic = topic_manager.topic(topic_name, config=config)
-
-        assert topic.config.replication_factor == config.replication_factor
-        assert topic.config.num_partitions == config.num_partitions
+        assert changelog.config.num_partitions == num_partitions
+        assert changelog.config.replication_factor == rep_factor

--- a/tests/test_quixstreams/test_sources/test_core/test_kafka.py
+++ b/tests/test_quixstreams/test_sources/test_core/test_kafka.py
@@ -346,7 +346,7 @@ class TestQuixEnvironmentSource(Base):
                     "retentionInMinutes": 1,
                     "retentionInBytes": 1,
                     "cleanupPolicy": topic.config.extra_config.get(
-                        "cleanup.policy", "delete"
+                        "cleanup.policy", "Delete"
                     ),
                 },
             }


### PR DESCRIPTION
# NON-Quix APPLICATION BEHAVIOR IS ENTIRELY UNCHANGED, AND THIS IS NON-BREAKING.

All topic and state store names remain the same. 

This has been fully tested in Quix with both Quix and External brokers using all our internal topic naming schemes to confirm no namings have changed.

This changes only how Quix topics are managed internally in the Application and when Quix topics are created. 

Topic validation step remains unchanged.

## Recap of topic naming in Quix Cloud
Quix has two identifiers for each topic: a topic "name" and topic "ID". 

The name is typically what the user will provide (i.e. app.topic("NAME")) 

The ID is the true cluster topic name (and what corresponds to typical topic use for the SDK), which usually has some sort of workspace or other identifier prepended to the "name" since Quix is multi-tenant. 

The user will typically be unaware and/or not need to use the ID version.

## Why our current approach is problematic

We currently manage the name resolution ourselves (including prepending/appending WS id's ourselves as needed) in most cases, which depends on the naming behavior in the platform to correspond to how we handle it. Basically we have redundant logic going on, and we ideally should let the API handle as much of the platform-related behaviors as possible.

## Why does the current approach exist
1. we wanted topic creation behavior steps to be the same regardless of Quix App vs Non-Quix App 
2. the API could not correctly resolve receiving the Topic ID version of a topic (but it now can).

## NEW CHANGES/APPROACH

Essentially, the SDK now fully relies on the API to return the correct topic ID's based on the names the user hands the application with app.topic(<NAME>).

This is accomplished by three main changes: 

1. topics being get/created in a Quix App when app.topic(<NAME>) is called, allowing us to get/use the topic ID immediately and directly throughout the App (all behavior afterward is then is like a non-Quix App).

2. The "name" from the API call is now stored and used for "internal topic" name constructions, which don't want to have the WS name in them multiple times (again, this results in the same topic names we were previously constructing ourselves).

3. During the original topic creation step, we now instead confirm the "Ready" status (originally, we both created AND waited for "Ready" status here).