### PR TITLE
Fix default state dir for Quix apps

### DIFF
--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -63,7 +63,7 @@ _default_producer_extra_config = {"enable.idempotence": True}
 consumer_extra_config_overrides = {"partition.assignment.strategy": "range"}
 
 _default_max_poll_interval_ms = 300000
-_default_state_dir = Path("state")
+_default_state_dir = Path("/app/state") if is_quix_deployment() else Path("state")
 
 
 class TopicManagerFactory(Protocol):
@@ -241,9 +241,6 @@ class Application:
                 broker_address = ConnectionConfig(bootstrap_servers=broker_address)
         else:
             self._is_quix_app = True
-
-            if is_quix_deployment() and state_dir == _default_state_dir:
-                state_dir = Path("/app/state")
 
             if quix_config_builder:
                 quix_app_source = "Quix Config Builder"

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -38,6 +38,7 @@ from .platforms.quix import (
     QuixTopicManager,
     check_state_dir,
     check_state_management_enabled,
+    is_quix_deployment,
 )
 from .processing import PausingManager, ProcessingContext
 from .rowconsumer import RowConsumer
@@ -241,7 +242,7 @@ class Application:
         else:
             self._is_quix_app = True
 
-            if state_dir == _default_state_dir:
+            if is_quix_deployment() and state_dir == _default_state_dir:
                 state_dir = Path("/app/state")
 
             if quix_config_builder:

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -63,7 +63,6 @@ _default_producer_extra_config = {"enable.idempotence": True}
 consumer_extra_config_overrides = {"partition.assignment.strategy": "range"}
 
 _default_max_poll_interval_ms = 300000
-_default_state_dir = Path("/app/state") if is_quix_deployment() else Path("state")
 
 
 class TopicManagerFactory(Protocol):
@@ -126,7 +125,7 @@ class Application:
         commit_every: int = 0,
         consumer_extra_config: Optional[dict] = None,
         producer_extra_config: Optional[dict] = None,
-        state_dir: Union[str, Path] = _default_state_dir,
+        state_dir: Union[None, str, Path] = None,
         rocksdb_options: Optional[RocksDBOptionsType] = None,
         on_consumer_error: Optional[ConsumerErrorCallback] = None,
         on_processing_error: Optional[ProcessingErrorCallback] = None,
@@ -222,6 +221,8 @@ class Application:
         producer_extra_config = producer_extra_config or {}
         consumer_extra_config = consumer_extra_config or {}
 
+        if state_dir is None:
+            state_dir = "/app/state" if is_quix_deployment() else "state"
         state_dir = Path(state_dir)
 
         # We can't use os.getenv as defaults (and have testing work nicely)

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -62,6 +62,7 @@ _default_producer_extra_config = {"enable.idempotence": True}
 consumer_extra_config_overrides = {"partition.assignment.strategy": "range"}
 
 _default_max_poll_interval_ms = 300000
+_default_state_dir = Path("state")
 
 
 class TopicManagerFactory(Protocol):
@@ -124,7 +125,7 @@ class Application:
         commit_every: int = 0,
         consumer_extra_config: Optional[dict] = None,
         producer_extra_config: Optional[dict] = None,
-        state_dir: Union[str, Path] = Path("state"),
+        state_dir: Union[str, Path] = _default_state_dir,
         rocksdb_options: Optional[RocksDBOptionsType] = None,
         on_consumer_error: Optional[ConsumerErrorCallback] = None,
         on_processing_error: Optional[ProcessingErrorCallback] = None,
@@ -239,6 +240,9 @@ class Application:
                 broker_address = ConnectionConfig(bootstrap_servers=broker_address)
         else:
             self._is_quix_app = True
+
+            if state_dir == _default_state_dir:
+                state_dir = Path("/app/state")
 
             if quix_config_builder:
                 quix_app_source = "Quix Config Builder"

--- a/quixstreams/platforms/quix/checks.py
+++ b/quixstreams/platforms/quix/checks.py
@@ -5,7 +5,14 @@ from pathlib import Path
 from .env import QUIX_ENVIRONMENT
 
 logger = logging.getLogger(__name__)
-__all__ = ("check_state_management_enabled", "check_state_dir")
+__all__ = ("check_state_management_enabled", "check_state_dir", "is_quix_deployment")
+
+
+def is_quix_deployment() -> bool:
+    """
+    Check if the current deployment is a Quix deployment.
+    """
+    return bool(QUIX_ENVIRONMENT.deployment_id)
 
 
 def check_state_management_enabled() -> None:
@@ -16,7 +23,7 @@ def check_state_management_enabled() -> None:
     If it's disabled, the warning will be logged.
 
     """
-    if QUIX_ENVIRONMENT.deployment_id and not QUIX_ENVIRONMENT.state_management_enabled:
+    if is_quix_deployment() and not QUIX_ENVIRONMENT.state_management_enabled:
         warnings.warn(
             f"State Management feature is disabled for Quix deployment "
             f'"{QUIX_ENVIRONMENT.deployment_id}". '

--- a/quixstreams/platforms/quix/checks.py
+++ b/quixstreams/platforms/quix/checks.py
@@ -8,11 +8,12 @@ logger = logging.getLogger(__name__)
 __all__ = ("check_state_management_enabled", "check_state_dir")
 
 
-def check_state_management_enabled():
+def check_state_management_enabled() -> None:
     """
     Check if State Management feature is enabled for the current deployment on
     Quix platform.
-    If it's disabled, the exception will be raised.
+
+    If it's disabled, the warning will be logged.
 
     """
     if QUIX_ENVIRONMENT.deployment_id and not QUIX_ENVIRONMENT.state_management_enabled:
@@ -25,7 +26,7 @@ def check_state_management_enabled():
         )
 
 
-def check_state_dir(state_dir: Path):
+def check_state_dir(state_dir: Path) -> None:
     """
     Check if Application "state_dir" matches the state dir on Quix platform.
 

--- a/tests/test_quixstreams/test_app.py
+++ b/tests/test_quixstreams/test_app.py
@@ -5,6 +5,7 @@ import time
 import uuid
 from concurrent.futures import Future
 from json import dumps, loads
+from pathlib import Path
 from unittest.mock import create_autospec, patch
 
 import pytest
@@ -1101,6 +1102,21 @@ class TestQuixApplicationWithState:
         warnings = [w for w in warned.list if w.category is RuntimeWarning]
         warning = str(warnings[0].message)
         assert "does not match the state directory" in warning
+
+
+@pytest.mark.parametrize(
+    ["deployment_id", "expected_state_dir"],
+    [
+        ("123", "/app/state"),
+        ("", "state"),
+    ],
+)
+def test_quix_app_state_dir_default(
+    monkeypatch, quix_mock_config_builder_factory, deployment_id, expected_state_dir
+):
+    monkeypatch.setenv(QuixEnvironment.DEPLOYMENT_ID, deployment_id)
+    app = Application(quix_config_builder=quix_mock_config_builder_factory())
+    assert app._config.state_dir == Path(expected_state_dir)
 
 
 @pytest.mark.parametrize("store_type", SUPPORTED_STORES, indirect=True)


### PR DESCRIPTION
### Problem
After the latest update, Quix Cloud changed the default app placement from `/app` to `/app/<something>`.

Because of that, the default state dir in Quix now points to `/app/<something>/state` instead of `/app/state` (mounted PVC).

### Solution
Set the default path for Quix apps to `/app/state` instead of the current `state/` (relative).

Users should be able to override it, so we need to change the defaults for the whole Application.