### PR TITLE
Add optional connector connect success and failure callbacks

### DIFF
--- a/quixstreams/processing/context.py
+++ b/quixstreams/processing/context.py
@@ -101,6 +101,7 @@ class ProcessingContext:
         self.pausing_manager.revoke(topic=topic, partition=partition)
 
     def __enter__(self):
+        self.sink_manager.start_sinks()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/quixstreams/sinks/__init__.py
+++ b/quixstreams/sinks/__init__.py
@@ -1,4 +1,11 @@
-from .base import BaseSink, BatchingSink, SinkBackpressureError, SinkBatch, SinkManager
+from .base import (
+    BaseSink,
+    BatchingSink,
+    ClientConnectCallback,
+    SinkBackpressureError,
+    SinkBatch,
+    SinkManager,
+)
 
 __all__ = [
     "BaseSink",
@@ -6,4 +13,5 @@ __all__ = [
     "SinkBackpressureError",
     "SinkBatch",
     "SinkManager",
+    "ClientConnectCallback",
 ]

--- a/quixstreams/sinks/__init__.py
+++ b/quixstreams/sinks/__init__.py
@@ -1,7 +1,8 @@
 from .base import (
     BaseSink,
     BatchingSink,
-    ClientConnectCallback,
+    ClientConnectFailureCallback,
+    ClientConnectSuccessCallback,
     SinkBackpressureError,
     SinkBatch,
     SinkManager,
@@ -13,5 +14,6 @@ __all__ = [
     "SinkBackpressureError",
     "SinkBatch",
     "SinkManager",
-    "ClientConnectCallback",
+    "ClientConnectSuccessCallback",
+    "ClientConnectFailureCallback",
 ]

--- a/quixstreams/sinks/base/__init__.py
+++ b/quixstreams/sinks/base/__init__.py
@@ -1,7 +1,7 @@
 from .batch import SinkBatch
 from .exceptions import SinkBackpressureError
 from .manager import SinkManager
-from .sink import BaseSink, BatchingSink
+from .sink import BaseSink, BatchingSink, ClientConnectCallback
 
 __all__ = (
     "SinkBatch",
@@ -9,4 +9,5 @@ __all__ = (
     "SinkManager",
     "BatchingSink",
     "BaseSink",
+    "ClientConnectCallback",
 )

--- a/quixstreams/sinks/base/__init__.py
+++ b/quixstreams/sinks/base/__init__.py
@@ -1,7 +1,12 @@
 from .batch import SinkBatch
 from .exceptions import SinkBackpressureError
 from .manager import SinkManager
-from .sink import BaseSink, BatchingSink, ClientConnectCallback
+from .sink import (
+    BaseSink,
+    BatchingSink,
+    ClientConnectFailureCallback,
+    ClientConnectSuccessCallback,
+)
 
 __all__ = (
     "SinkBatch",
@@ -9,5 +14,6 @@ __all__ = (
     "SinkManager",
     "BatchingSink",
     "BaseSink",
-    "ClientConnectCallback",
+    "ClientConnectSuccessCallback",
+    "ClientConnectFailureCallback",
 )

--- a/quixstreams/sinks/base/manager.py
+++ b/quixstreams/sinks/base/manager.py
@@ -14,6 +14,10 @@ class SinkManager:
         if sink_id not in self._sinks:
             self._sinks[id(sink)] = sink
 
+    def start_sinks(self):
+        for sink in self.sinks:
+            sink.start()
+
     @property
     def sinks(self) -> List[BaseSink]:
         return list(self._sinks.values())

--- a/quixstreams/sinks/base/sink.py
+++ b/quixstreams/sinks/base/sink.py
@@ -81,7 +81,7 @@ class BaseSink(abc.ABC):
         """
 
     @abc.abstractmethod
-    def setup_client(self):
+    def setup(self):
         """
         When applicable, set up the client here along with any validation to affirm a
         valid/successful authentication/connection.
@@ -93,7 +93,7 @@ class BaseSink(abc.ABC):
         Allows using a callback pattern around the connection attempt.
         """
         try:
-            self.setup_client()
+            self.setup()
             self._client_connect_success_cb()
         except Exception as e:
             self._client_connect_failure_cb(e)

--- a/quixstreams/sinks/base/sink.py
+++ b/quixstreams/sinks/base/sink.py
@@ -72,6 +72,10 @@ class BaseSink(abc.ABC):
         """
 
     def start(self):
+        """
+        Called as part of `Application.run()` to initialize the sink's client.
+        Allows using a callback pattern around the connection attempt.
+        """
         error = None
         try:
             self.setup_client()
@@ -80,6 +84,7 @@ class BaseSink(abc.ABC):
         finally:
             if cb := self._client_connect_cb:
                 cb(error)
+            # Only raise if no callback; callback could intentionally supress errors
             elif error:
                 raise error
 
@@ -92,7 +97,7 @@ class BaseSink(abc.ABC):
         """
 
 
-class BatchingSink(BaseSink, abc.ABC):
+class BatchingSink(BaseSink):
     """
     A base class for batching sinks, that need to accumulate the data first before
     sending it to the external destinations.

--- a/quixstreams/sinks/base/sink.py
+++ b/quixstreams/sinks/base/sink.py
@@ -12,11 +12,11 @@ ClientConnectSuccessCallback = Callable[[], None]
 ClientConnectFailureCallback = Callable[[Optional[Exception]], None]
 
 
-def _default_client_connect_success_cb():
+def _default_on_client_connect_success():
     logger.info("CONNECTED!")
 
 
-def _default_client_connect_failure_cb(exception: Exception):
+def _default_on_client_connect_failure(exception: Exception):
     logger.error(f"ERROR: Failed while connecting to client: {exception}")
 
 
@@ -31,22 +31,22 @@ class BaseSink(abc.ABC):
 
     def __init__(
         self,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ):
         """
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
         """
-        self._client_connect_success_cb = (
-            client_connect_success_cb or _default_client_connect_success_cb
+        self._on_client_connect_success = (
+            on_client_connect_success or _default_on_client_connect_success
         )
-        self._client_connect_failure_cb = (
-            client_connect_failure_cb or _default_client_connect_failure_cb
+        self._on_client_connect_failure = (
+            on_client_connect_failure or _default_on_client_connect_failure
         )
 
     @abc.abstractmethod
@@ -94,9 +94,9 @@ class BaseSink(abc.ABC):
         """
         try:
             self.setup()
-            self._client_connect_success_cb()
+            self._on_client_connect_success()
         except Exception as e:
-            self._client_connect_failure_cb(e)
+            self._on_client_connect_failure(e)
 
     def on_paused(self, topic: str, partition: int):
         """
@@ -125,20 +125,20 @@ class BatchingSink(BaseSink):
 
     def __init__(
         self,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ):
         """
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
         """
         super().__init__(
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
         self._batches = {}
 

--- a/quixstreams/sinks/base/sink.py
+++ b/quixstreams/sinks/base/sink.py
@@ -25,8 +25,11 @@ class BaseSink(abc.ABC):
         client_connect_cb: ClientConnectCallback = None,
     ):
         """
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         """
         self._client_connect_cb = client_connect_cb
 
@@ -110,8 +113,11 @@ class BatchingSink(BaseSink, abc.ABC):
         client_connect_cb: ClientConnectCallback = None,
     ):
         """
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         """
         super().__init__(client_connect_cb=client_connect_cb)
         self._batches = {}

--- a/quixstreams/sinks/community/bigquery.py
+++ b/quixstreams/sinks/community/bigquery.py
@@ -100,8 +100,11 @@ class BigQuerySink(BatchingSink):
         :param retry_timeout: a total timeout for each request to BigQuery API.
             During this timeout, a request can be retried according
             to the client's default retrying policy.
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         :param kwargs: Additional keyword arguments passed to `bigquery.Client`.
         """
         super().__init__(client_connect_cb=client_connect_cb)

--- a/quixstreams/sinks/community/bigquery.py
+++ b/quixstreams/sinks/community/bigquery.py
@@ -65,8 +65,8 @@ class BigQuerySink(BatchingSink):
         ddl_timeout: float = 10.0,
         insert_timeout: float = 10.0,
         retry_timeout: float = 30.0,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
         **kwargs,
     ):
         """
@@ -106,17 +106,17 @@ class BigQuerySink(BatchingSink):
         :param retry_timeout: a total timeout for each request to BigQuery API.
             During this timeout, a request can be retried according
             to the client's default retrying policy.
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
         :param kwargs: Additional keyword arguments passed to `bigquery.Client`.
         """
         super().__init__(
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         self.location = location

--- a/quixstreams/sinks/community/bigquery.py
+++ b/quixstreams/sinks/community/bigquery.py
@@ -140,7 +140,7 @@ class BigQuerySink(BatchingSink):
         self._client: Optional[bigquery.Client] = None
         self._client_settings = kwargs
 
-    def setup_client(self):
+    def setup(self):
         if not self._client:
             self._client = bigquery.Client(**self._client_settings)
             logger.info("Successfully authenticated to BigQuery.")

--- a/quixstreams/sinks/community/bigquery.py
+++ b/quixstreams/sinks/community/bigquery.py
@@ -3,7 +3,7 @@ import logging
 import time
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Mapping, Optional
 
 try:
     from google.cloud import bigquery
@@ -17,7 +17,7 @@ except ImportError as exc:
 
 from quixstreams.exceptions import QuixException
 from quixstreams.models import HeadersTuples
-from quixstreams.sinks import BatchingSink, SinkBatch
+from quixstreams.sinks import BatchingSink, ClientConnectCallback, SinkBatch
 
 __all__ = ("BigQuerySink", "BigQuerySinkException")
 
@@ -60,7 +60,7 @@ class BigQuerySink(BatchingSink):
         ddl_timeout: float = 10.0,
         insert_timeout: float = 10.0,
         retry_timeout: float = 30.0,
-        client_connect_cb: Optional[Callable[[Optional[Exception]], None]] = None,
+        client_connect_cb: ClientConnectCallback = None,
         **kwargs,
     ):
         """
@@ -104,6 +104,7 @@ class BigQuerySink(BatchingSink):
             is established. Callback expects an Exception or None as an argument.
         :param kwargs: Additional keyword arguments passed to `bigquery.Client`.
         """
+        super().__init__(client_connect_cb=client_connect_cb)
 
         self.location = location
         self.project_id = project_id
@@ -125,7 +126,6 @@ class BigQuerySink(BatchingSink):
             kwargs["credentials"] = credentials
         self._client: Optional[bigquery.Client] = None
         self._client_settings = kwargs
-        super().__init__(client_connect_cb=client_connect_cb)
 
     def setup_client(self):
         if not self._client:

--- a/quixstreams/sinks/community/file/destinations/azure.py
+++ b/quixstreams/sinks/community/file/destinations/azure.py
@@ -86,7 +86,7 @@ class AzureFileDestination(Destination):
             raise
         raise AzureContainerNotFoundError(f"Container not found: {self._container}")
 
-    def connect(self):
+    def setup_client(self):
         if not self._client:
             self._client = self._get_client()
             self._validate_container()

--- a/quixstreams/sinks/community/file/destinations/azure.py
+++ b/quixstreams/sinks/community/file/destinations/azure.py
@@ -86,7 +86,7 @@ class AzureFileDestination(Destination):
             raise
         raise AzureContainerNotFoundError(f"Container not found: {self._container}")
 
-    def setup_client(self):
+    def setup(self):
         if not self._client:
             self._client = self._get_client()
             self._validate_container()

--- a/quixstreams/sinks/community/file/destinations/base.py
+++ b/quixstreams/sinks/community/file/destinations/base.py
@@ -25,6 +25,21 @@ class Destination(ABC):
     _base_directory: str = ""
     _extension: str = ""
 
+    @abstractmethod
+    def connect(self):
+        """Authenticate and validate connection here"""
+        ...
+
+    @abstractmethod
+    def write(self, data: bytes, batch: SinkBatch) -> None:
+        """Write the serialized data to storage.
+
+        :param data: The serialized data to write.
+        :param batch: The batch information containing topic, partition and offset
+            details.
+        """
+        ...
+
     def set_directory(self, directory: str) -> None:
         """Configure the base directory for storing files.
 
@@ -49,16 +64,6 @@ class Destination(ABC):
         """
         self._extension = format.file_extension
         logger.info("File extension set to '%s'", self._extension)
-
-    @abstractmethod
-    def write(self, data: bytes, batch: SinkBatch) -> None:
-        """Write the serialized data to storage.
-
-        :param data: The serialized data to write.
-        :param batch: The batch information containing topic, partition and offset
-            details.
-        """
-        ...
 
     def _path(self, batch: SinkBatch) -> Path:
         """Generate the full path where the batch data should be stored.

--- a/quixstreams/sinks/community/file/destinations/base.py
+++ b/quixstreams/sinks/community/file/destinations/base.py
@@ -10,7 +10,7 @@ __all__ = ("Destination",)
 
 logger = logging.getLogger(__name__)
 
-_UNSAFE_CHARACTERS_REGEX = re.compile(r"[^a-zA-Z0-9 ._]")
+_UNSAFE_CHARACTERS_REGEX = re.compile(r"[^a-zA-Z0-9 ._/]")
 
 
 class Destination(ABC):
@@ -40,14 +40,18 @@ class Destination(ABC):
         """
         ...
 
-    def set_directory(self, directory: str) -> None:
+    def set_directory(
+        self,
+        directory: str,
+    ) -> None:
         """Configure the base directory for storing files.
 
         :param directory: The base directory path where files will be stored.
         :raises ValueError: If the directory path contains invalid characters.
-            Only alphanumeric characters (a-zA-Z0-9), spaces, dots, and
+            Only alphanumeric characters (a-zA-Z0-9), spaces, dots, slashes, and
             underscores are allowed.
         """
+        # TODO: logic around "/" for sinks that require special handling of them
         if _UNSAFE_CHARACTERS_REGEX.search(directory):
             raise ValueError(
                 f"Invalid characters in directory path: {directory}. "

--- a/quixstreams/sinks/community/file/destinations/base.py
+++ b/quixstreams/sinks/community/file/destinations/base.py
@@ -26,7 +26,7 @@ class Destination(ABC):
     _extension: str = ""
 
     @abstractmethod
-    def connect(self):
+    def setup(self):
         """Authenticate and validate connection here"""
         ...
 

--- a/quixstreams/sinks/community/file/destinations/local.py
+++ b/quixstreams/sinks/community/file/destinations/local.py
@@ -29,7 +29,7 @@ class LocalDestination(Destination):
         self._mode = "ab" if append else "wb"
         logger.debug("LocalDestination initialized with append=%s", append)
 
-    def connect(self):
+    def setup(self):
         return
 
     def set_extension(self, format: Format) -> None:

--- a/quixstreams/sinks/community/file/destinations/local.py
+++ b/quixstreams/sinks/community/file/destinations/local.py
@@ -29,6 +29,9 @@ class LocalDestination(Destination):
         self._mode = "ab" if append else "wb"
         logger.debug("LocalDestination initialized with append=%s", append)
 
+    def connect(self):
+        return
+
     def set_extension(self, format: Format) -> None:
         """Set the file extension and validate append mode compatibility.
 

--- a/quixstreams/sinks/community/file/destinations/s3.py
+++ b/quixstreams/sinks/community/file/destinations/s3.py
@@ -61,7 +61,7 @@ class S3Destination(Destination):
         }
         self._client: Optional[S3Client] = None
 
-    def connect(self):
+    def setup(self):
         if not self._client:
             # See init comment as to why we cannot set the client here.
             # We then attempt a likely-to-succeed query on the bucket to confirm auth.

--- a/quixstreams/sinks/community/file/sink.py
+++ b/quixstreams/sinks/community/file/sink.py
@@ -39,9 +39,13 @@ class FileSink(BatchingSink):
         """
         super().__init__()
         self._format = resolve_format(format)
-        self._destination = destination or LocalDestination()
-        self._destination.set_directory(directory)
-        self._destination.set_extension(self._format)
+        self._client = destination or LocalDestination()
+        self._client.set_directory(directory)
+        self._client.set_extension(self._format)
+
+    def setup_client(self) -> Destination:
+        self._client.connect()
+        return self._client
 
     def write(self, batch: SinkBatch) -> None:
         """Write a batch of data using the configured format and destination.
@@ -58,7 +62,7 @@ class FileSink(BatchingSink):
         data = self._format.serialize(batch)
 
         try:
-            self._destination.write(data, batch)
+            self._client.write(data, batch)
         except Exception as e:
             raise SinkBackpressureError(
                 retry_after=5.0,

--- a/quixstreams/sinks/community/file/sink.py
+++ b/quixstreams/sinks/community/file/sink.py
@@ -33,8 +33,8 @@ class FileSink(BatchingSink):
         directory: str = "",
         format: Union[FormatName, Format] = "json",
         destination: Optional[Destination] = None,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ) -> None:
         """Initialize the FileSink with the specified configuration.
 
@@ -44,16 +44,16 @@ class FileSink(BatchingSink):
             ("json", "parquet") or a Format instance.
         :param destination: Storage destination handler. Defaults to
             LocalDestination if not specified.
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
         """
         super().__init__(
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         self._format = resolve_format(format)

--- a/quixstreams/sinks/community/file/sink.py
+++ b/quixstreams/sinks/community/file/sink.py
@@ -42,8 +42,11 @@ class FileSink(BatchingSink):
             ("json", "parquet") or a Format instance.
         :param destination: Storage destination handler. Defaults to
             LocalDestination if not specified.
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         """
         self._format = resolve_format(format)
         self._client = destination or LocalDestination()

--- a/quixstreams/sinks/community/file/sink.py
+++ b/quixstreams/sinks/community/file/sink.py
@@ -1,6 +1,11 @@
 from typing import Optional, Union
 
-from quixstreams.sinks import BatchingSink, SinkBackpressureError, SinkBatch
+from quixstreams.sinks import (
+    BatchingSink,
+    ClientConnectCallback,
+    SinkBackpressureError,
+    SinkBatch,
+)
 
 from .destinations import Destination, LocalDestination
 from .formats import Format, FormatName, resolve_format
@@ -27,6 +32,7 @@ class FileSink(BatchingSink):
         directory: str = "",
         format: Union[FormatName, Format] = "json",
         destination: Optional[Destination] = None,
+        client_connect_cb: ClientConnectCallback = None,
     ) -> None:
         """Initialize the FileSink with the specified configuration.
 
@@ -36,12 +42,14 @@ class FileSink(BatchingSink):
             ("json", "parquet") or a Format instance.
         :param destination: Storage destination handler. Defaults to
             LocalDestination if not specified.
+        :param client_connect_cb: An optional callback made once a client connection
+            is established. Callback expects an Exception or None as an argument.
         """
-        super().__init__()
         self._format = resolve_format(format)
         self._client = destination or LocalDestination()
         self._client.set_directory(directory)
         self._client.set_extension(self._format)
+        super().__init__(client_connect_cb=client_connect_cb)
 
     def setup_client(self) -> Destination:
         self._client.connect()

--- a/quixstreams/sinks/community/file/sink.py
+++ b/quixstreams/sinks/community/file/sink.py
@@ -51,18 +51,18 @@ class FileSink(BatchingSink):
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
         """
-        self._format = resolve_format(format)
-        self._destination = destination or LocalDestination()
-        self._destination.set_directory(directory)
-        self._destination.set_extension(self._format)
         super().__init__(
             client_connect_success_cb=client_connect_success_cb,
             client_connect_failure_cb=client_connect_failure_cb,
         )
 
-    def setup_client(self) -> Destination:
+        self._format = resolve_format(format)
+        self._destination = destination or LocalDestination()
+        self._destination.set_directory(directory)
+        self._destination.set_extension(self._format)
+
+    def setup_client(self):
         self._destination.connect()
-        return self._destination
 
     def write(self, batch: SinkBatch) -> None:
         """Write a batch of data using the configured format and destination.

--- a/quixstreams/sinks/community/file/sink.py
+++ b/quixstreams/sinks/community/file/sink.py
@@ -49,14 +49,14 @@ class FileSink(BatchingSink):
             If used, errors must be resolved (or propagated) with the callback.
         """
         self._format = resolve_format(format)
-        self._client = destination or LocalDestination()
-        self._client.set_directory(directory)
-        self._client.set_extension(self._format)
+        self._destination = destination or LocalDestination()
+        self._destination.set_directory(directory)
+        self._destination.set_extension(self._format)
         super().__init__(client_connect_cb=client_connect_cb)
 
     def setup_client(self) -> Destination:
-        self._client.connect()
-        return self._client
+        self._destination.connect()
+        return self._destination
 
     def write(self, batch: SinkBatch) -> None:
         """Write a batch of data using the configured format and destination.
@@ -73,7 +73,7 @@ class FileSink(BatchingSink):
         data = self._format.serialize(batch)
 
         try:
-            self._client.write(data, batch)
+            self._destination.write(data, batch)
         except Exception as e:
             raise SinkBackpressureError(
                 retry_after=5.0,

--- a/quixstreams/sinks/community/file/sink.py
+++ b/quixstreams/sinks/community/file/sink.py
@@ -61,8 +61,8 @@ class FileSink(BatchingSink):
         self._destination.set_directory(directory)
         self._destination.set_extension(self._format)
 
-    def setup_client(self):
-        self._destination.connect()
+    def setup(self):
+        self._destination.setup()
 
     def write(self, batch: SinkBatch) -> None:
         """Write a batch of data using the configured format and destination.

--- a/quixstreams/sinks/community/iceberg.py
+++ b/quixstreams/sinks/community/iceberg.py
@@ -9,7 +9,8 @@ from typing import Literal, Optional, Type, get_args
 
 from quixstreams.sinks import (
     BatchingSink,
-    ClientConnectCallback,
+    ClientConnectFailureCallback,
+    ClientConnectSuccessCallback,
     SinkBackpressureError,
     SinkBatch,
 )
@@ -103,8 +104,12 @@ class IcebergSink(BatchingSink):
     :param schema: The Iceberg table schema. If None, a default schema is used.
     :param partition_spec: The partition specification for the table.
         If None, a default is used.
-    :param client_connect_cb: An optional callback made once a client connection
-        is established. Callback expects an Exception or None as an argument.
+    :param client_connect_success_cb: An optional callback made after successful
+        client authentication, primarily for additional logging.
+    :param client_connect_failure_cb: An optional callback made after failed
+        client authentication (which should raise an Exception).
+        Callback should accept the raised Exception as an argument.
+        Callback must resolve (or propagate/re-raise) the Exception.
 
     Example setup using an AWS-hosted Iceberg with AWS Glue:
 
@@ -147,9 +152,13 @@ class IcebergSink(BatchingSink):
         data_catalog_spec: DataCatalogSpec,
         schema: Optional[Schema] = None,
         partition_spec: Optional[PartitionSpec] = None,
-        client_connect_cb: ClientConnectCallback = None,
+        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
+        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
     ):
-        super().__init__(client_connect_cb=client_connect_cb)
+        super().__init__(
+            client_connect_success_cb=client_connect_success_cb,
+            client_connect_failure_cb=client_connect_failure_cb,
+        )
 
         self._iceberg_config = config
         self._table_name = table_name

--- a/quixstreams/sinks/community/iceberg.py
+++ b/quixstreams/sinks/community/iceberg.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from importlib import import_module
 from io import BytesIO
-from typing import Literal, Optional, Type, get_args
+from typing import Callable, Literal, Optional, Type, get_args
 
 from quixstreams.sinks import BatchingSink, SinkBackpressureError, SinkBatch
 
@@ -16,6 +16,7 @@ try:
     from pyiceberg.exceptions import CommitFailedException
     from pyiceberg.partitioning import PartitionField, PartitionSpec
     from pyiceberg.schema import NestedField, Schema
+    from pyiceberg.table import Table
     from pyiceberg.transforms import DayTransform, IdentityTransform
     from pyiceberg.types import StringType, TimestampType
 except ImportError as exc:
@@ -97,6 +98,8 @@ class IcebergSink(BatchingSink):
     :param schema: The Iceberg table schema. If None, a default schema is used.
     :param partition_spec: The partition specification for the table.
         If None, a default is used.
+    :param client_connect_cb: An optional callback made once a client connection
+        is established. Callback expects an Exception or None as an argument.
 
     Example setup using an AWS-hosted Iceberg with AWS Glue:
 
@@ -139,37 +142,45 @@ class IcebergSink(BatchingSink):
         data_catalog_spec: DataCatalogSpec,
         schema: Optional[Schema] = None,
         partition_spec: Optional[PartitionSpec] = None,
+        client_connect_cb: Optional[Callable[[Optional[Exception]], None]] = None,
     ):
-        super().__init__()
-        self.iceberg_config = config
+        self._iceberg_config = config
+        self._table_name = table_name
+        self._table: Optional[Table] = None
 
         # Configure Iceberg Catalog
         data_catalog_cls = _import_data_catalog(data_catalog_spec)
         self.data_catalog = data_catalog_cls(
             name=f"{data_catalog_spec}_catalog",
-            **self.iceberg_config.auth,
+            **self._iceberg_config.auth,
         )
 
         # Set up the schema.
-        if schema is None:
-            # Use a default schema if none is provided.
-            schema = self._get_default_schema()
+        self._schema = schema if schema is not None else self._get_default_schema()
 
         # Set up the partition specification.
-        if partition_spec is None:
-            partition_spec = self._get_default_partition_spec(schema=schema)
+        self._partition_spec = (
+            partition_spec
+            if partition_spec is not None
+            else self._get_default_partition_spec(self._schema)
+        )
 
+        super().__init__(client_connect_cb=client_connect_cb)
+
+    def setup_client(self):
         # Create the Iceberg table if it doesn't exist.
-        self.table = self.data_catalog.create_table_if_not_exists(
-            identifier=table_name,
-            schema=schema,
-            location=self.iceberg_config.location,
-            partition_spec=partition_spec,
+        self._table = self.data_catalog.create_table_if_not_exists(
+            identifier=self._table_name,
+            schema=self._schema,
+            location=self._iceberg_config.location,
+            partition_spec=self._partition_spec,
             properties={"write.distribution-mode": "fanout"},
         )
         logger.info(
-            f"Loaded Iceberg table '{table_name}' at '{self.iceberg_config.location}'."
+            f"Loaded Iceberg table '{self._table_name}' at "
+            f"'{self._iceberg_config.location}'."
         )
+        return
 
     def write(self, batch: SinkBatch):
         """
@@ -187,16 +198,16 @@ class IcebergSink(BatchingSink):
             parquet_table = pq.read_table(input_buffer)
 
             # Reload the table to get the latest metadata
-            self.table = self.data_catalog.load_table(self.table.name())
+            self._table = self.data_catalog.load_table(self._table.name())
 
             # Update the table schema if necessary.
-            with self.table.update_schema() as update:
+            with self._table.update_schema() as update:
                 update.union_by_name(parquet_table.schema)
 
             append_start_epoch = time.time()
-            self.table.append(parquet_table)
+            self._table.append(parquet_table)
             logger.info(
-                f"Appended {batch.size} records to {self.table.name()} table "
+                f"Appended {batch.size} records to {self._table.name()} table "
                 f"in {time.time() - append_start_epoch}s."
             )
 

--- a/quixstreams/sinks/community/iceberg.py
+++ b/quixstreams/sinks/community/iceberg.py
@@ -181,7 +181,7 @@ class IcebergSink(BatchingSink):
             else self._get_default_partition_spec(self._schema)
         )
 
-    def setup_client(self):
+    def setup(self):
         # Our client is an interface for a table, so for the sake of
         # readability, the client will be called "_table"
         self._table = self.data_catalog.create_table_if_not_exists(

--- a/quixstreams/sinks/community/iceberg.py
+++ b/quixstreams/sinks/community/iceberg.py
@@ -104,9 +104,9 @@ class IcebergSink(BatchingSink):
     :param schema: The Iceberg table schema. If None, a default schema is used.
     :param partition_spec: The partition specification for the table.
         If None, a default is used.
-    :param client_connect_success_cb: An optional callback made after successful
+    :param on_client_connect_success: An optional callback made after successful
         client authentication, primarily for additional logging.
-    :param client_connect_failure_cb: An optional callback made after failed
+    :param on_client_connect_failure: An optional callback made after failed
         client authentication (which should raise an Exception).
         Callback should accept the raised Exception as an argument.
         Callback must resolve (or propagate/re-raise) the Exception.
@@ -152,12 +152,12 @@ class IcebergSink(BatchingSink):
         data_catalog_spec: DataCatalogSpec,
         schema: Optional[Schema] = None,
         partition_spec: Optional[PartitionSpec] = None,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ):
         super().__init__(
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         self._iceberg_config = config

--- a/quixstreams/sinks/community/iceberg.py
+++ b/quixstreams/sinks/community/iceberg.py
@@ -195,7 +195,6 @@ class IcebergSink(BatchingSink):
             f"Loaded Iceberg table '{self._table_name}' at "
             f"'{self._iceberg_config.location}'."
         )
-        return
 
     def write(self, batch: SinkBatch):
         """

--- a/quixstreams/sinks/community/kinesis.py
+++ b/quixstreams/sinks/community/kinesis.py
@@ -39,8 +39,8 @@ class KinesisSink(BaseSink):
         aws_endpoint_url: Optional[str] = getenv("AWS_ENDPOINT_URL_KINESIS"),
         value_serializer: Callable[[Any], str] = json.dumps,
         key_serializer: Callable[[Any], str] = bytes.decode,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
         **kwargs,
     ) -> None:
         """
@@ -55,16 +55,16 @@ class KinesisSink(BaseSink):
         :param key_serializer: Function to serialize the key to string
             (defaults to bytes.decode).
         :param kwargs: Additional keyword arguments passed to boto3.client.
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
         """
         super().__init__(
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         self._client: Optional[KinesisClient] = None

--- a/quixstreams/sinks/community/kinesis.py
+++ b/quixstreams/sinks/community/kinesis.py
@@ -87,7 +87,7 @@ class KinesisSink(BaseSink):
         # that records are sent in order at the expense of throughput.
         self._executor = ThreadPoolExecutor(max_workers=1)
 
-    def setup_client(self):
+    def setup(self):
         self._client = boto3.client("kinesis", **self._credentials)
 
         # Check if the Kinesis stream exists

--- a/quixstreams/sinks/community/kinesis.py
+++ b/quixstreams/sinks/community/kinesis.py
@@ -50,8 +50,11 @@ class KinesisSink(BaseSink):
         :param key_serializer: Function to serialize the key to string
             (defaults to bytes.decode).
         :param kwargs: Additional keyword arguments passed to boto3.client.
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         """
         super().__init__(client_connect_cb=client_connect_cb)
 

--- a/quixstreams/sinks/community/postgresql.py
+++ b/quixstreams/sinks/community/postgresql.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Mapping
 
 try:
     import psycopg2
@@ -15,7 +15,7 @@ except ImportError as exc:
 
 from quixstreams.exceptions import QuixException
 from quixstreams.models import HeadersTuples
-from quixstreams.sinks import BatchingSink, SinkBatch
+from quixstreams.sinks import BatchingSink, ClientConnectCallback, SinkBatch
 
 __all__ = ("PostgreSQLSink", "PostgreSQLSinkException")
 
@@ -57,7 +57,7 @@ class PostgreSQLSink(BatchingSink):
         schema_auto_update: bool = True,
         connection_timeout_seconds: int = 30,
         statement_timeout_seconds: int = 30,
-        client_connect_cb: Optional[Callable[[Optional[Exception]], None]] = None,
+        client_connect_cb: ClientConnectCallback = None,
         **kwargs,
     ):
         """
@@ -77,6 +77,8 @@ class PostgreSQLSink(BatchingSink):
             is established. Callback expects an Exception or None as an argument.
         :param kwargs: Additional parameters for `psycopg2.connect`.
         """
+        super().__init__(client_connect_cb=client_connect_cb)
+
         self.table_name = table_name
         self.schema_auto_update = schema_auto_update
         options = kwargs.pop("options", "")
@@ -93,7 +95,6 @@ class PostgreSQLSink(BatchingSink):
             **kwargs,
         }
         self._client = None
-        super().__init__(client_connect_cb=client_connect_cb)
 
     def setup_client(self):
         self._client = psycopg2.connect(**self._client_settings)

--- a/quixstreams/sinks/community/postgresql.py
+++ b/quixstreams/sinks/community/postgresql.py
@@ -109,7 +109,7 @@ class PostgreSQLSink(BatchingSink):
         }
         self._client = None
 
-    def setup_client(self):
+    def setup(self):
         self._client = psycopg2.connect(**self._client_settings)
 
         # Initialize table if schema_auto_update is enabled

--- a/quixstreams/sinks/community/postgresql.py
+++ b/quixstreams/sinks/community/postgresql.py
@@ -73,8 +73,11 @@ class PostgreSQLSink(BatchingSink):
         :param connection_timeout_seconds: Timeout for connection.
         :param statement_timeout_seconds: Timeout for DDL operations such as table
             creation or schema updates.
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         :param kwargs: Additional parameters for `psycopg2.connect`.
         """
         super().__init__(client_connect_cb=client_connect_cb)

--- a/quixstreams/sinks/community/postgresql.py
+++ b/quixstreams/sinks/community/postgresql.py
@@ -62,8 +62,8 @@ class PostgreSQLSink(BatchingSink):
         schema_auto_update: bool = True,
         connection_timeout_seconds: int = 30,
         statement_timeout_seconds: int = 30,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
         **kwargs,
     ):
         """
@@ -79,17 +79,17 @@ class PostgreSQLSink(BatchingSink):
         :param connection_timeout_seconds: Timeout for connection.
         :param statement_timeout_seconds: Timeout for DDL operations such as table
             creation or schema updates.
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
         :param kwargs: Additional parameters for `psycopg2.connect`.
         """
         super().__init__(
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         self.table_name = table_name

--- a/quixstreams/sinks/community/pubsub.py
+++ b/quixstreams/sinks/community/pubsub.py
@@ -93,7 +93,7 @@ class PubSubSink(BaseSink):
         self._client: Optional[pubsub_v1.PublisherClient] = None
         self._topic: Optional[str] = None
 
-    def setup_client(self):
+    def setup(self):
         self._client = pubsub_v1.PublisherClient(**self._client_settings)
         self._topic = self._client.topic_path(self._project_id, self._topic_id)
         try:

--- a/quixstreams/sinks/community/pubsub.py
+++ b/quixstreams/sinks/community/pubsub.py
@@ -42,8 +42,8 @@ class PubSubSink(BaseSink):
         value_serializer: Callable[[Any], Union[bytes, str]] = json.dumps,
         key_serializer: Callable[[Any], str] = bytes.decode,
         flush_timeout: int = 5,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
         **kwargs,
     ) -> None:
         """
@@ -60,17 +60,17 @@ class PubSubSink(BaseSink):
             (defaults to json.dumps).
         :param key_serializer: Function to serialize the key to string
             (defaults to bytes.decode).
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
         :param kwargs: Additional keyword arguments passed to PublisherClient.
         """
         super().__init__(
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         # Parse the service account credentials from JSON

--- a/quixstreams/sinks/community/pubsub.py
+++ b/quixstreams/sinks/community/pubsub.py
@@ -58,8 +58,11 @@ class PubSubSink(BaseSink):
             (defaults to json.dumps).
         :param key_serializer: Function to serialize the key to string
             (defaults to bytes.decode).
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         :param kwargs: Additional keyword arguments passed to PublisherClient.
         """
         super().__init__(client_connect_cb=client_connect_cb)

--- a/quixstreams/sinks/community/redis.py
+++ b/quixstreams/sinks/community/redis.py
@@ -33,8 +33,8 @@ class RedisSink(BatchingSink):
         key_serializer: Optional[Callable[[Any, Any], Union[bytes, str]]] = None,
         password: Optional[str] = None,
         socket_timeout: float = 30.0,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
         **kwargs,
     ) -> None:
         """
@@ -51,17 +51,17 @@ class RedisSink(BatchingSink):
         :param password: Redis password, optional.
         :param socket_timeout: Redis socket timeout.
             Default - 30s.
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
         :param kwargs: Additional keyword arguments passed to the `redis.Redis` instance.
         """
         super().__init__(
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         self._key_serializer = key_serializer

--- a/quixstreams/sinks/community/redis.py
+++ b/quixstreams/sinks/community/redis.py
@@ -81,7 +81,7 @@ class RedisSink(BatchingSink):
             f"{self._client_settings['db']}"
         )
 
-    def setup_client(self):
+    def setup(self):
         self._client = redis.Redis(**self._client_settings)
         self._client.info()
 

--- a/quixstreams/sinks/community/redis.py
+++ b/quixstreams/sinks/community/redis.py
@@ -66,7 +66,6 @@ class RedisSink(BatchingSink):
 
         self._key_serializer = key_serializer
         self._value_serializer = value_serializer
-        self._redis_uri: Optional[str] = None
         self._client: Optional[redis.Redis] = None
         self._client_settings = {
             "host": host,
@@ -76,13 +75,13 @@ class RedisSink(BatchingSink):
             "socket_timeout": socket_timeout,
             **kwargs,
         }
-
-    def setup_client(self):
         self._redis_uri = (
             f"{self._client_settings['host']}:"
             f"{self._client_settings['port']}/"
             f"{self._client_settings['db']}"
         )
+
+    def setup_client(self):
         self._client = redis.Redis(**self._client_settings)
         self._client.info()
 

--- a/quixstreams/sinks/community/redis.py
+++ b/quixstreams/sinks/community/redis.py
@@ -45,8 +45,11 @@ class RedisSink(BatchingSink):
         :param password: Redis password, optional.
         :param socket_timeout: Redis socket timeout.
             Default - 30s.
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         :param kwargs: Additional keyword arguments passed to the `redis.Redis` instance.
         """
         super().__init__(client_connect_cb=client_connect_cb)

--- a/quixstreams/sinks/community/redis.py
+++ b/quixstreams/sinks/community/redis.py
@@ -11,7 +11,7 @@ except ImportError as exc:
         'run "pip install quixstreams[redis]" to use RedisSink'
     ) from exc
 
-from quixstreams.sinks import BatchingSink, SinkBatch
+from quixstreams.sinks import BatchingSink, ClientConnectCallback, SinkBatch
 
 __all__ = ("RedisSink",)
 
@@ -28,7 +28,7 @@ class RedisSink(BatchingSink):
         key_serializer: Optional[Callable[[Any, Any], Union[bytes, str]]] = None,
         password: Optional[str] = None,
         socket_timeout: float = 30.0,
-        client_connect_cb: Optional[Callable[[Optional[Exception]], None]] = None,
+        client_connect_cb: ClientConnectCallback = None,
         **kwargs,
     ) -> None:
         """
@@ -49,6 +49,8 @@ class RedisSink(BatchingSink):
             is established. Callback expects an Exception or None as an argument.
         :param kwargs: Additional keyword arguments passed to the `redis.Redis` instance.
         """
+        super().__init__(client_connect_cb=client_connect_cb)
+
         self._key_serializer = key_serializer
         self._value_serializer = value_serializer
         self._redis_uri: Optional[str] = None
@@ -61,8 +63,6 @@ class RedisSink(BatchingSink):
             "socket_timeout": socket_timeout,
             **kwargs,
         }
-
-        super().__init__(client_connect_cb=client_connect_cb)
 
     def setup_client(self):
         self._redis_uri = (

--- a/quixstreams/sinks/core/csv.py
+++ b/quixstreams/sinks/core/csv.py
@@ -36,7 +36,7 @@ class CSVSink(BatchingSink):
         self._key_serializer = key_serializer
         self._value_serializer = value_serializer
 
-    def setup_client(self):
+    def setup(self):
         return
 
     def write(self, batch: SinkBatch):

--- a/quixstreams/sinks/core/csv.py
+++ b/quixstreams/sinks/core/csv.py
@@ -36,6 +36,9 @@ class CSVSink(BatchingSink):
         self._key_serializer = key_serializer
         self._value_serializer = value_serializer
 
+    def setup_client(self):
+        return
+
     def write(self, batch: SinkBatch):
         is_new = not os.path.exists(self.path)
         fieldnames = (

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -194,7 +194,7 @@ class InfluxDB3Sink(BatchingSink):
             return setter
         return lambda value: setter
 
-    def setup_client(self):
+    def setup(self):
         self._client = InfluxDBClient3(**self._client_args)
         try:
             # We cannot safely parameterize the table (measurement) selection, so

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -123,8 +123,11 @@ class InfluxDB3Sink(BatchingSink):
             Default - `10000`.
         :param debug: if True, print debug logs from InfluxDB client.
             Default - `False`.
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         """
 
         super().__init__(client_connect_cb=client_connect_cb)

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -65,8 +65,8 @@ class InfluxDB3Sink(BatchingSink):
         enable_gzip: bool = True,
         request_timeout_ms: int = 10_000,
         debug: bool = False,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ):
         """
         A connector to sink processed data to InfluxDB v3.
@@ -129,17 +129,17 @@ class InfluxDB3Sink(BatchingSink):
             Default - `10000`.
         :param debug: if True, print debug logs from InfluxDB client.
             Default - `False`.
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
         """
 
         super().__init__(
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         if time_precision not in (time_args := get_args(TimePrecision)):

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -1,8 +1,7 @@
 import logging
 import sys
 import time
-import typing
-from typing import Any, Iterable, Literal, Mapping, Optional, Union
+from typing import Any, Callable, Iterable, Literal, Mapping, Optional, Union, get_args
 
 from quixstreams.models import HeadersTuples
 
@@ -143,7 +142,7 @@ class InfluxDB3Sink(BatchingSink):
             client_connect_failure_cb=client_connect_failure_cb,
         )
 
-        if time_precision not in (time_args := typing.get_args(TimePrecision)):
+        if time_precision not in (time_args := get_args(TimePrecision)):
             raise ValueError(
                 f"Invalid 'time_precision' argument {time_precision}; "
                 f"valid options: {time_args}"
@@ -194,7 +193,6 @@ class InfluxDB3Sink(BatchingSink):
         if callable(setter):
             return setter
         return lambda value: setter
-        super().__init__(client_connect_cb=client_connect_cb)
 
     def setup_client(self):
         self._client = InfluxDBClient3(**self._client_args)

--- a/quixstreams/sources/__init__.py
+++ b/quixstreams/sources/__init__.py
@@ -1,6 +1,7 @@
 from .base import (
     BaseSource,
-    ClientConnectCallback,
+    ClientConnectFailureCallback,
+    ClientConnectSuccessCallback,
     Source,
     SourceException,
     SourceManager,
@@ -12,7 +13,8 @@ from .core.kafka import KafkaReplicatorSource, QuixEnvironmentSource
 
 __all__ = [
     "BaseSource",
-    "ClientConnectCallback",
+    "ClientConnectSuccessCallback",
+    "ClientConnectFailureCallback",
     "CSVSource",
     "KafkaReplicatorSource",
     "multiprocessing",

--- a/quixstreams/sources/__init__.py
+++ b/quixstreams/sources/__init__.py
@@ -1,5 +1,6 @@
 from .base import (
     BaseSource,
+    ClientConnectCallback,
     Source,
     SourceException,
     SourceManager,
@@ -11,6 +12,7 @@ from .core.kafka import KafkaReplicatorSource, QuixEnvironmentSource
 
 __all__ = [
     "BaseSource",
+    "ClientConnectCallback",
     "CSVSource",
     "KafkaReplicatorSource",
     "multiprocessing",

--- a/quixstreams/sources/base/__init__.py
+++ b/quixstreams/sources/base/__init__.py
@@ -1,7 +1,13 @@
 from .exceptions import SourceException
 from .manager import SourceManager
 from .multiprocessing import multiprocessing
-from .source import BaseSource, ClientConnectCallback, Source, StatefulSource
+from .source import (
+    BaseSource,
+    ClientConnectFailureCallback,
+    ClientConnectSuccessCallback,
+    Source,
+    StatefulSource,
+)
 
 __all__ = (
     "Source",
@@ -10,5 +16,6 @@ __all__ = (
     "SourceManager",
     "SourceException",
     "StatefulSource",
-    "ClientConnectCallback",
+    "ClientConnectSuccessCallback",
+    "ClientConnectFailureCallback",
 )

--- a/quixstreams/sources/base/__init__.py
+++ b/quixstreams/sources/base/__init__.py
@@ -1,7 +1,7 @@
 from .exceptions import SourceException
 from .manager import SourceManager
 from .multiprocessing import multiprocessing
-from .source import BaseSource, Source, StatefulSource
+from .source import BaseSource, ClientConnectCallback, Source, StatefulSource
 
 __all__ = (
     "Source",
@@ -10,4 +10,5 @@ __all__ = (
     "SourceManager",
     "SourceException",
     "StatefulSource",
+    "ClientConnectCallback",
 )

--- a/quixstreams/sources/base/source.py
+++ b/quixstreams/sources/base/source.py
@@ -98,6 +98,7 @@ class BaseSource(ABC):
         finally:
             if cb := self._client_connect_cb:
                 cb(error)
+            # Only raise if no callback; callback could intentionally supress errors
             elif error:
                 raise error
 
@@ -157,7 +158,7 @@ class BaseSource(ABC):
         """
 
 
-class Source(BaseSource, ABC):
+class Source(BaseSource):
     """
     A base class for custom Sources that provides a basic implementation of `BaseSource`
     interface.
@@ -361,7 +362,7 @@ class Source(BaseSource, ABC):
         return self.name
 
 
-class StatefulSource(Source, ABC):
+class StatefulSource(Source):
     """
     A `Source` class for custom Sources that need a state.
 

--- a/quixstreams/sources/base/source.py
+++ b/quixstreams/sources/base/source.py
@@ -216,8 +216,11 @@ class Source(BaseSource, ABC):
         """
         :param name: The source unique name. It is used to generate the topic configuration.
         :param shutdown_timeout: Time in second the application waits for the source to gracefully shutdown.
-        :param client_connect_cb: An optional callback made once a client connection is established.
-            Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         """
         super().__init__(client_connect_cb=client_connect_cb)
 

--- a/quixstreams/sources/base/source.py
+++ b/quixstreams/sources/base/source.py
@@ -107,7 +107,7 @@ class BaseSource(ABC):
 
     def _init_client(self):
         try:
-            self.setup_client()
+            self.setup()
             self._client_connect_success_cb()
         except Exception as e:
             self._client_connect_failure_cb(e)
@@ -161,7 +161,7 @@ class BaseSource(ABC):
         """
 
     @abstractmethod
-    def setup_client(self):
+    def setup(self):
         """
         When applicable, set up the client here along with any validation to affirm a
         valid/successful authentication/connection.

--- a/quixstreams/sources/community/file/file.py
+++ b/quixstreams/sources/community/file/file.py
@@ -140,8 +140,8 @@ class FileSource(Source):
         replay_speed: float = 1.0,
         name: Optional[str] = None,
         shutdown_timeout: float = 30,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ):
         """
         :param directory: a directory to recursively read through; it is recommended to
@@ -158,9 +158,9 @@ class FileSource(Source):
         :param name: The name of the Source application (Default: last folder name).
         :param shutdown_timeout: Time in seconds the application waits for the source
             to gracefully shutdown
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
@@ -169,8 +169,8 @@ class FileSource(Source):
         super().__init__(
             name=name or self._directory.name,
             shutdown_timeout=shutdown_timeout,
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         if not replay_speed >= 0:

--- a/quixstreams/sources/community/file/file.py
+++ b/quixstreams/sources/community/file/file.py
@@ -153,8 +153,11 @@ class FileSource(Source):
         :param name: The name of the Source application (Default: last folder name).
         :param shutdown_timeout: Time in seconds the application waits for the source
             to gracefully shutdown
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         """
         self._directory = Path(directory)
         super().__init__(

--- a/quixstreams/sources/community/file/file.py
+++ b/quixstreams/sources/community/file/file.py
@@ -235,7 +235,7 @@ class FileSource(Source):
             self._file_fetcher.stop()
         super().stop()
 
-    def setup_client(self):
+    def setup(self):
         self._origin = self._origin.__enter__()
 
     def run(self):

--- a/quixstreams/sources/community/file/origins/base.py
+++ b/quixstreams/sources/community/file/origins/base.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import BinaryIO, Iterable
 
+from typing_extensions import Self
+
 __all__ = ("Origin",)
 
 
@@ -34,3 +36,9 @@ class Origin(ABC):
     
     Result should be ready for deserialization (and/or decompression).
     """
+
+    @abstractmethod
+    def __enter__(self) -> Self: ...
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_val, exc_tb): ...

--- a/quixstreams/sources/community/file/origins/local.py
+++ b/quixstreams/sources/community/file/origins/local.py
@@ -2,6 +2,8 @@ from io import BytesIO
 from pathlib import Path
 from typing import Generator
 
+from typing_extensions import Self
+
 from .base import Origin
 
 __all__ = ("LocalOrigin",)
@@ -20,3 +22,9 @@ class LocalOrigin(Origin):
 
     def get_raw_file_stream(self, filepath: Path) -> BytesIO:
         return BytesIO(filepath.read_bytes())
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass

--- a/quixstreams/sources/community/kinesis/consumer.py
+++ b/quixstreams/sources/community/kinesis/consumer.py
@@ -108,15 +108,14 @@ class KinesisConsumer:
         self._checkpointer.commit(force=force)
 
     def __enter__(self) -> Self:
-        self._init_client()
-        self._init_shards()
+        if not self._client:
+            self._client = boto3.client("kinesis", **self._credentials)
+            self._init_shards()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-    def _init_client(self):
-        self._client = boto3.client("kinesis", **self._credentials)
+        if self._client:
+            self._client.close()
 
     def _list_shards(self) -> list[ShardTypeDef]:
         """List all shards in the stream."""

--- a/quixstreams/sources/community/kinesis/kinesis.py
+++ b/quixstreams/sources/community/kinesis/kinesis.py
@@ -142,7 +142,7 @@ class KinesisSource(StatefulSource):
             timestamp=serialized_msg.timestamp,
         )
 
-    def setup_client(self):
+    def setup(self):
         self._client = KinesisConsumer(
             stream_name=self._stream_name,
             credentials=self._credentials,

--- a/quixstreams/sources/community/kinesis/kinesis.py
+++ b/quixstreams/sources/community/kinesis/kinesis.py
@@ -70,8 +70,8 @@ class KinesisSource(StatefulSource):
         max_records_per_shard: int = 1000,
         commit_interval: float = 5.0,
         retry_backoff_secs: float = 5.0,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ):
         """
         :param stream_name: name of the desired Kinesis stream to consume.
@@ -92,9 +92,9 @@ class KinesisSource(StatefulSource):
         :param commit_interval: the time between commits
         :param retry_backoff_secs: how long to back off from doing HTTP calls for a
              shard when Kinesis consumer encounters handled/expected errors.
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
@@ -102,8 +102,8 @@ class KinesisSource(StatefulSource):
         super().__init__(
             name=f"kinesis_{stream_name}",
             shutdown_timeout=shutdown_timeout,
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         self._stream_name = stream_name

--- a/quixstreams/sources/community/kinesis/kinesis.py
+++ b/quixstreams/sources/community/kinesis/kinesis.py
@@ -87,8 +87,11 @@ class KinesisSource(StatefulSource):
         :param commit_interval: the time between commits
         :param retry_backoff_secs: how long to back off from doing HTTP calls for a
              shard when Kinesis consumer encounters handled/expected errors.
-        :param client_connect_cb: An optional callback made once a client connection
-             is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         """
         super().__init__(
             name=f"kinesis_{stream_name}",

--- a/quixstreams/sources/community/pandas.py
+++ b/quixstreams/sources/community/pandas.py
@@ -60,6 +60,10 @@ class PandasDataFrameSource(Source):
 
         super().__init__(name=name, shutdown_timeout=shutdown_timeout)
 
+    def setup(self):
+        # nothing client related to set up
+        return
+
     def _get_key_column(self, col_name: str) -> str:
         """
         Validates the key column.

--- a/quixstreams/sources/community/pubsub/pubsub.py
+++ b/quixstreams/sources/community/pubsub/pubsub.py
@@ -132,7 +132,7 @@ class PubSubSource(Source):
             headers=dict(message.attributes),
         )
 
-    def setup_client(self):
+    def setup(self):
         self._client = PubSubConsumer(
             credentials=self._credentials,
             project_id=self._project_id,

--- a/quixstreams/sources/community/pubsub/pubsub.py
+++ b/quixstreams/sources/community/pubsub/pubsub.py
@@ -3,7 +3,11 @@ import logging
 from typing import Optional
 
 from quixstreams.models import Topic
-from quixstreams.sources import ClientConnectCallback, Source
+from quixstreams.sources import (
+    ClientConnectFailureCallback,
+    ClientConnectSuccessCallback,
+    Source,
+)
 
 from .consumer import PubSubConsumer, PubSubMessage
 
@@ -63,7 +67,8 @@ class PubSubSource(Source):
         create_subscription: bool = False,
         enable_message_ordering: bool = False,
         shutdown_timeout: float = 10.0,
-        client_connect_cb: ClientConnectCallback = None,
+        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
+        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
     ):
         """
         :param project_id: a Google Cloud project ID.
@@ -80,16 +85,18 @@ class PubSubSource(Source):
         :param enable_message_ordering: When creating a Pub/Sub subscription, whether
             to allow message ordering. NOTE: does NOT affect existing subscriptions!
         :param shutdown_timeout: How long to wait for a graceful shutdown of the source.
-        :param client_connect_cb: An optional callback made after attempting client
-            authentication, primarily for additional logging.
-            It should accept a single argument, which will be populated with an
-            Exception if connecting failed (else None).
-            If used, errors must be resolved (or propagated) with the callback.
+        :param client_connect_success_cb: An optional callback made after successful
+            client authentication, primarily for additional logging.
+        :param client_connect_failure_cb: An optional callback made after failed
+            client authentication (which should raise an Exception).
+            Callback should accept the raised Exception as an argument.
+            Callback must resolve (or propagate/re-raise) the Exception.
         """
         super().__init__(
             name=subscription_id,
             shutdown_timeout=shutdown_timeout,
-            client_connect_cb=client_connect_cb,
+            client_connect_success_cb=client_connect_success_cb,
+            client_connect_failure_cb=client_connect_failure_cb,
         )
 
         self._credentials = service_account_json

--- a/quixstreams/sources/community/pubsub/pubsub.py
+++ b/quixstreams/sources/community/pubsub/pubsub.py
@@ -80,8 +80,11 @@ class PubSubSource(Source):
         :param enable_message_ordering: When creating a Pub/Sub subscription, whether
             to allow message ordering. NOTE: does NOT affect existing subscriptions!
         :param shutdown_timeout: How long to wait for a graceful shutdown of the source.
-        :param client_connect_cb: An optional callback made once a client connection
-             is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         """
         super().__init__(
             name=subscription_id,

--- a/quixstreams/sources/community/pubsub/pubsub.py
+++ b/quixstreams/sources/community/pubsub/pubsub.py
@@ -116,8 +116,8 @@ class PubSubSource(Source):
             headers=dict(message.attributes),
         )
 
-    def run(self):
-        with PubSubConsumer(
+    def setup_client(self):
+        self._client = PubSubConsumer(
             credentials=self._credentials,
             project_id=self._project_id,
             topic_id=self._topic_id,
@@ -127,7 +127,10 @@ class PubSubSource(Source):
             async_function=self._handle_pubsub_message,
             max_batch_size=self._commit_every,
             batch_timeout_secs=self._commit_interval,
-        ) as consumer:
+        ).__enter__()
+
+    def run(self):
+        with self._client as consumer:
             while self._running:
                 consumer.poll_and_process_batch()
                 self.flush()

--- a/quixstreams/sources/community/pubsub/pubsub.py
+++ b/quixstreams/sources/community/pubsub/pubsub.py
@@ -67,8 +67,8 @@ class PubSubSource(Source):
         create_subscription: bool = False,
         enable_message_ordering: bool = False,
         shutdown_timeout: float = 10.0,
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ):
         """
         :param project_id: a Google Cloud project ID.
@@ -85,9 +85,9 @@ class PubSubSource(Source):
         :param enable_message_ordering: When creating a Pub/Sub subscription, whether
             to allow message ordering. NOTE: does NOT affect existing subscriptions!
         :param shutdown_timeout: How long to wait for a graceful shutdown of the source.
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
@@ -95,8 +95,8 @@ class PubSubSource(Source):
         super().__init__(
             name=subscription_id,
             shutdown_timeout=shutdown_timeout,
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         self._credentials = service_account_json

--- a/quixstreams/sources/core/csv.py
+++ b/quixstreams/sources/core/csv.py
@@ -52,6 +52,9 @@ class CSVSource(Source):
 
         super().__init__(name=name, shutdown_timeout=shutdown_timeout)
 
+    def setup_client(self):
+        return
+
     def run(self):
         # Start reading the file
         with open(self.path, "r") as f:

--- a/quixstreams/sources/core/csv.py
+++ b/quixstreams/sources/core/csv.py
@@ -52,7 +52,7 @@ class CSVSource(Source):
 
         super().__init__(name=name, shutdown_timeout=shutdown_timeout)
 
-    def setup_client(self):
+    def setup(self):
         return
 
     def run(self):

--- a/quixstreams/sources/core/kafka/kafka.py
+++ b/quixstreams/sources/core/kafka/kafka.py
@@ -66,8 +66,8 @@ class KafkaReplicatorSource(Source):
         on_consumer_error: ConsumerErrorCallback = default_on_consumer_error,
         value_deserializer: DeserializerType = "json",
         key_deserializer: DeserializerType = "bytes",
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ) -> None:
         """
         :param name: The source unique name.
@@ -90,9 +90,9 @@ class KafkaReplicatorSource(Source):
             Default - `json`
         :param key_deserializer: The default topic key deserializer, used by StreamingDataframe connected to the source.
             Default - `json`
-        :param client_connect_success_cb: An optional callback made after successful
+        :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
-        :param client_connect_failure_cb: An optional callback made after failed
+        :param on_client_connect_failure: An optional callback made after failed
             client authentication (which should raise an Exception).
             Callback should accept the raised Exception as an argument.
             Callback must resolve (or propagate/re-raise) the Exception.
@@ -100,8 +100,8 @@ class KafkaReplicatorSource(Source):
         super().__init__(
             name=name,
             shutdown_timeout=shutdown_timeout,
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
         if consumer_extra_config is None:

--- a/quixstreams/sources/core/kafka/kafka.py
+++ b/quixstreams/sources/core/kafka/kafka.py
@@ -161,7 +161,9 @@ class KafkaReplicatorSource(Source):
             raise RuntimeError("source not started")
         return self._target_cluster_admin
 
-    def run(self) -> None:
+    def setup_client(self):
+        # There are several client objects to manage here, so won't return anything
+        # for self._client (or use it at all)
         logger.info(
             f'Starting the source "{self.name}" with the config: '
             f'source_broker_address="{self._broker_address}" '
@@ -208,6 +210,7 @@ class KafkaReplicatorSource(Source):
             on_revoke=self.on_revoke,
         )
 
+    def run(self) -> None:
         self.init_checkpoint()
         while self._running:
             self.producer.poll()

--- a/quixstreams/sources/core/kafka/kafka.py
+++ b/quixstreams/sources/core/kafka/kafka.py
@@ -176,7 +176,7 @@ class KafkaReplicatorSource(Source):
             raise RuntimeError("source not started")
         return self._target_cluster_admin
 
-    def setup_client(self):
+    def setup(self):
         logger.info(
             f'Starting the source "{self.name}" with the config: '
             f'source_broker_address="{self._broker_address}" '

--- a/quixstreams/sources/core/kafka/kafka.py
+++ b/quixstreams/sources/core/kafka/kafka.py
@@ -85,8 +85,11 @@ class KafkaReplicatorSource(Source):
             Default - `json`
         :param key_deserializer: The default topic key deserializer, used by StreamingDataframe connected to the source.
             Default - `json`
-        :param client_connect_cb: An optional callback made once a client connection
-            is established. Callback expects an Exception or None as an argument.
+        :param client_connect_cb: An optional callback made after attempting client
+            authentication, primarily for additional logging.
+            It should accept a single argument, which will be populated with an
+            Exception if connecting failed (else None).
+            If used, errors must be resolved (or propagated) with the callback.
         """
         super().__init__(
             name=name,

--- a/quixstreams/sources/core/kafka/quix.py
+++ b/quixstreams/sources/core/kafka/quix.py
@@ -6,7 +6,10 @@ from quixstreams.models.serializers import DeserializerType
 from quixstreams.models.topics import Topic
 from quixstreams.platforms.quix import QuixKafkaConfigsBuilder
 from quixstreams.platforms.quix.api import QuixPortalApiService
-from quixstreams.sources import ClientConnectCallback
+from quixstreams.sources import (
+    ClientConnectFailureCallback,
+    ClientConnectSuccessCallback,
+)
 
 from .kafka import KafkaReplicatorSource
 
@@ -63,7 +66,8 @@ class QuixEnvironmentSource(KafkaReplicatorSource):
         on_consumer_error: ConsumerErrorCallback = default_on_consumer_error,
         value_deserializer: DeserializerType = "json",
         key_deserializer: DeserializerType = "bytes",
-        client_connect_cb: ClientConnectCallback = None,
+        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
+        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
     ) -> None:
         """
         :param quix_workspace_id: The Quix workspace ID of the source environment.
@@ -104,7 +108,8 @@ class QuixEnvironmentSource(KafkaReplicatorSource):
             on_consumer_error=on_consumer_error,
             value_deserializer=value_deserializer,
             key_deserializer=key_deserializer,
-            client_connect_cb=client_connect_cb,
+            client_connect_success_cb=client_connect_success_cb,
+            client_connect_failure_cb=client_connect_failure_cb,
         )
 
     @property

--- a/quixstreams/sources/core/kafka/quix.py
+++ b/quixstreams/sources/core/kafka/quix.py
@@ -6,6 +6,7 @@ from quixstreams.models.serializers import DeserializerType
 from quixstreams.models.topics import Topic
 from quixstreams.platforms.quix import QuixKafkaConfigsBuilder
 from quixstreams.platforms.quix.api import QuixPortalApiService
+from quixstreams.sources import ClientConnectCallback
 
 from .kafka import KafkaReplicatorSource
 
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from quixstreams.app import ApplicationConfig
 
 
-__all__ = ["QuixEnvironmentSource"]
+__all__ = ("QuixEnvironmentSource",)
 
 
 class QuixEnvironmentSource(KafkaReplicatorSource):
@@ -62,6 +63,7 @@ class QuixEnvironmentSource(KafkaReplicatorSource):
         on_consumer_error: ConsumerErrorCallback = default_on_consumer_error,
         value_deserializer: DeserializerType = "json",
         key_deserializer: DeserializerType = "bytes",
+        client_connect_cb: ClientConnectCallback = None,
     ) -> None:
         """
         :param quix_workspace_id: The Quix workspace ID of the source environment.
@@ -102,6 +104,7 @@ class QuixEnvironmentSource(KafkaReplicatorSource):
             on_consumer_error=on_consumer_error,
             value_deserializer=value_deserializer,
             key_deserializer=key_deserializer,
+            client_connect_cb=client_connect_cb,
         )
 
     @property

--- a/quixstreams/sources/core/kafka/quix.py
+++ b/quixstreams/sources/core/kafka/quix.py
@@ -66,8 +66,8 @@ class QuixEnvironmentSource(KafkaReplicatorSource):
         on_consumer_error: ConsumerErrorCallback = default_on_consumer_error,
         value_deserializer: DeserializerType = "json",
         key_deserializer: DeserializerType = "bytes",
-        client_connect_success_cb: Optional[ClientConnectSuccessCallback] = None,
-        client_connect_failure_cb: Optional[ClientConnectFailureCallback] = None,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ) -> None:
         """
         :param quix_workspace_id: The Quix workspace ID of the source environment.
@@ -108,8 +108,8 @@ class QuixEnvironmentSource(KafkaReplicatorSource):
             on_consumer_error=on_consumer_error,
             value_deserializer=value_deserializer,
             key_deserializer=key_deserializer,
-            client_connect_success_cb=client_connect_success_cb,
-            client_connect_failure_cb=client_connect_failure_cb,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
         )
 
     @property

--- a/tests/test_quixstreams/test_checkpointing.py
+++ b/tests/test_quixstreams/test_checkpointing.py
@@ -66,10 +66,14 @@ class BackpressuredSink(BatchingSink):
             retry_after=999, topic=batch.topic, partition=batch.partition
         )
 
+    def setup_client(self): ...
+
 
 class FailingSink(BatchingSink):
     def write(self, batch: SinkBatch):
         raise ValueError("Sink write failed")
+
+    def setup_client(self): ...
 
 
 @pytest.mark.parametrize("store_type", SUPPORTED_STORES, indirect=True)

--- a/tests/test_quixstreams/test_checkpointing.py
+++ b/tests/test_quixstreams/test_checkpointing.py
@@ -66,14 +66,14 @@ class BackpressuredSink(BatchingSink):
             retry_after=999, topic=batch.topic, partition=batch.partition
         )
 
-    def setup_client(self): ...
+    def setup(self): ...
 
 
 class FailingSink(BatchingSink):
     def write(self, batch: SinkBatch):
         raise ValueError("Sink write failed")
 
-    def setup_client(self): ...
+    def setup(self): ...
 
 
 @pytest.mark.parametrize("store_type", SUPPORTED_STORES, indirect=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -111,7 +111,7 @@ class DummySink(BatchingSink):
         super().__init__()
         self._results = []
 
-    def setup_client(self):
+    def setup(self):
         return
 
     def write(self, batch: SinkBatch):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -161,7 +161,7 @@ class DummySource(Source):
             msg = self.serialize(key=self.key, value=value)
             self.produce(value=msg.value, key=msg.key)
 
-    def setup_client(self):
+    def setup(self):
         return
 
     def cleanup(self, failed):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -111,6 +111,9 @@ class DummySink(BatchingSink):
         super().__init__()
         self._results = []
 
+    def setup_client(self):
+        return
+
     def write(self, batch: SinkBatch):
         for item in batch:
             self._results.append(item)
@@ -157,6 +160,9 @@ class DummySource(Source):
         for value in self.values:
             msg = self.serialize(key=self.key, value=value)
             self.produce(value=msg.value, key=msg.key)
+
+    def setup_client(self):
+        return
 
     def cleanup(self, failed):
         if "cleanup" in self.error_in:


### PR DESCRIPTION
## What

Provides the ability to add an optional callback for a connection attempt with a connector.

> NOTE: There are defaults that use our desired Quix Cloud log output.

A  `setup` method is now an additional requirement when constructing a new connector template. 

## How to Use

This feature is fully backwards compatible: usage does not change for users who do not wish to use the callback.

To use it, the pattern is the same across all sources and sinks:

```
from quixstreams.sinks.core.influxdb3 import InfluxDB3Sink

def client_connect_success_cb():
    print(f"CONNECTED!")

def client_connect_failure_cb(error):
    print(f"ERROR!")
    raise error

influxdb_sink = InfluxDB3Sink(
    token="BAD TOKEN",
    host="my host",
    ...,
    on_client_connect_success=client_connect_success_cb,
    on_client_connect_failure=client_connect_failure_cb,
)
```

## Other things:
- standardized some things like attributes across sources and sinks
- added minor things in order to test connections as expected (some client setups do not connect it immediately)
- fixed a few bugs here n' there