### PR TITLE
 Influxdb3 Sink: add some functionality and QoL improvements

### DIFF
--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -51,7 +51,7 @@ class InfluxDB3Sink(BatchingSink):
         host: str,
         organization_id: str,
         database: str,
-        measurement: MeasurementSetter = "default",
+        measurement: MeasurementSetter,
         fields_keys: FieldsSetter = (),
         tags_keys: TagsSetter = (),
         time_key: Optional[str] = None,

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -108,7 +108,7 @@ class InfluxDB3Sink(BatchingSink):
             Possible values: "ms", "ns", "us", "s".
             Default - `"ms"`.
         :param allow_missing_fields: Allow missing keys (auto-populated as nulls in
-            Influx), else raise KeyError.
+            InfluxDB), else raise KeyError.
             Default - `False`
         :param include_metadata_tags: if True, includes record's key, topic,
             and partition as tags.

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 TimePrecision = Literal[
-    "milliseconds", "ms", "nanoseconds", "ns", "microseconds", "us", "seconds", "s"
+    "ms", "ns", "us", "s"
 ]
 
 InfluxDBValueMap = dict[str, Union[str, int, float, bool]]

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -102,7 +102,8 @@ class InfluxDB3Sink(BatchingSink):
             When using a custom key, you may need to adjust the `time_precision` setting
             to match.
         :param time_precision: a time precision to use when writing to InfluxDB.
-            Possible values: "ms", "ns", "us", "s". Default - `"ms"`.
+            Possible values: "ms", "ns", "us", "s". 
+            Default - `"ms"`.
         :param allow_missing_fields: Adds missing fields as nulls, else raise KeyError
             Default - `False`
         :param include_metadata_tags: if True, includes record's key, topic,

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -102,7 +102,7 @@ class InfluxDB3Sink(BatchingSink):
             When using a custom key, you may need to adjust the `time_precision` setting
             to match.
         :param time_precision: a time precision to use when writing to InfluxDB.
-            Default - `milliseconds`.
+            Possible values: "ms", "ns", "us", "s". Default - `"ms"`.
         :param allow_missing_fields: Adds missing fields as nulls, else raise KeyError
             Default - `False`
         :param include_metadata_tags: if True, includes record's key, topic,

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -55,7 +55,7 @@ class InfluxDB3Sink(BatchingSink):
         fields_keys: FieldsSetter = (),
         tags_keys: TagsSetter = (),
         time_key: Optional[str] = None,
-        time_precision: TimePrecision = "milliseconds",
+        time_precision: TimePrecision = "ms",
         allow_missing_fields: bool = False,
         include_metadata_tags: bool = False,
         batch_size: int = 1000,

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -107,8 +107,7 @@ class InfluxDB3Sink(BatchingSink):
         :param time_precision: a time precision to use when writing to InfluxDB.
             Possible values: "ms", "ns", "us", "s".
             Default - `"ms"`.
-        :param allow_missing_fields: Allow missing keys (auto-populated as nulls in
-            InfluxDB), else raise KeyError.
+        :param allow_missing_fields: if `True`, skip the missing fields keys, else raise `KeyError`.
             Default - `False`
         :param include_metadata_tags: if True, includes record's key, topic,
             and partition as tags.


### PR DESCRIPTION
Added some callables for fields, tags, and measurements (in case you need fields only for those purposes and can't filter them out otherwise).

Allowed passing a string to specify timestamp type (milliseconds, seconds, etc)