### PR TITLE
print_table method handles non-dict values

### DIFF
--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -49,7 +49,11 @@ from quixstreams.models.serializers import DeserializerType, SerializerType
 from quixstreams.processing import ProcessingContext
 from quixstreams.sinks import BaseSink
 from quixstreams.state.base import State
-from quixstreams.utils.printing import DEFAULT_LIVE, DEFAULT_LIVE_SLOWDOWN
+from quixstreams.utils.printing import (
+    DEFAULT_COLUMN_NAME,
+    DEFAULT_LIVE,
+    DEFAULT_LIVE_SLOWDOWN,
+)
 
 from .exceptions import InvalidOperation
 from .registry import DataframeRegistry
@@ -881,6 +885,8 @@ class StreamingDataFrame:
         )
 
         def _add_row(value: Any, *_metadata: tuple[Any, int, HeadersTuples]) -> None:
+            if not isinstance(value, dict):
+                value = {DEFAULT_COLUMN_NAME: value}
             if metadata:
                 value = dict(_key=_metadata[0], _timestamp=_metadata[1], **value)
             table.add_row(value)

--- a/quixstreams/utils/printing.py
+++ b/quixstreams/utils/printing.py
@@ -8,6 +8,7 @@ from rich.table import Table as RichTable
 
 __all__ = ("Printer",)
 
+DEFAULT_COLUMN_NAME = "0"
 DEFAULT_LIVE = True
 DEFAULT_LIVE_SLOWDOWN = 0.5
 

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -421,6 +421,19 @@ class TestStreamingDataFrame:
             sdf.print_table(columns=[], metadata=False)
             warn.assert_called_once()
 
+    def test_print_table_non_dict_value(self, dataframe_factory, get_output):
+        sdf = dataframe_factory()
+        sdf.print_table(size=1, metadata=False)
+        sdf.test(value=1, key=b"key", timestamp=12345)
+        sdf._processing_context.printer.print()
+        assert get_output() == (
+            "┏━━━┓\n"
+            "┃ 0 ┃\n"
+            "┡━━━┩\n"
+            "│ 1 │\n"
+            "└───┘\n"
+        )  # fmt: skip
+
     @pytest.mark.parametrize(
         "columns, expected",
         [


### PR DESCRIPTION
Fix for a bug when `print_table` method would fail if values are not dicts.

Proposed name for a default column is "0"