### PR TITLE
Feature: Collection Aggregations

### DIFF
--- a/docs/windowing.md
+++ b/docs/windowing.md
@@ -1,4 +1,3 @@
-
 # Windowed Aggregations
 
 
@@ -400,6 +399,7 @@ sdf = (
 Currently, windows support the following aggregation functions:
 
 - [`reduce()`](api-reference/quixstreams.md#fixedtimewindowdefinitionreduce) - to perform custom aggregations using "reducer" and "initializer" functions
+- [`collect()`](api-reference/quixstreams.md#fixedtimewindowdefinitioncollect) - to collect all values within a window into a list
 - [`min()`](api-reference/quixstreams.md#fixedtimewindowdefinitionmin) - to get a minimum value within a window
 - [`max()`](api-reference/quixstreams.md#fixedtimewindowdefinitionmax) - to get a maximum value within a window
 - [`mean()`](api-reference/quixstreams.md#fixedtimewindowdefinitionmean) - to get a mean value within a window 
@@ -408,7 +408,7 @@ Currently, windows support the following aggregation functions:
 
 We will go over each ot them in more detail below.
 
-###  Reduce()
+### Reduce()
 
 `.reduce()` allows you to perform complex aggregations using custom "reducer" and "initializer" functions:
 
@@ -502,6 +502,42 @@ sdf = (
 #   'value': {'min_temp': 1, 'max_temp': 999, 'total_events': 999, 'avg_temp': 34.32, '_sum_temp': 9999},
 # }
 
+```
+
+
+### Collect()
+Use `.collect()` to gather all events in the window into a list. This operation is optimized for collecting values and performs significantly better than using `reduce()` to build a list.
+
+!!! note
+    Performance benefit comes at a price: `.collect()` only supports `.final()` mode. Using `.current()` is not supported.
+
+**Example:**
+
+Collect all events over a 10-minute tumbling window into a list.
+
+```python
+from datetime import timedelta
+from quixstreams import Application
+
+app = Application(...)
+sdf = app.dataframe(...)
+
+sdf = (
+    # Define a tumbling window of 10 minutes
+    sdf.tumbling_window(timedelta(minutes=10))
+
+    # Collect events in the window into a list
+    .collect()
+
+    # Emit results only for closed windows
+    .final()
+)
+# Output:
+# {
+#   'start': <window start>, 
+#   'end': <window end>, 
+#   'value': [event1, event2, event3, ...] - list of all events in the window
+# }
 ```
 
 

--- a/quixstreams/dataframe/windows/definitions.py
+++ b/quixstreams/dataframe/windows/definitions.py
@@ -189,6 +189,17 @@ class FixedTimeWindowDefinition(abc.ABC):
             func_name="min", aggregate_func=func, aggregate_default=None
         )
 
+    def collect(self) -> "FixedTimeWindow":
+        def func(old: Any, new: Any) -> None:
+            return None
+
+        return self._create_window(
+            func_name="collect",
+            aggregate_func=func,
+            aggregate_default=None,
+            aggregate_collection=True,
+        )
+
 
 class HoppingWindowDefinition(FixedTimeWindowDefinition):
     def __init__(
@@ -216,6 +227,7 @@ class HoppingWindowDefinition(FixedTimeWindowDefinition):
         func_name: str,
         aggregate_func: WindowAggregateFunc,
         aggregate_default: Any,
+        aggregate_collection: bool = False,
         merge_func: Optional[WindowMergeFunc] = None,
     ) -> FixedTimeWindow:
         return FixedTimeWindow(
@@ -226,6 +238,7 @@ class HoppingWindowDefinition(FixedTimeWindowDefinition):
             dataframe=self._dataframe,
             aggregate_func=aggregate_func,
             aggregate_default=aggregate_default,
+            aggregate_collection=aggregate_collection,
             merge_func=merge_func,
         )
 
@@ -251,6 +264,7 @@ class TumblingWindowDefinition(FixedTimeWindowDefinition):
         func_name: str,
         aggregate_func: WindowAggregateFunc,
         aggregate_default: Any,
+        aggregate_collection: bool = False,
         merge_func: Optional[WindowMergeFunc] = None,
     ) -> FixedTimeWindow:
         return FixedTimeWindow(
@@ -260,6 +274,7 @@ class TumblingWindowDefinition(FixedTimeWindowDefinition):
             dataframe=self._dataframe,
             aggregate_func=aggregate_func,
             aggregate_default=aggregate_default,
+            aggregate_collection=aggregate_collection,
             merge_func=merge_func,
         )
 
@@ -285,6 +300,7 @@ class SlidingWindowDefinition(FixedTimeWindowDefinition):
         func_name: str,
         aggregate_func: WindowAggregateFunc,
         aggregate_default: Any,
+        aggregate_collection: bool = False,
         merge_func: Optional[WindowMergeFunc] = None,
     ) -> SlidingWindow:
         return SlidingWindow(
@@ -294,5 +310,6 @@ class SlidingWindowDefinition(FixedTimeWindowDefinition):
             dataframe=self._dataframe,
             aggregate_func=aggregate_func,
             aggregate_default=aggregate_default,
+            aggregate_collection=aggregate_collection,
             merge_func=merge_func,
         )

--- a/quixstreams/dataframe/windows/definitions.py
+++ b/quixstreams/dataframe/windows/definitions.py
@@ -223,10 +223,10 @@ class HoppingWindowDefinition(FixedTimeWindowDefinition):
             grace_ms=self._grace_ms,
             step_ms=self._step_ms,
             name=self._get_name(func_name=func_name),
+            dataframe=self._dataframe,
             aggregate_func=aggregate_func,
             aggregate_default=aggregate_default,
             merge_func=merge_func,
-            dataframe=self._dataframe,
         )
 
 
@@ -257,10 +257,10 @@ class TumblingWindowDefinition(FixedTimeWindowDefinition):
             duration_ms=self._duration_ms,
             grace_ms=self._grace_ms,
             name=self._get_name(func_name=func_name),
+            dataframe=self._dataframe,
             aggregate_func=aggregate_func,
             aggregate_default=aggregate_default,
             merge_func=merge_func,
-            dataframe=self._dataframe,
         )
 
 
@@ -291,8 +291,8 @@ class SlidingWindowDefinition(FixedTimeWindowDefinition):
             duration_ms=self._duration_ms,
             grace_ms=self._grace_ms,
             name=self._get_name(func_name=func_name),
+            dataframe=self._dataframe,
             aggregate_func=aggregate_func,
             aggregate_default=aggregate_default,
             merge_func=merge_func,
-            dataframe=self._dataframe,
         )

--- a/quixstreams/dataframe/windows/definitions.py
+++ b/quixstreams/dataframe/windows/definitions.py
@@ -217,7 +217,7 @@ class HoppingWindowDefinition(FixedTimeWindowDefinition):
         aggregate_func: WindowAggregateFunc,
         aggregate_default: Any,
         merge_func: Optional[WindowMergeFunc] = None,
-    ) -> "FixedTimeWindow":
+    ) -> FixedTimeWindow:
         return FixedTimeWindow(
             duration_ms=self._duration_ms,
             grace_ms=self._grace_ms,
@@ -252,7 +252,7 @@ class TumblingWindowDefinition(FixedTimeWindowDefinition):
         aggregate_func: WindowAggregateFunc,
         aggregate_default: Any,
         merge_func: Optional[WindowMergeFunc] = None,
-    ) -> "FixedTimeWindow":
+    ) -> FixedTimeWindow:
         return FixedTimeWindow(
             duration_ms=self._duration_ms,
             grace_ms=self._grace_ms,
@@ -286,7 +286,7 @@ class SlidingWindowDefinition(FixedTimeWindowDefinition):
         aggregate_func: WindowAggregateFunc,
         aggregate_default: Any,
         merge_func: Optional[WindowMergeFunc] = None,
-    ) -> "FixedTimeWindow":
+    ) -> SlidingWindow:
         return SlidingWindow(
             duration_ms=self._duration_ms,
             grace_ms=self._grace_ms,

--- a/quixstreams/dataframe/windows/definitions.py
+++ b/quixstreams/dataframe/windows/definitions.py
@@ -50,7 +50,7 @@ class FixedTimeWindowDefinition(abc.ABC):
         aggregate_default: Any,
         aggregate_collection: bool = False,
         merge_func: Optional[WindowMergeFunc] = None,
-    ) -> "FixedTimeWindow": ...
+    ) -> FixedTimeWindow: ...
 
     @property
     def duration_ms(self) -> int:
@@ -64,7 +64,7 @@ class FixedTimeWindowDefinition(abc.ABC):
     def step_ms(self) -> Optional[int]:
         return self._step_ms
 
-    def sum(self) -> "FixedTimeWindow":
+    def sum(self) -> FixedTimeWindow:
         """
         Configure the window to aggregate data by summing up values within
         each window period.
@@ -79,7 +79,7 @@ class FixedTimeWindowDefinition(abc.ABC):
             func_name="sum", aggregate_func=func, aggregate_default=0
         )
 
-    def count(self) -> "FixedTimeWindow":
+    def count(self) -> FixedTimeWindow:
         """
         Configure the window to aggregate data by counting the number of values
         within each window period.
@@ -94,7 +94,7 @@ class FixedTimeWindowDefinition(abc.ABC):
             func_name="count", aggregate_func=func, aggregate_default=0
         )
 
-    def mean(self) -> "FixedTimeWindow":
+    def mean(self) -> FixedTimeWindow:
         """
         Configure the window to aggregate data by calculating the mean of the values
         within each window period.
@@ -116,7 +116,7 @@ class FixedTimeWindowDefinition(abc.ABC):
 
     def reduce(
         self, reducer: Callable[[Any, Any], Any], initializer: Callable[[Any], Any]
-    ) -> "FixedTimeWindow":
+    ) -> FixedTimeWindow:
         """
         Configure the window to perform a custom aggregation using `reducer`
         and `initializer` functions.
@@ -160,7 +160,7 @@ class FixedTimeWindowDefinition(abc.ABC):
             func_name="reduce", aggregate_func=func, aggregate_default=None
         )
 
-    def max(self) -> "FixedTimeWindow":
+    def max(self) -> FixedTimeWindow:
         """
         Configure a window to aggregate the maximum value within each window period.
 
@@ -175,7 +175,7 @@ class FixedTimeWindowDefinition(abc.ABC):
             func_name="max", aggregate_func=func, aggregate_default=None
         )
 
-    def min(self) -> "FixedTimeWindow":
+    def min(self) -> FixedTimeWindow:
         """
         Configure a window to aggregate the minimum value within each window period.
 
@@ -190,7 +190,7 @@ class FixedTimeWindowDefinition(abc.ABC):
             func_name="min", aggregate_func=func, aggregate_default=None
         )
 
-    def collect(self) -> "FixedTimeWindow":
+    def collect(self) -> FixedTimeWindow:
         """
         Configure the window to collect all values within each window period into a
         list, without performing any aggregation.

--- a/quixstreams/dataframe/windows/definitions.py
+++ b/quixstreams/dataframe/windows/definitions.py
@@ -48,6 +48,7 @@ class FixedTimeWindowDefinition(abc.ABC):
         func_name: str,
         aggregate_func: WindowAggregateFunc,
         aggregate_default: Any,
+        aggregate_collection: bool = False,
         merge_func: Optional[WindowMergeFunc] = None,
     ) -> "FixedTimeWindow": ...
 

--- a/quixstreams/dataframe/windows/definitions.py
+++ b/quixstreams/dataframe/windows/definitions.py
@@ -191,6 +191,25 @@ class FixedTimeWindowDefinition(abc.ABC):
         )
 
     def collect(self) -> "FixedTimeWindow":
+        """
+        Configure the window to collect all values within each window period into a
+        list, without performing any aggregation.
+
+        This method is useful when you need to gather all raw values that fall
+        within a window period for further processing or analysis.
+
+        Example Snippet:
+        ```python
+        # Collect all values in 1-second windows
+        window = df.tumbling_window(duration_ms=1000).collect()
+        # Each window will contain a list of all values that occurred
+        # within that second
+        ```
+
+        :return: an instance of `FixedTimeWindow` configured to collect all values
+            within each window period.
+        """
+
         def func(old: Any, new: Any) -> None:
             return None
 

--- a/quixstreams/dataframe/windows/sliding.py
+++ b/quixstreams/dataframe/windows/sliding.py
@@ -228,8 +228,10 @@ class SlidingWindow(FixedTimeWindow):
             delete_values=collect,
         )
 
-        updated_windows = [] if collect else reversed(updated_windows)
-        return updated_windows, expired_windows
+        if collect:
+            return [], expired_windows
+        else:
+            return reversed(updated_windows), expired_windows
 
     def _update_window(
         self,

--- a/quixstreams/dataframe/windows/sliding.py
+++ b/quixstreams/dataframe/windows/sliding.py
@@ -216,7 +216,7 @@ class SlidingWindow(FixedTimeWindow):
                 )
 
         if collect:
-            state.collect_value(value=value, timestamp_ms=timestamp_ms)
+            state.add_to_collection(value=value, timestamp_ms=timestamp_ms)
 
         expired_windows: list[WindowResult] = [
             WindowResult(start=start, end=end, value=self._merge_func(aggregation))

--- a/quixstreams/dataframe/windows/sliding.py
+++ b/quixstreams/dataframe/windows/sliding.py
@@ -31,7 +31,7 @@ class SlidingWindow(FixedTimeWindow):
         ----|---------|---------|---------|---------|---------|---------|--->
                                     A
         left window ->    |---------||---------|    <- right window
-                            16      26  27      37
+                          16      26  27      37
 
         The algorithm scans backward through the window store:
         - Starting at: start_time = message timestamp + 1 ms (the right window's start time)
@@ -47,6 +47,12 @@ class SlidingWindow(FixedTimeWindow):
         4. If the left window does not exist, create it. Locate the existing
            aggregation and combine it with the incoming message.
         5. Locate and update all existing windows to which the new message belongs.
+
+        Note:
+            For collection aggregations (created using .collect()), the behavior is special:
+            Windows are persisted with empty values (None) only to preserve their start and
+            end times. The actual values are collected separately and combined during
+            the window expiration step.
         """
 
         duration = self._duration_ms

--- a/quixstreams/dataframe/windows/sliding.py
+++ b/quixstreams/dataframe/windows/sliding.py
@@ -99,22 +99,22 @@ class SlidingWindow(FixedTimeWindow):
                         end=right_end,
                         value=aggregation,
                         timestamp=timestamp_ms,
-                        window_timestamp=max_timestamp,
+                        max_timestamp=max_timestamp,
                     )
                     right_exists = True
 
                 # Update existing window if it is not expired
                 if start > max_expired_window_start:
-                    window_timestamp = max(timestamp_ms, max_timestamp)
+                    max_timestamp = max(timestamp_ms, max_timestamp)
                     window = self._update_window(
                         state=state,
                         start=start,
                         end=end,
                         value=aggregate(aggregation, value),
                         timestamp=timestamp_ms,
-                        window_timestamp=window_timestamp,
+                        max_timestamp=max_timestamp,
                     )
-                    if end == window_timestamp:  # Emit only left windows
+                    if end == max_timestamp:  # Emit only left windows
                         updated_windows.append(window)
                 else:
                     self._log_expired_window(
@@ -134,7 +134,7 @@ class SlidingWindow(FixedTimeWindow):
                         end=right_start + duration,
                         value=aggregate(default, value),
                         timestamp=timestamp_ms,
-                        window_timestamp=timestamp_ms,
+                        max_timestamp=timestamp_ms,
                     )
 
                 # The left window already exists; updating it is sufficient
@@ -147,7 +147,7 @@ class SlidingWindow(FixedTimeWindow):
                             end=end,
                             value=aggregate(aggregation, value),
                             timestamp=timestamp_ms,
-                            window_timestamp=timestamp_ms,
+                            max_timestamp=timestamp_ms,
                         )
                     )
                 else:
@@ -169,7 +169,7 @@ class SlidingWindow(FixedTimeWindow):
                         end=right_start + duration,
                         value=aggregate(default, value),
                         timestamp=timestamp_ms,
-                        window_timestamp=timestamp_ms,
+                        max_timestamp=timestamp_ms,
                     )
 
                 # Create a left window with existing aggregation if it falls within the window
@@ -183,7 +183,7 @@ class SlidingWindow(FixedTimeWindow):
                         end=left_end,
                         value=aggregate(aggregation, value),
                         timestamp=timestamp_ms,
-                        window_timestamp=timestamp_ms,
+                        max_timestamp=timestamp_ms,
                     )
                 )
 
@@ -204,7 +204,7 @@ class SlidingWindow(FixedTimeWindow):
                         end=left_end,
                         value=aggregate(default, value),
                         timestamp=timestamp_ms,
-                        window_timestamp=timestamp_ms,
+                        max_timestamp=timestamp_ms,
                     )
                 )
 
@@ -227,13 +227,12 @@ class SlidingWindow(FixedTimeWindow):
         end: int,
         value: Any,
         timestamp: int,
-        window_timestamp: int,
+        max_timestamp: int,
     ) -> WindowResult:
         state.update_window(
             start_ms=start,
             end_ms=end,
-            value=value,
+            value=[max_timestamp, value],
             timestamp_ms=timestamp,
-            window_timestamp_ms=window_timestamp,
         )
         return WindowResult(start=start, end=end, value=self._merge_func(value))

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -78,6 +78,7 @@ class FixedTimeWindow:
         duration_ms = self._duration_ms
         grace_ms = self._grace_ms
         default = self._aggregate_default
+        collect = self._aggregate_collection
 
         ranges = get_window_ranges(
             timestamp_ms=timestamp_ms,
@@ -99,7 +100,7 @@ class FixedTimeWindow:
                 )
                 continue
 
-            if self._aggregate_collection:
+            if collect:
                 state.update_window(start, end, value=None, timestamp_ms=timestamp_ms)
                 continue
 
@@ -110,13 +111,13 @@ class FixedTimeWindow:
                 WindowResult(start=start, end=end, value=self._merge_func(aggregated))
             )
 
-        if self._aggregate_collection:
+        if collect:
             state.collect_value(value=value, timestamp_ms=timestamp_ms)
 
         expired_windows: list[WindowResult] = []
         for (start, end), aggregated in state.expire_windows(
             max_start_time=max_expired_window_start,
-            collect=self._aggregate_collection,
+            collect=collect,
         ):
             expired_windows.append(
                 WindowResult(start=start, end=end, value=self._merge_func(aggregated))

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -101,6 +101,9 @@ class FixedTimeWindow:
                 continue
 
             if collect:
+                # When collecting values, we only mark the window existence with None
+                # since actual values are stored separately and combined into an array
+                # during window expiration.
                 state.update_window(start, end, value=None, timestamp_ms=timestamp_ms)
                 continue
 

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -45,9 +45,9 @@ class FixedTimeWindow:
         duration_ms: int,
         grace_ms: int,
         name: str,
+        dataframe: "StreamingDataFrame",
         aggregate_func: WindowAggregateFunc,
         aggregate_default: Any,
-        dataframe: "StreamingDataFrame",
         merge_func: Optional[WindowMergeFunc] = None,
         step_ms: Optional[int] = None,
     ):

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -115,7 +115,7 @@ class FixedTimeWindow:
             )
 
         if collect:
-            state.collect_value(value=value, timestamp_ms=timestamp_ms)
+            state.add_to_collection(value=value, timestamp_ms=timestamp_ms)
 
         expired_windows: list[WindowResult] = []
         for (start, end), aggregated in state.expire_windows(

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -99,7 +99,7 @@ class FixedTimeWindow:
 
             current_value = state.get_window(start, end, default=default)
             aggregated = self._aggregate_func(current_value, value)
-            state.update_window(start, end, timestamp_ms=timestamp_ms, value=aggregated)
+            state.update_window(start, end, value=aggregated, timestamp_ms=timestamp_ms)
             updated_windows.append(
                 WindowResult(start=start, end=end, value=self._merge_func(aggregated))
             )

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -48,6 +48,7 @@ class FixedTimeWindow:
         dataframe: "StreamingDataFrame",
         aggregate_func: WindowAggregateFunc,
         aggregate_default: Any,
+        aggregate_collection: bool = False,
         merge_func: Optional[WindowMergeFunc] = None,
         step_ms: Optional[int] = None,
     ):
@@ -59,6 +60,7 @@ class FixedTimeWindow:
         self._name = name
         self._aggregate_func = aggregate_func
         self._aggregate_default = aggregate_default
+        self._aggregate_collection = aggregate_collection
         self._merge_func = merge_func or _default_merge_func
         self._dataframe = dataframe
         self._step_ms = step_ms

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -189,6 +189,10 @@ class FixedTimeWindow:
 
         This method processes streaming data and returns results as they come,
         regardless of whether the window is closed or not.
+
+        Note:
+            This method cannot be used with collection aggregations (created using
+            .collect()). Use .final() instead for collection aggregations.
         """
         if self._aggregate_collection:
             raise ValueError(

--- a/quixstreams/state/base/transaction.py
+++ b/quixstreams/state/base/transaction.py
@@ -11,7 +11,7 @@ from quixstreams.state.metadata import (
     CHANGELOG_CF_MESSAGE_HEADER,
     CHANGELOG_PROCESSED_OFFSET_MESSAGE_HEADER,
     DEFAULT_PREFIX,
-    PREFIX_SEPARATOR,
+    SEPARATOR,
     Marker,
 )
 from quixstreams.state.serialization import DumpsFunc, LoadsFunc, deserialize, serialize
@@ -257,7 +257,7 @@ class PartitionTransaction(ABC):
 
     def _serialize_key(self, key: Any, prefix: bytes) -> bytes:
         key_bytes = serialize(key, dumps=self._dumps)
-        prefix = prefix + PREFIX_SEPARATOR if prefix else b""
+        prefix = prefix + SEPARATOR if prefix else b""
         return prefix + key_bytes
 
     def as_state(self, prefix: Any = DEFAULT_PREFIX) -> State:

--- a/quixstreams/state/base/transaction.py
+++ b/quixstreams/state/base/transaction.py
@@ -104,7 +104,6 @@ class PartitionTransactionCache:
         Delete a key.
 
         :param: key: key as bytes
-        :param: value: value as bytes
         :param: prefix: key prefix as bytes
         :param: cf_name: column family name
         """

--- a/quixstreams/state/metadata.py
+++ b/quixstreams/state/metadata.py
@@ -1,6 +1,6 @@
 import enum
 
-PREFIX_SEPARATOR = b"|"
+SEPARATOR = b"|"
 
 CHANGELOG_CF_MESSAGE_HEADER = "__column_family__"
 CHANGELOG_PROCESSED_OFFSET_MESSAGE_HEADER = "__processed_tp_offset__"

--- a/quixstreams/state/rocksdb/windowed/metadata.py
+++ b/quixstreams/state/rocksdb/windowed/metadata.py
@@ -4,6 +4,9 @@ LATEST_EXPIRED_WINDOW_TIMESTAMP_KEY = b"__expired_start_gt__"
 LATEST_DELETED_WINDOW_CF_NAME = "__deletion-index__"
 LATEST_DELETED_WINDOW_TIMESTAMP_KEY = b"__deleted_start_gt__"
 
+LATEST_DELETED_VALUE_CF_NAME = "__value-deletion-index__"
+LATEST_DELETED_VALUE_TIMESTAMP_KEY = b"__value_deleted_start_gt__"
+
 LATEST_TIMESTAMPS_CF_NAME = "__latest-timestamps__"
 LATEST_TIMESTAMP_KEY = b"__latest_timestamp__"
 

--- a/quixstreams/state/rocksdb/windowed/metadata.py
+++ b/quixstreams/state/rocksdb/windowed/metadata.py
@@ -6,3 +6,8 @@ LATEST_DELETED_WINDOW_TIMESTAMP_KEY = b"__deleted_start_gt__"
 
 LATEST_TIMESTAMPS_CF_NAME = "__latest-timestamps__"
 LATEST_TIMESTAMP_KEY = b"__latest_timestamp__"
+
+GLOBAL_COUNTER_CF_NAME = "__global-counter__"
+GLOBAL_COUNTER_KEY = b"__global_counter__"
+
+VALUES_CF_NAME = "__values__"

--- a/quixstreams/state/rocksdb/windowed/partition.py
+++ b/quixstreams/state/rocksdb/windowed/partition.py
@@ -10,6 +10,7 @@ from ..partition import RocksDBStorePartition
 from ..types import RocksDBOptionsType
 from .metadata import (
     GLOBAL_COUNTER_CF_NAME,
+    LATEST_DELETED_VALUE_CF_NAME,
     LATEST_DELETED_WINDOW_CF_NAME,
     LATEST_EXPIRED_WINDOW_CF_NAME,
     LATEST_TIMESTAMPS_CF_NAME,
@@ -41,6 +42,7 @@ class WindowedRocksDBStorePartition(RocksDBStorePartition):
         super().__init__(
             path=path, options=options, changelog_producer=changelog_producer
         )
+        self._ensure_column_family(LATEST_DELETED_VALUE_CF_NAME)
         self._ensure_column_family(LATEST_EXPIRED_WINDOW_CF_NAME)
         self._ensure_column_family(LATEST_DELETED_WINDOW_CF_NAME)
         self._ensure_column_family(LATEST_TIMESTAMPS_CF_NAME)

--- a/quixstreams/state/rocksdb/windowed/partition.py
+++ b/quixstreams/state/rocksdb/windowed/partition.py
@@ -9,9 +9,11 @@ from quixstreams.state.recovery import ChangelogProducer
 from ..partition import RocksDBStorePartition
 from ..types import RocksDBOptionsType
 from .metadata import (
+    GLOBAL_COUNTER_CF_NAME,
     LATEST_DELETED_WINDOW_CF_NAME,
     LATEST_EXPIRED_WINDOW_CF_NAME,
     LATEST_TIMESTAMPS_CF_NAME,
+    VALUES_CF_NAME,
 )
 from .transaction import WindowedRocksDBPartitionTransaction
 
@@ -42,6 +44,8 @@ class WindowedRocksDBStorePartition(RocksDBStorePartition):
         self._ensure_column_family(LATEST_EXPIRED_WINDOW_CF_NAME)
         self._ensure_column_family(LATEST_DELETED_WINDOW_CF_NAME)
         self._ensure_column_family(LATEST_TIMESTAMPS_CF_NAME)
+        self._ensure_column_family(GLOBAL_COUNTER_CF_NAME)
+        self._ensure_column_family(VALUES_CF_NAME)
 
     def iter_items(
         self, from_key: bytes, read_opt: ReadOptions, cf_name: str = "default"

--- a/quixstreams/state/rocksdb/windowed/serialization.py
+++ b/quixstreams/state/rocksdb/windowed/serialization.py
@@ -1,5 +1,4 @@
 import struct
-from typing import Tuple
 
 from quixstreams.state.metadata import PREFIX_SEPARATOR
 from quixstreams.state.serialization import (
@@ -18,7 +17,7 @@ _window_pack = _window_packer.pack
 _window_unpack = _window_packer.unpack
 
 
-def parse_window_key(key: bytes) -> Tuple[bytes, int, int]:
+def parse_window_key(key: bytes) -> tuple[bytes, int, int]:
     """
     Parse the window key from Rocksdb into (message_key, start, end) structure.
 

--- a/quixstreams/state/rocksdb/windowed/serialization.py
+++ b/quixstreams/state/rocksdb/windowed/serialization.py
@@ -1,17 +1,17 @@
 import struct
 
-from quixstreams.state.metadata import PREFIX_SEPARATOR
+from quixstreams.state.metadata import SEPARATOR
 from quixstreams.state.serialization import (
     int_to_int64_bytes,
 )
 
-__all__ = ("parse_window_key", "encode_window_key", "append_integer")
+__all__ = ("parse_window_key", "encode_integer_pair", "append_integer")
 
 _TIMESTAMP_BYTE_LENGTH = len(int_to_int64_bytes(0))
-_PREFIX_SEPARATOR_LENGTH = len(PREFIX_SEPARATOR)
-_TIMESTAMPS_SEGMENT_LEN = _TIMESTAMP_BYTE_LENGTH * 2 + _PREFIX_SEPARATOR_LENGTH
+_SEPARATOR_LENGTH = len(SEPARATOR)
+_TIMESTAMPS_SEGMENT_LEN = _TIMESTAMP_BYTE_LENGTH * 2 + _SEPARATOR_LENGTH
 
-_window_pack_format = ">q" + "c" * _PREFIX_SEPARATOR_LENGTH + "q"
+_window_pack_format = ">q" + "c" * _SEPARATOR_LENGTH + "q"
 _window_packer = struct.Struct(_window_pack_format)
 _window_pack = _window_packer.pack
 _window_unpack = _window_packer.unpack
@@ -37,18 +37,18 @@ def parse_window_key(key: bytes) -> tuple[bytes, int, int]:
     return message_key, start_ms, end_ms
 
 
-def encode_window_key(start_ms: int, end_ms: int) -> bytes:
+def encode_integer_pair(integer_1: int, integer_2: int) -> bytes:
     """
-    Encode window start and end timestamps into bytes of the following format:
-    ```<start>|<end>```
+    Encode a pair of integers into bytes of the following format:
+    ```<integer_1>|<integer_2>```
 
-    Encoding window keys this way make them sortable in RocksDB within the same prefix.
+    Encoding integers this way make them sortable in RocksDB within the same prefix.
 
-    :param start_ms: window start in milliseconds
-    :param end_ms: window end in milliseconds
-    :return: window timestamps as bytes
+    :param integer_1: first integer
+    :param integer_2: second integer
+    :return: integers as bytes
     """
-    return _window_pack(start_ms, PREFIX_SEPARATOR, end_ms)
+    return _window_pack(integer_1, SEPARATOR, integer_2)
 
 
 def append_integer(base_bytes: bytes, integer: int) -> bytes:
@@ -61,4 +61,4 @@ def append_integer(base_bytes: bytes, integer: int) -> bytes:
     :param integer: integer to append
     :return: bytes
     """
-    return base_bytes + PREFIX_SEPARATOR + int_to_int64_bytes(integer)
+    return base_bytes + SEPARATOR + int_to_int64_bytes(integer)

--- a/quixstreams/state/rocksdb/windowed/serialization.py
+++ b/quixstreams/state/rocksdb/windowed/serialization.py
@@ -6,7 +6,7 @@ from quixstreams.state.serialization import (
     int_to_int64_bytes,
 )
 
-__all__ = ("parse_window_key", "encode_window_key", "encode_window_prefix")
+__all__ = ("parse_window_key", "encode_window_key", "append_integer")
 
 _TIMESTAMP_BYTE_LENGTH = len(int_to_int64_bytes(0))
 _PREFIX_SEPARATOR_LENGTH = len(PREFIX_SEPARATOR)
@@ -52,14 +52,14 @@ def encode_window_key(start_ms: int, end_ms: int) -> bytes:
     return _window_pack(start_ms, PREFIX_SEPARATOR, end_ms)
 
 
-def encode_window_prefix(prefix: bytes, start_ms: int) -> bytes:
+def append_integer(base_bytes: bytes, integer: int) -> bytes:
     """
-    Encode window prefix and start time to iterate over keys in RocksDB
+    Append integer to the base bytes
     Format:
-    ```<prefix>|<start>```
+    ```<base_bytes>|<integer>```
 
-    :param prefix: transaction prefix
-    :param start_ms: window start time in milliseconds
+    :param base_bytes: base bytes
+    :param integer: integer to append
     :return: bytes
     """
-    return prefix + PREFIX_SEPARATOR + int_to_int64_bytes(start_ms)
+    return base_bytes + PREFIX_SEPARATOR + int_to_int64_bytes(integer)

--- a/quixstreams/state/rocksdb/windowed/state.py
+++ b/quixstreams/state/rocksdb/windowed/state.py
@@ -42,7 +42,6 @@ class WindowedTransactionState(WindowedState):
         end_ms: int,
         value: Any,
         timestamp_ms: int,
-        window_timestamp_ms: Optional[int] = None,
     ) -> None:
         """
         Set a value for the window.
@@ -55,7 +54,6 @@ class WindowedTransactionState(WindowedState):
         :param end_ms: end of the window in milliseconds
         :param value: value of the window
         :param timestamp_ms: current message timestamp in milliseconds
-        :param window_timestamp_ms: arbitrary timestamp stored with the window value
         """
         return self._transaction.update_window(
             start_ms=start_ms,
@@ -63,7 +61,6 @@ class WindowedTransactionState(WindowedState):
             timestamp_ms=timestamp_ms,
             value=value,
             prefix=self._prefix,
-            window_timestamp_ms=window_timestamp_ms,
         )
 
     def get_latest_timestamp(self) -> Optional[int]:

--- a/quixstreams/state/rocksdb/windowed/state.py
+++ b/quixstreams/state/rocksdb/windowed/state.py
@@ -62,7 +62,7 @@ class WindowedTransactionState(WindowedState):
             prefix=self._prefix,
         )
 
-    def collect_value(self, value: Any, timestamp_ms: int) -> None:
+    def add_to_collection(self, value: Any, timestamp_ms: int) -> None:
         """
         Collect a value for collection-type window aggregations.
 
@@ -73,7 +73,7 @@ class WindowedTransactionState(WindowedState):
         :param value: value to be collected
         :param timestamp_ms: current message timestamp in milliseconds
         """
-        return self._transaction.collect_value(
+        return self._transaction.add_to_collection(
             value=value,
             timestamp_ms=timestamp_ms,
             prefix=self._prefix,

--- a/quixstreams/state/rocksdb/windowed/state.py
+++ b/quixstreams/state/rocksdb/windowed/state.py
@@ -58,8 +58,8 @@ class WindowedTransactionState(WindowedState):
         return self._transaction.update_window(
             start_ms=start_ms,
             end_ms=end_ms,
-            timestamp_ms=timestamp_ms,
             value=value,
+            timestamp_ms=timestamp_ms,
             prefix=self._prefix,
         )
 

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -137,7 +137,7 @@ class WindowedRocksDBPartitionTransaction(PartitionTransaction):
             timestamp_ms=updated_timestamp_ms,
         )
 
-    def collect_value(
+    def add_to_collection(
         self,
         timestamp_ms: int,
         value: Any,

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -302,10 +302,19 @@ class WindowedRocksDBPartitionTransaction(PartitionTransaction):
             or -1
         )
 
+        key = None
         for key, _ in self._get_items(
             start=start, end=max_timestamp, prefix=prefix, cf_name=VALUES_CF_NAME
         ):
             self.delete(key=key, prefix=prefix, cf_name=VALUES_CF_NAME)
+
+        if key is not None:
+            _, timestamp_ms, _ = parse_window_key(key)
+            self._set_timestamp(
+                cache=self._last_deleted_value_timestamps,
+                prefix=prefix,
+                timestamp_ms=timestamp_ms,
+            )
 
     def get_windows(
         self,

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -97,15 +97,12 @@ class WindowedRocksDBPartitionTransaction(PartitionTransaction):
         value: Any,
         timestamp_ms: int,
         prefix: bytes,
-        window_timestamp_ms: Optional[int] = None,
     ) -> None:
         if timestamp_ms < 0:
             raise ValueError("Timestamp cannot be negative")
         self._validate_duration(start_ms=start_ms, end_ms=end_ms)
 
         key = encode_window_key(start_ms, end_ms)
-        if window_timestamp_ms is not None:
-            value = [window_timestamp_ms, value]
         self.set(key=key, value=value, prefix=prefix)
         latest_timestamp_ms = self.get_latest_timestamp(prefix=prefix)
         updated_timestamp_ms = (

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -387,7 +387,11 @@ class WindowedRocksDBPartitionTransaction(PartitionTransaction):
         :param cf_name: The RocksDB column family name.
         :return: A sorted list of key-value pairs.
         """
-        seek_from_key = append_integer(base_bytes=prefix, integer=max(start, 0))
+        start = max(start, 0)
+        if start > end:
+            return []
+
+        seek_from_key = append_integer(base_bytes=prefix, integer=start)
         seek_to_key = append_integer(base_bytes=prefix, integer=end)
 
         # Create an iterator over the state store

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -17,7 +17,7 @@ from .metadata import (
     LATEST_TIMESTAMP_KEY,
     LATEST_TIMESTAMPS_CF_NAME,
 )
-from .serialization import encode_window_key, encode_window_prefix, parse_window_key
+from .serialization import append_integer, encode_window_key, parse_window_key
 from .state import WindowedTransactionState
 
 if TYPE_CHECKING:
@@ -250,11 +250,11 @@ class WindowedRocksDBPartitionTransaction(PartitionTransaction):
         :return: A sorted list of tuples in the format `((start, end), value)`.
         """
         seek_from = max(start_from_ms, 0)
-        seek_from_key = encode_window_prefix(prefix=prefix, start_ms=seek_from)
+        seek_from_key = append_integer(base_bytes=prefix, integer=seek_from)
 
         # Add +1 to make the upper bound inclusive
         seek_to = start_to_ms + 1
-        seek_to_key = encode_window_prefix(prefix=prefix, start_ms=seek_to)
+        seek_to_key = append_integer(base_bytes=prefix, integer=seek_to)
 
         # Create an iterator over the state store
         # Set iterator bounds to reduce IO by limiting the range of keys fetched

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -380,8 +380,8 @@ class WindowedRocksDBPartitionTransaction(PartitionTransaction):
         This function also checks the update cache for any updates not yet
         committed to RocksDB.
 
-        :param start: Start of the range, exclusive.
-        :param end: End of the range, inclusive.
+        :param start: Start of the range, inclusive.
+        :param end: End of the range, exclusive.
         :param prefix: The key prefix for filtering items.
         :param backwards: If True, returns items in reverse order.
         :param cf_name: The RocksDB column family name.

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -156,12 +156,10 @@ class WindowedRocksDBPartitionTransaction(PartitionTransaction):
 
         # Use the latest expired timestamp to limit the iteration over
         # only those windows that have not been expired before
-        expired_windows = list(
-            self.get_windows(
-                start_from_ms=start_from,
-                start_to_ms=max_start_time,
-                prefix=prefix,
-            )
+        expired_windows = self.get_windows(
+            start_from_ms=start_from,
+            start_to_ms=max_start_time,
+            prefix=prefix,
         )
         if not expired_windows:
             return []

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -166,20 +166,24 @@ class WindowedRocksDBPartitionTransaction(PartitionTransaction):
                 prefix=prefix,
             )
         )
-        if expired_windows:
-            # Save the start of the latest expired window to the expiration index
-            latest_window = expired_windows[-1]
-            last_expired__gt = latest_window[0][0]
+        if not expired_windows:
+            return []
 
-            self._set_timestamp(
-                cache=self._last_expired_timestamps,
-                prefix=prefix,
-                timestamp_ms=last_expired__gt,
-            )
-            # Delete expired windows from the state
-            if delete:
-                for (start, end), _ in expired_windows:
-                    self.delete_window(start, end, prefix=prefix)
+        # Save the start of the latest expired window to the expiration index
+        latest_window = expired_windows[-1]
+        last_expired__gt = latest_window[0][0]
+
+        self._set_timestamp(
+            cache=self._last_expired_timestamps,
+            prefix=prefix,
+            timestamp_ms=last_expired__gt,
+        )
+
+        # Delete expired windows from the state
+        if delete:
+            for (start, end), _ in expired_windows:
+                self.delete_window(start, end, prefix=prefix)
+
         return expired_windows
 
     def delete_windows(self, max_start_time: int, prefix: bytes) -> None:

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -43,6 +43,15 @@ class WindowedState(Protocol):
         """
         ...
 
+    def collect_value(self, value: Any, timestamp_ms: int) -> None:
+        """
+        Collect a value for the window.
+
+        :param value: value of the window
+        :param timestamp_ms: current message timestamp in milliseconds
+        """
+        ...
+
     def get_latest_timestamp(self) -> Optional[int]:
         """
         Get the latest observed timestamp for the current state partition.
@@ -55,7 +64,11 @@ class WindowedState(Protocol):
         ...
 
     def expire_windows(
-        self, max_start_time: int, delete: bool = True
+        self,
+        max_start_time: int,
+        delete: bool = True,
+        collect: bool = False,
+        end_inclusive: bool = False,
     ) -> list[tuple[tuple[int, int], Any]]:
         """
         Get all expired windows from RocksDB up to the specified `max_start_time` timestamp.
@@ -65,11 +78,13 @@ class WindowedState(Protocol):
 
         :param max_start_time: The timestamp up to which windows are considered expired, inclusive.
         :param delete: If True, expired windows will be deleted.
+        :param collect: If True, scattered values will be collected into single window.
+        :param end_inclusive: If True, the end of the window will be inclusive.
         :return: A sorted list of tuples in the format `((start, end), value)`.
         """
         ...
 
-    def delete_windows(self, max_start_time: int) -> None:
+    def delete_windows(self, max_start_time: int, delete_values: bool) -> None:
         """
         Delete windows from RocksDB up to the specified `max_start_time` timestamp.
 
@@ -78,6 +93,7 @@ class WindowedState(Protocol):
         unexpired windows.
 
         :param max_start_time: The timestamp up to which windows should be deleted, inclusive.
+        :param delete_values: If True, values will be deleted.
         """
         ...
 
@@ -179,6 +195,15 @@ class WindowedPartitionTransaction(Protocol):
         """
         ...
 
+    def collect_value(self, value: Any, timestamp_ms: int) -> None:
+        """
+        Collect a value for the window.
+
+        :param value: value of the window
+        :param timestamp_ms: current message timestamp in milliseconds
+        """
+        ...
+
     def get_latest_timestamp(self, prefix: bytes) -> int:
         """
         Get the latest observed timestamp for the current state prefix
@@ -192,7 +217,12 @@ class WindowedPartitionTransaction(Protocol):
         ...
 
     def expire_windows(
-        self, max_start_time: int, prefix: bytes, delete: bool = True
+        self,
+        max_start_time: int,
+        prefix: bytes,
+        delete: bool = True,
+        collect: bool = False,
+        end_inclusive: bool = False,
     ) -> list[tuple[tuple[int, int], Any]]:
         """
         Get all expired windows from RocksDB up to the specified `max_start_time` timestamp.
@@ -203,11 +233,15 @@ class WindowedPartitionTransaction(Protocol):
         :param max_start_time: The timestamp up to which windows are considered expired, inclusive.
         :param prefix: The key prefix for filtering windows.
         :param delete: If True, expired windows will be deleted.
+        :param collect: If True, scattered values will be collected into single window.
+        :param end_inclusive: If True, the end of the window will be inclusive.
         :return: A sorted list of tuples in the format `((start, end), value)`.
         """
         ...
 
-    def delete_windows(self, max_start_time: int, prefix: bytes) -> None:
+    def delete_windows(
+        self, max_start_time: int, delete_values: bool, prefix: bytes
+    ) -> None:
         """
         Delete windows from RocksDB up to the specified `max_start_time` timestamp.
 
@@ -216,6 +250,7 @@ class WindowedPartitionTransaction(Protocol):
         unexpired windows.
 
         :param max_start_time: The timestamp up to which windows should be deleted, inclusive.
+        :param delete_values: If True, values will be deleted.
         :param prefix: The key prefix used to identify and filter relevant windows.
         """
         ...

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -43,7 +43,7 @@ class WindowedState(Protocol):
         """
         ...
 
-    def collect_value(self, value: Any, timestamp_ms: int) -> None:
+    def add_to_collection(self, value: Any, timestamp_ms: int) -> None:
         """
         Collect a value for collection-type window aggregations.
 
@@ -201,7 +201,7 @@ class WindowedPartitionTransaction(Protocol):
         """
         ...
 
-    def collect_value(self, value: Any, timestamp_ms: int) -> None:
+    def add_to_collection(self, value: Any, timestamp_ms: int) -> None:
         """
         Collect a value for collection-type window aggregations.
 

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -34,7 +34,7 @@ class WindowedState(Protocol):
         Set a value for the window.
 
         This method will also update the latest observed timestamp in state partition
-        using the provided `timestamp`.
+        using the provided `timestamp_ms`.
 
         :param start_ms: start of the window in milliseconds
         :param end_ms: end of the window in milliseconds
@@ -45,9 +45,13 @@ class WindowedState(Protocol):
 
     def collect_value(self, value: Any, timestamp_ms: int) -> None:
         """
-        Collect a value for the window.
+        Collect a value for collection-type window aggregations.
 
-        :param value: value of the window
+        This method is used internally by collection windows (created using
+        .collect()) to store individual values. These values are later combined
+        during window expiration.
+
+        :param value: value to be collected
         :param timestamp_ms: current message timestamp in milliseconds
         """
         ...
@@ -78,8 +82,9 @@ class WindowedState(Protocol):
 
         :param max_start_time: The timestamp up to which windows are considered expired, inclusive.
         :param delete: If True, expired windows will be deleted.
-        :param collect: If True, scattered values will be collected into single window.
+        :param collect: If True, values will be collected into windows.
         :param end_inclusive: If True, the end of the window will be inclusive.
+            Relevant only together with `collect=True`.
         :return: A sorted list of tuples in the format `((start, end), value)`.
         """
         ...
@@ -88,12 +93,13 @@ class WindowedState(Protocol):
         """
         Delete windows from RocksDB up to the specified `max_start_time` timestamp.
 
-        This method removes all window entries that have a start time less than or equal to the given
-        `max_start_time`. It ensures that expired data is cleaned up efficiently without affecting
-        unexpired windows.
+        This method removes all window entries that have a start time less than or equal
+        to the given `max_start_time`. It ensures that expired data is cleaned up
+        efficiently without affecting unexpired windows.
 
         :param max_start_time: The timestamp up to which windows should be deleted, inclusive.
-        :param delete_values: If True, values will be deleted.
+        :param delete_values: If True, values with timestamps less than max_start_time
+            will be deleted, as they can no longer belong to any active window.
         """
         ...
 
@@ -197,9 +203,13 @@ class WindowedPartitionTransaction(Protocol):
 
     def collect_value(self, value: Any, timestamp_ms: int) -> None:
         """
-        Collect a value for the window.
+        Collect a value for collection-type window aggregations.
 
-        :param value: value of the window
+        This method is used internally by collection windows (created using
+        .collect()) to store individual values. These values are later combined
+        during window expiration.
+
+        :param value: value to be collected
         :param timestamp_ms: current message timestamp in milliseconds
         """
         ...
@@ -233,8 +243,9 @@ class WindowedPartitionTransaction(Protocol):
         :param max_start_time: The timestamp up to which windows are considered expired, inclusive.
         :param prefix: The key prefix for filtering windows.
         :param delete: If True, expired windows will be deleted.
-        :param collect: If True, scattered values will be collected into single window.
+        :param collect: If True, values will be collected into windows.
         :param end_inclusive: If True, the end of the window will be inclusive.
+            Relevant only together with `collect=True`.
         :return: A sorted list of tuples in the format `((start, end), value)`.
         """
         ...
@@ -245,12 +256,13 @@ class WindowedPartitionTransaction(Protocol):
         """
         Delete windows from RocksDB up to the specified `max_start_time` timestamp.
 
-        This method removes all window entries that have a start time less than or equal to the given
-        `max_start_time`. It ensures that expired data is cleaned up efficiently without affecting
-        unexpired windows.
+        This method removes all window entries that have a start time less than or equal
+        to the given `max_start_time`. It ensures that expired data is cleaned up
+        efficiently without affecting unexpired windows.
 
         :param max_start_time: The timestamp up to which windows should be deleted, inclusive.
-        :param delete_values: If True, values will be deleted.
+        :param delete_values: If True, values with timestamps less than max_start_time
+            will be deleted, as they can no longer belong to any active window.
         :param prefix: The key prefix used to identify and filter relevant windows.
         """
         ...

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -29,7 +29,6 @@ class WindowedState(Protocol):
         end_ms: int,
         value: Any,
         timestamp_ms: int,
-        window_timestamp_ms: Optional[int] = None,
     ):
         """
         Set a value for the window.
@@ -41,7 +40,6 @@ class WindowedState(Protocol):
         :param end_ms: end of the window in milliseconds
         :param value: value of the window
         :param timestamp_ms: current message timestamp in milliseconds
-        :param window_timestamp_ms: arbitrary timestamp stored with the window value
         """
         ...
 

--- a/tests/test_quixstreams/test_dataframe/test_windows/test_hopping.py
+++ b/tests/test_quixstreams/test_dataframe/test_windows/test_hopping.py
@@ -193,15 +193,16 @@ class TestHoppingWindow:
         with store.start_partition_transaction(0) as tx:
             state = tx.as_state(prefix=b"key")
             window.process_window(value=1, state=state, timestamp_ms=100)
-            window.process_window(value=2, state=state, timestamp_ms=101)
+            window.process_window(value=2, state=state, timestamp_ms=100)
+            window.process_window(value=3, state=state, timestamp_ms=101)
             updated, expired = window.process_window(
-                value=3, state=state, timestamp_ms=110
+                value=4, state=state, timestamp_ms=110
             )
 
         assert not updated
         assert expired == [
-            {"start": 95, "end": 105, "value": [1, 2]},
-            {"start": 100, "end": 110, "value": [1, 2]},
+            {"start": 95, "end": 105, "value": [1, 2, 3]},
+            {"start": 100, "end": 110, "value": [1, 2, 3]},
         ]
 
     @pytest.mark.parametrize(

--- a/tests/test_quixstreams/test_dataframe/test_windows/test_sliding.py
+++ b/tests/test_quixstreams/test_dataframe/test_windows/test_sliding.py
@@ -8,7 +8,7 @@ import pytest
 
 from quixstreams.dataframe.windows import SlidingWindowDefinition
 
-A, B, C, D, E, F, G, H, I = "A", "B", "C", "D", "E", "F", "G", "H", "I"
+A, B, C, D = "A", "B", "C", "D"
 
 
 @dataclass
@@ -125,7 +125,7 @@ RIGHT_WINDOW_CREATED = [
 #                |---------||---------|
 #                10      20  21      31
 # ______________________________________________________________________
-# B 27                         |---------|
+# C 27                         |---------|
 #                              24       34
 #                                 C
 #                       |---------|

--- a/tests/test_quixstreams/test_dataframe/test_windows/test_tumbling.py
+++ b/tests/test_quixstreams/test_dataframe/test_windows/test_tumbling.py
@@ -164,12 +164,13 @@ class TestTumblingWindow:
         with store.start_partition_transaction(0) as tx:
             state = tx.as_state(prefix=b"key")
             window.process_window(value=1, state=state, timestamp_ms=100)
-            window.process_window(value=2, state=state, timestamp_ms=101)
+            window.process_window(value=2, state=state, timestamp_ms=100)
+            window.process_window(value=3, state=state, timestamp_ms=101)
             updated, expired = window.process_window(
-                value=3, state=state, timestamp_ms=200
+                value=4, state=state, timestamp_ms=200
             )
         assert not updated
-        assert expired == [{"start": 100, "end": 110, "value": [1, 2]}]
+        assert expired == [{"start": 100, "end": 110, "value": [1, 2, 3]}]
 
     @pytest.mark.parametrize(
         "duration, grace, name",

--- a/tests/test_quixstreams/test_state/test_partition.py
+++ b/tests/test_quixstreams/test_state/test_partition.py
@@ -8,7 +8,7 @@ from quixstreams.state.manager import SUPPORTED_STORES
 from quixstreams.state.metadata import (
     CHANGELOG_CF_MESSAGE_HEADER,
     CHANGELOG_PROCESSED_OFFSET_MESSAGE_HEADER,
-    PREFIX_SEPARATOR,
+    SEPARATOR,
 )
 from quixstreams.utils.json import dumps
 from tests.utils import ConfluentKafkaMessageStub
@@ -39,7 +39,7 @@ class TestStorePartitionChangelog:
         kafka_key = b"my_key"
         user_store_key = "count"
         changelog_msg = ConfluentKafkaMessageStub(
-            key=kafka_key + PREFIX_SEPARATOR + dumps(user_store_key),
+            key=kafka_key + SEPARATOR + dumps(user_store_key),
             value=dumps(store_value),
             headers=[(CHANGELOG_CF_MESSAGE_HEADER, b"default")],
             offset=50,
@@ -92,7 +92,7 @@ class TestStorePartitionChangelog:
         )
         committted_offset = 2
         changelog_msg = ConfluentKafkaMessageStub(
-            key=kafka_key + PREFIX_SEPARATOR + dumps(user_store_key),
+            key=kafka_key + SEPARATOR + dumps(user_store_key),
             value=dumps(10),
             headers=[
                 (CHANGELOG_CF_MESSAGE_HEADER, b"default"),
@@ -135,7 +135,7 @@ class TestStorePartitionChangelog:
             dumps(processed_offset),
         )
         changelog_msg = ConfluentKafkaMessageStub(
-            key=kafka_key + PREFIX_SEPARATOR + dumps(user_store_key),
+            key=kafka_key + SEPARATOR + dumps(user_store_key),
             value=dumps(10),
             headers=[
                 (CHANGELOG_CF_MESSAGE_HEADER, b"default"),

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_partition.py
@@ -2,13 +2,13 @@ import pytest
 
 from quixstreams.state.metadata import (
     CHANGELOG_CF_MESSAGE_HEADER,
-    PREFIX_SEPARATOR,
+    SEPARATOR,
 )
 from quixstreams.state.rocksdb.windowed.metadata import (
     LATEST_EXPIRED_WINDOW_CF_NAME,
     LATEST_EXPIRED_WINDOW_TIMESTAMP_KEY,
 )
-from quixstreams.state.rocksdb.windowed.serialization import encode_window_key
+from quixstreams.state.rocksdb.windowed.serialization import encode_integer_pair
 from quixstreams.utils.json import dumps
 from tests.utils import ConfluentKafkaMessageStub
 
@@ -30,8 +30,8 @@ class TestWindowedRocksDBPartitionTransactionChangelog:
         window = dict(start_ms=0, end_ms=10, value=store_value, timestamp_ms=2)
         changelog_msg = ConfluentKafkaMessageStub(
             key=kafka_key
-            + PREFIX_SEPARATOR
-            + encode_window_key(window["start_ms"], window["end_ms"]),
+            + SEPARATOR
+            + encode_integer_pair(window["start_ms"], window["end_ms"]),
             value=dumps(store_value),
             headers=[(CHANGELOG_CF_MESSAGE_HEADER, b"default")],
             offset=50,
@@ -60,7 +60,7 @@ class TestWindowedRocksDBPartitionTransactionChangelog:
         kafka_key = b"my_key"
         store_value = 10
         changelog_msg = ConfluentKafkaMessageStub(
-            key=kafka_key + PREFIX_SEPARATOR + LATEST_EXPIRED_WINDOW_TIMESTAMP_KEY,
+            key=kafka_key + SEPARATOR + LATEST_EXPIRED_WINDOW_TIMESTAMP_KEY,
             value=dumps(store_value),
             headers=[
                 (CHANGELOG_CF_MESSAGE_HEADER, LATEST_EXPIRED_WINDOW_CF_NAME.encode())

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_serialization.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_serialization.py
@@ -1,9 +1,9 @@
 import pytest
 
-from quixstreams.state.metadata import PREFIX_SEPARATOR
+from quixstreams.state.metadata import SEPARATOR
 from quixstreams.state.rocksdb.windowed.serialization import (
     append_integer,
-    encode_window_key,
+    encode_integer_pair,
     parse_window_key,
 )
 
@@ -17,8 +17,8 @@ from quixstreams.state.rocksdb.windowed.serialization import (
         (2, -2),
     ],
 )
-def test_encode_window_key(start, end):
-    key = encode_window_key(start_ms=start, end_ms=end)
+def test_encode_integer_pair(start, end):
+    key = encode_integer_pair(start, end)
     assert isinstance(key, bytes)
 
     prefix, decoded_start, decoded_end = parse_window_key(key)
@@ -31,8 +31,6 @@ def test_append_integer(
     base_bytes: bytes,
 ):
     start, end = 0, 10
-    window_key = (
-        base_bytes + PREFIX_SEPARATOR + encode_window_key(start_ms=start, end_ms=end)
-    )
+    window_key = base_bytes + SEPARATOR + encode_integer_pair(start, end)
     window_base_bytes = append_integer(base_bytes=base_bytes, integer=start)
     assert window_key.startswith(window_base_bytes)

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_serialization.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_serialization.py
@@ -2,8 +2,8 @@ import pytest
 
 from quixstreams.state.metadata import PREFIX_SEPARATOR
 from quixstreams.state.rocksdb.windowed.serialization import (
+    append_integer,
     encode_window_key,
-    encode_window_prefix,
     parse_window_key,
 )
 
@@ -26,13 +26,13 @@ def test_encode_window_key(start, end):
     assert decoded_end == end
 
 
-@pytest.mark.parametrize("prefix", [b"", b"prefix"])
-def test_encode_window_prefix(
-    prefix: bytes,
+@pytest.mark.parametrize("base_bytes", [b"", b"base_bytes"])
+def test_append_integer(
+    base_bytes: bytes,
 ):
     start, end = 0, 10
     window_key = (
-        prefix + PREFIX_SEPARATOR + encode_window_key(start_ms=start, end_ms=end)
+        base_bytes + PREFIX_SEPARATOR + encode_window_key(start_ms=start, end_ms=end)
     )
-    window_prefix = encode_window_prefix(prefix=prefix, start_ms=start)
-    assert window_key.startswith(window_prefix)
+    window_base_bytes = append_integer(base_bytes=base_bytes, integer=start)
+    assert window_key.startswith(window_base_bytes)

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
@@ -20,24 +20,14 @@ def transaction_state(store):
     return _transaction_state
 
 
-def test_update_window(transaction_state):
+@pytest.mark.parametrize("value", [1, [3, 1], [3, None]])
+def test_update_window(transaction_state, value):
     with transaction_state() as state:
-        state.update_window(start_ms=0, end_ms=10, value=1, timestamp_ms=2)
-        assert state.get_window(start_ms=0, end_ms=10) == 1
+        state.update_window(start_ms=0, end_ms=10, value=value, timestamp_ms=2)
+        assert state.get_window(start_ms=0, end_ms=10) == value
 
     with transaction_state() as state:
-        assert state.get_window(start_ms=0, end_ms=10) == 1
-
-
-def test_update_window_with_window_timestamp(transaction_state):
-    with transaction_state() as state:
-        state.update_window(
-            start_ms=0, end_ms=10, value=1, timestamp_ms=2, window_timestamp_ms=3
-        )
-        assert state.get_window(start_ms=0, end_ms=10) == [3, 1]
-
-    with transaction_state() as state:
-        assert state.get_window(start_ms=0, end_ms=10) == [3, 1]
+        assert state.get_window(start_ms=0, end_ms=10) == value
 
 
 @pytest.mark.parametrize("delete", [True, False])

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
@@ -90,9 +90,9 @@ def test_expire_windows_with_collect(transaction_state, end_inclusive):
         state.update_window(start_ms=0, end_ms=10, value=None, timestamp_ms=2)
         state.update_window(start_ms=10, end_ms=20, value=[777, None], timestamp_ms=10)
 
-        state.collect_value(value="a", timestamp_ms=0)
-        state.collect_value(value="b", timestamp_ms=10)
-        state.collect_value(value="c", timestamp_ms=20)
+        state.add_to_collection(value="a", timestamp_ms=0)
+        state.add_to_collection(value="b", timestamp_ms=10)
+        state.add_to_collection(value="c", timestamp_ms=20)
 
     with transaction_state() as state:
         state.update_window(start_ms=20, end_ms=30, value=None, timestamp_ms=20)
@@ -332,8 +332,8 @@ def test_delete_windows(transaction_state):
 def test_delete_windows_with_values(transaction_state, get_value):
     with transaction_state() as state:
         state.update_window(start_ms=2, end_ms=3, value=1, timestamp_ms=2)
-        state.collect_value(value="a", timestamp_ms=1)
-        state.collect_value(value="b", timestamp_ms=2)
+        state.add_to_collection(value="a", timestamp_ms=1)
+        state.add_to_collection(value="b", timestamp_ms=2)
 
     with transaction_state() as state:
         assert state.get_window(start_ms=2, end_ms=3)
@@ -349,11 +349,11 @@ def test_delete_windows_with_values(transaction_state, get_value):
 
 
 @pytest.mark.parametrize("value", [1, "string", None, ["list"], {"dict": "dict"}])
-def test_collect_value(transaction_state, get_value, value):
+def test_add_to_collection(transaction_state, get_value, value):
     with transaction_state() as state:
-        state.collect_value(value=value, timestamp_ms=11)
-        state.collect_value(value=value, timestamp_ms=22)
-        state.collect_value(value=value, timestamp_ms=33)
+        state.add_to_collection(value=value, timestamp_ms=11)
+        state.add_to_collection(value=value, timestamp_ms=22)
+        state.add_to_collection(value=value, timestamp_ms=33)
 
     assert get_value(timestamp_ms=11, counter=0) == value
     assert get_value(timestamp_ms=22, counter=1) == value

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
@@ -269,7 +269,7 @@ def test_delete_windows(transaction_state):
         assert state.get_window(start_ms=2, end_ms=3)
         assert state.get_window(start_ms=3, end_ms=4)
 
-        state.delete_windows(max_start_time=2)
+        state.delete_windows(max_start_time=2, delete_values=False)
 
         assert not state.get_window(start_ms=1, end_ms=2)
         assert not state.get_window(start_ms=2, end_ms=3)

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_transaction.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_transaction.py
@@ -4,7 +4,7 @@ from quixstreams.state.metadata import (
     CHANGELOG_CF_MESSAGE_HEADER,
     CHANGELOG_PROCESSED_OFFSET_MESSAGE_HEADER,
 )
-from quixstreams.state.rocksdb.windowed.serialization import encode_window_key
+from quixstreams.state.rocksdb.windowed.serialization import encode_integer_pair
 from quixstreams.utils.json import dumps
 
 
@@ -367,7 +367,7 @@ class TestWindowedRocksDBPartitionTransaction:
         # One for the window itself, and another for the latest timestamp
         assert changelog_producer_mock.produce.call_count == 2
         expected_produced_key = tx._serialize_key(
-            encode_window_key(start_ms, end_ms), prefix=prefix
+            encode_integer_pair(start_ms, end_ms), prefix=prefix
         )
         expected_produced_value = tx._serialize_value(value)
         changelog_producer_mock.produce.assert_any_call(
@@ -397,7 +397,7 @@ class TestWindowedRocksDBPartitionTransaction:
 
         assert changelog_producer_mock.produce.call_count == 1
         expected_produced_key = tx._serialize_key(
-            encode_window_key(start_ms, end_ms), prefix=prefix
+            encode_integer_pair(start_ms, end_ms), prefix=prefix
         )
         changelog_producer_mock.produce.assert_called_with(
             key=expected_produced_key,


### PR DESCRIPTION
This PR introduces a new `.collect()` aggregation method for windowed operations that efficiently gathers all values within a window into a list.

## Features
- New `.collect()` method for windowed aggregations
- Optimized performance compared to using `reduce()` for list building
- Supports all window types (tumbling, hopping, sliding)

## Implementation Details
- Only supports `.final()` mode to ensure complete window results
- Groups values by message key like other window operations
- Returns standard window result format with collection in the `value` field:
  ```python
  {
    'start': window_start_ms,
    'end': window_end_ms,
    'value': [value1, value2, ...]
  }
  ```