### PR TITLE
InfluxDB3Source: new connector

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - pandas >=1.0.0,<3.0
     - elasticsearch >=8.17,<9
     - rich >=13,<15
+    - influxdb3-python[pandas] >=0.7,<1.0
 
 test:
   imports:

--- a/conda/post-link.sh
+++ b/conda/post-link.sh
@@ -3,7 +3,7 @@
 $PREFIX/bin/pip install \
 'rocksdict>=0.3,<0.4' \
 'protobuf>=5.27.2,<7.0' \
-'influxdb3-python>=0.7,<1.0' \
+'influxdb3-python[pandas]>=0.7,<1.0' \
 'pyiceberg[pyarrow,glue]>=0.7' \
 'redis[hiredis]>=5.2.0,<6' \
 'confluent-kafka[avro,json,protobuf,schemaregistry]>=2.8.2,<2.10'

--- a/docs/connectors/sources/influxdb3-source.md
+++ b/docs/connectors/sources/influxdb3-source.md
@@ -38,7 +38,9 @@ Note that 'end_date' is optional; when not provided, it will run indefinitely fo
 
 ## How to Use
 
-To use Kinesis Source, hand `InfluxDB3Source` to `app.dataframe()`.
+Import and instantiate an `InfluxDB3Source` instance and hand it to an Application using
+`app.add_source(<InfluxDB3Source>)` or instead to a StreamingDataFrame with 
+`app.dataframe(source=<InfluxDB3Source>)` if further data manipulation is required.
 
 For more details around various settings, see [configuration](#configuration).
 

--- a/docs/connectors/sources/influxdb3-source.md
+++ b/docs/connectors/sources/influxdb3-source.md
@@ -86,17 +86,28 @@ Here are the InfluxDB-related configurations to be aware of (see [InfluxDB3Sourc
 
 
 ### Optional:
-
-- `start_date`: The start datetime for querying InfluxDB. Uses current time by default.
-- `end_date`: The end datetime for querying InfluxDB. If none provided, runs indefinitely for a single measurement.
-- `measurements`: The measurements to query. If None, all measurements will be processed.
+- `key_setter`: sets the kafka message key for a measurement record.  
+  By default, will set the key to the measurement's name.
+- `timestamp_setter`: sets the kafka message timestamp for a measurement record.  
+  By default, the timestamp will be the Kafka default (Kafka produce time).
+- `start_date`: The start datetime for querying InfluxDB.  
+  Uses current time by default.
+- `end_date`: The end datetime for querying InfluxDB.  
+  If none provided, runs indefinitely for a single measurement.
+- `measurements`: The measurements to query.  
+  If None, all measurements will be processed.
+- `measurement_column_name`: The column name used for appending the measurement name to the record.
+  Default: `_measurement_name`.
 - `sql_query`: Custom SQL query for retrieving data.
-    Query expects a `{start_time}`, `{end_time}`, and `{measurement_name}` for later formatting. 
-    If provided, it overrides the default window-query logic.
-- `time_delta`: Time interval for batching queries, e.g. "5m" for 5 minutes.
-- `delay`: Add a delay (in seconds) between producing batches.
-- `max_retries`: Maximum number of retries for querying or producing;    
-    Note that consecutive retries have a multiplicative backoff.
+  Query expects a `{start_time}`, `{end_time}`, and `{measurement_name}` for later formatting.  
+  If provided, it overrides the default window-query logic.
+- `time_delta`: Time interval for batching queries, e.g. "5m" for 5 minutes.  
+  Default: `5m`.
+- `delay`: Add a delay (in seconds) between producing batches.  
+  Default: `0`.
+- `max_retries`: Maximum number of retries for querying or producing;  
+  Note that consecutive retries have a multiplicative backoff.
+  Default: `5`.
 
 
 ## Testing Locally

--- a/docs/connectors/sources/influxdb3-source.md
+++ b/docs/connectors/sources/influxdb3-source.md
@@ -131,7 +131,8 @@ application using a local instance of Influxdb3 using Docker:
         host="http://localhost:8181",   # be sure to add http
         organization_id="local",        # unused, but required
         token="local",                  # unused, but required
+        database="<YOUR DB>",
     )
     ```
 
-The `database` you provide will be auto-created for you.
+Note: the database must exist for this to successfully run.

--- a/docs/connectors/sources/influxdb3-source.md
+++ b/docs/connectors/sources/influxdb3-source.md
@@ -1,0 +1,126 @@
+# InfluxDB v3 Source
+
+!!! info
+
+    This is a **Community** connector. Test it before using in production.
+
+    To learn more about differences between Core and Community connectors, see the [Community and Core Connectors](../community-and-core.md) page.
+
+
+InfluxDB is an open source time series database for metrics, events, and real-time analytics.
+
+Quix Streams provides a source to extract "measurements" from InfluxDB v3 databases 
+  and dump them to a Kafka topic.
+
+>***NOTE***: This source only supports InfluxDB v3. Versions 1 and 2 are not supported.
+
+## How to Install
+
+Install Quix Streams with the following optional dependencies:
+
+```bash
+pip install quixstreams[influxdb3]
+```
+
+## How it Works
+
+`InfluxDB3Source` extracts data from a specified set of measurements in a
+  database (or all available ones if none are specified).
+
+It processes measurements sequentially by gathering/producing a tumbling
+  "time_delta"-sized window of data, starting from a specified 'start_date' and 
+  eventually stopping at a specified 'end_date', completing that measurement.
+
+It then starts the next measurement, continuing until all are complete.
+
+Note that 'end_date' is optional; when not provided, it will run indefinitely for a 
+  single measurement (which means no other measurements will be processed!).
+
+## How to Use
+
+To use Kinesis Source, hand `InfluxDB3Source` to `app.dataframe()`.
+
+For more details around various settings, see [configuration](#configuration).
+
+```python
+from quixstreams import Application
+from quixstreams.sources.community.influxdb3 import InfluxDB3Source
+from datetime import datetime, timedelta, timezone
+
+app = Application(broker_address="localhost:9092")
+topic = app.topic("influx-topic")
+
+influx = InfluxDB3Source(
+    token="<influxdb-access-token>",
+    host="<influxdb-host>",
+    organization_id="<influxdb-org>",
+    database="<influxdb-database>",
+    measurements="my-measurement",
+    start_date=datetime.now(tz=timezone.utc) - timedelta(days=2),
+    end_date=datetime.now(tz=timezone.utc),
+)
+
+app = Application(
+    broker_address="<YOUR BROKER INFO>",
+    consumer_group="<YOUR GROUP>",
+)
+
+sdf = app.dataframe(source=influx).print(metadata=True)
+# YOUR LOGIC HERE!
+sdf.to_topic(topic)
+
+if __name__ == "__main__":
+    app.run()
+```
+
+
+## Configuration
+Here are the InfluxDB-related configurations to be aware of (see [InfluxDB3Source API](../../api-reference/sources.md#influxdb3source) for all parameters).
+
+### Required:
+
+- `host`: Host URL of the InfluxDB instance.
+- `token`: Authentication token for InfluxDB.
+- `organization_id`: Organization name in InfluxDB.
+- `database`: Database name in InfluxDB.
+
+
+### Optional:
+
+- `start_date`: The start datetime for querying InfluxDB. Uses current time by default.
+- `end_date`: The end datetime for querying InfluxDB. If none provided, runs indefinitely for a single measurement.
+- `measurements`: The measurements to query. If None, all measurements will be processed.
+- `sql_query`: Custom SQL query for retrieving data.
+    Query expects a `{start_time}`, `{end_time}`, and `{measurement_name}` for later formatting. 
+    If provided, it overrides the default window-query logic.
+- `time_delta`: Time interval for batching queries, e.g. "5m" for 5 minutes.
+- `delay`: Add a delay (in seconds) between producing batches.
+- `max_retries`: Maximum number of retries for querying or producing;    
+    Note that consecutive retries have a multiplicative backoff.
+
+
+## Testing Locally
+
+Rather than connect to a hosted InfluxDB3 instance, you can alternatively test your 
+application using a local instance of Influxdb3 using Docker:
+
+1. Execute in terminal:
+
+    ```bash
+    docker run --rm -d --name influxdb3 \
+    -p 8181:8181 \
+    quay.io/influxdb/influxdb3-core:latest \
+    serve --node-id=host0 --object-store=memory
+    ```
+
+2. Use the following settings for `InfluxDB3Source` to connect:
+
+    ```python
+    InfluxDB3Source(
+        host="http://localhost:8181",   # be sure to add http
+        organization_id="local",        # unused, but required
+        token="local",                  # unused, but required
+    )
+    ```
+
+The `database` you provide will be auto-created for you.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Homepage = "https://github.com/quixio/quix-streams"
 all = [
     "fastavro>=1.8,<2.0",
     "protobuf>=5.27.2,<7.0",
-    "influxdb3-python>=0.7,<1.0",
+    "influxdb3-python[pandas]>=0.7,<1.0",
     "pyiceberg[pyarrow,glue]>=0.7",
     "google-cloud-bigquery>=3.26.0,<3.27",
     "google-cloud-pubsub>=2.23.1,<3",
@@ -47,7 +47,7 @@ all = [
 
 avro = ["fastavro>=1.8,<2.0"]
 protobuf = ["protobuf>=5.27.2,<7.0"]
-influxdb3 = ["influxdb3-python>=0.7,<1.0"]
+influxdb3 = ["influxdb3-python[pandas]>=0.7,<1.0"]
 iceberg = ["pyiceberg[pyarrow]>=0.7"]
 iceberg_aws = ["pyiceberg[pyarrow,glue]>=0.7"]
 bigquery = ["google-cloud-bigquery>=3.26.0,<3.27"]

--- a/quixstreams/sources/community/influxdb3/__init__.py
+++ b/quixstreams/sources/community/influxdb3/__init__.py
@@ -1,0 +1,2 @@
+# ruff: noqa: F403
+from .influxdb3 import *

--- a/quixstreams/sources/community/influxdb3/influxdb3.py
+++ b/quixstreams/sources/community/influxdb3/influxdb3.py
@@ -5,7 +5,13 @@ from datetime import datetime, timedelta, timezone
 from functools import wraps
 from typing import Callable, Optional, Union
 
-from influxdb_client_3 import InfluxDBClient3
+try:
+    from influxdb_client_3 import InfluxDBClient3
+except ImportError as exc:
+    raise ImportError(
+        'Package "influxdb3-python" is missing: '
+        "run pip install quixstreams[influxdb3] to fix it"
+    ) from exc
 
 from quixstreams.models.topics import Topic
 from quixstreams.sources import (

--- a/quixstreams/sources/community/influxdb3/influxdb3.py
+++ b/quixstreams/sources/community/influxdb3/influxdb3.py
@@ -1,0 +1,216 @@
+import json
+import logging
+import random
+import time
+from datetime import datetime, timedelta, timezone
+from functools import wraps
+from typing import Optional
+
+from influxdb_client_3 import InfluxDBClient3
+
+from quixstreams.models.topics import Topic
+from quixstreams.sources import (
+    ClientConnectFailureCallback,
+    ClientConnectSuccessCallback,
+    Source,
+)
+
+logger = logging.getLogger(__name__)
+
+TIME_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+__all__ = ("InfluxDB3Source",)
+
+
+# retry decorator
+def with_retry(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        max_attempts = self.max_attempts
+        attempts_remaining = self.max_attempts
+        backoff = 1  # Initial backoff in seconds
+        while attempts_remaining:
+            try:
+                return func(*args, **kwargs)
+            except Exception as e:
+                logger.debug(f"{func.__name__} encountered an error: {e}")
+                attempts_remaining -= 1
+                if attempts_remaining:
+                    logger.warning(
+                        f"{func.__name__} failed and is retrying; "
+                        f"backing off for {backoff}s (attempt "
+                        f"{max_attempts-attempts_remaining}/{max_attempts})"
+                    )
+                    time.sleep(backoff)
+                    backoff *= 2  # Exponential backoff
+                else:
+                    logger.error(f"Maximum retries reached for {func.__name__}: {e}")
+                    raise
+
+    return wrapper
+
+
+class InfluxDB3Source(Source):
+    def __init__(
+        self,
+        influxdb_host: str,
+        influxdb_token: str,
+        influxdb_org: str,
+        influxdb_database: str,
+        start_date: datetime,
+        end_date: Optional[datetime] = None,
+        measurement: Optional[str] = None,
+        sql_query: Optional[str] = None,
+        time_delta: str = "5m",
+        delay: float = 0,
+        max_retries: int = 5,
+        name: Optional[str] = None,
+        shutdown_timeout: float = 10,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
+    ) -> None:
+        """
+        :param influxdb_host: Host URL of the InfluxDB instance.
+        :param influxdb_token: Authentication token for InfluxDB.
+        :param influxdb_org: Organization name in InfluxDB.
+        :param influxdb_database: Database name in InfluxDB.
+        :param start_date: The start datetime for querying InfluxDB.
+        :param end_date: The end datetime for querying InfluxDB.
+        :param measurement: The measurement to query. If None, all measurements will be processed.
+        :param sql_query: Custom SQL query for retrieving data. If provided, it overrides the default logic.
+        :param time_delta: Time interval for batching queries, e.g., "5m" for 5 minutes.
+        :param delay: An optional delay between producing batches.
+        :param name: A unique name for the Source, used as part of the topic name.
+        :param shutdown_timeout: Time in seconds to wait for graceful shutdown.
+        :param max_retries: Maximum number of retries for querying or producing.
+        :param on_client_connect_success: An optional callback made after successful
+            client authentication, primarily for additional logging.
+        :param on_client_connect_failure: An optional callback made after failed
+            client authentication (which should raise an Exception).
+            Callback should accept the raised Exception as an argument.
+            Callback must resolve (or propagate/re-raise) the Exception.
+        """
+        super().__init__(
+            name=name or f"influxdb_{influxdb_database}_{measurement}",
+            shutdown_timeout=shutdown_timeout,
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
+        )
+
+        self._client_kwargs = {
+            "host": influxdb_host,
+            "token": influxdb_token,
+            "org": influxdb_org,
+            "database": influxdb_database,
+        }
+        self.measurement = measurement
+        self.sql_query = sql_query  # Custom SQL query
+        self.start_date = start_date
+        self.end_date = end_date
+        self.time_delta = time_delta
+        self.delay = delay
+        self.max_retries = max_retries
+
+        self._client: Optional[InfluxDBClient3] = None
+
+    def setup(self):
+        self._client = InfluxDBClient3(**self._client_kwargs)
+        try:
+            # We cannot safely parameterize the table (measurement) selection, so
+            # the best we can do is confirm authentication was successful
+            self._client.query("")
+        except Exception as e:
+            if "No SQL statements were provided in the query string" not in str(e):
+                raise
+
+    @with_retry
+    def produce_records(self, records: list[dict], measurement_name: str):
+        for record in records:
+            msg = self.serialize(
+                key=f"{measurement_name}_{random.randint(1, 1000)}",  # noqa: S311
+                value=record,
+            )
+            self.produce(value=msg.value, key=msg.key)
+        self.producer.flush()
+
+    def run(self):
+        measurements = (
+            [self.measurement] if self.measurement else self.get_measurements()
+        )
+
+        for measurement_name in measurements:
+            logger.info(f"Processing measurement: {measurement_name}")
+            _start_date = self.start_date
+            _end_date = self.end_date
+
+            is_running = (
+                True
+                if _end_date is None
+                else (self.running and _start_date < _end_date)
+            )
+
+            while is_running:
+                end_time = _start_date + timedelta(
+                    seconds=interval_to_seconds(self.time_delta)
+                )
+                wait_time = (end_time - datetime.now(timezone.utc)).total_seconds()
+                if _end_date is None and wait_time > 0:
+                    logger.info(f"Sleeping for {wait_time}s")
+                    time.sleep(wait_time)
+
+                data = self.query_data(measurement_name, _start_date, end_time)
+                if data is not None and not data.empty:
+                    if "iox::measurement" in data.columns:
+                        data = data.drop(columns=["iox::measurement"])
+                    self.produce_records(
+                        json.loads(data.to_json(orient="records", date_format="iso")),
+                        data["measurement_name"],
+                    )
+
+                _start_date = end_time
+                if self.delay > 0:
+                    time.sleep(self.delay)
+
+    def get_measurements(self):
+        try:
+            query = "SHOW MEASUREMENTS"
+            result = self._client.query(query=query, mode="pandas", language="influxql")
+            return result["name"].tolist() if not result.empty else []
+        except Exception as e:
+            logger.error(f"Failed to retrieve measurements: {e}")
+            return []
+
+    @with_retry
+    def query_data(self, measurement_name, start_time, end_time):
+        try:
+            if self.sql_query:
+                query = self.sql_query.format(
+                    measurement_name=measurement_name,
+                    start_time=start_time.isoformat(),
+                    end_time=end_time.isoformat(),
+                )
+            else:
+                query = (
+                    f'SELECT * FROM "{measurement_name}" '  # noqa: S608
+                    f"WHERE time >= '{start_time.isoformat()}' "
+                    f"AND time < '{end_time.isoformat()}'"
+                )
+
+            logger.info(f"Executing query: {query}")
+            return self._client.query(query=query, mode="pandas", language="influxql")
+        except Exception as e:
+            logger.error(f"Query failed for measurement {measurement_name}: {e}")
+            raise
+
+    def default_topic(self) -> Topic:
+        return Topic(
+            name=self.name,
+            key_serializer="string",
+            key_deserializer="string",
+            value_deserializer="json",
+            value_serializer="json",
+        )
+
+
+def interval_to_seconds(interval: str) -> int:
+    return int(interval[:-1]) * TIME_UNITS[interval[-1]]

--- a/quixstreams/sources/community/influxdb3/influxdb3.py
+++ b/quixstreams/sources/community/influxdb3/influxdb3.py
@@ -112,12 +112,15 @@ class InfluxDB3Source(Source):
         :param start_date: The start datetime for querying InfluxDB. Uses current time by default.
         :param end_date: The end datetime for querying InfluxDB. If none provided, runs indefinitely for a single measurement.
         :param measurements: The measurements to query. If None, all measurements will be processed.
-        :param sql_query: Custom SQL query for retrieving data. If provided, it overrides the default logic.
+        :param sql_query: Custom SQL query for retrieving data.
+            Query expects a `{start_time}`, `{end_time}`, and `{measurement_name}` for later formatting.
+            If provided, it overrides the default window-query logic.
         :param time_delta: Time interval for batching queries, e.g., "5m" for 5 minutes.
         :param delay: An optional delay between producing batches.
         :param name: A unique name for the Source, used as part of the topic name.
         :param shutdown_timeout: Time in seconds to wait for graceful shutdown.
         :param max_retries: Maximum number of retries for querying or producing.
+            Note that consecutive retries have a multiplicative backoff.
         :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
         :param on_client_connect_failure: An optional callback made after failed

--- a/quixstreams/sources/community/influxdb3/influxdb3.py
+++ b/quixstreams/sources/community/influxdb3/influxdb3.py
@@ -74,9 +74,9 @@ class InfluxDB3Source(Source):
 
     It processes measurements sequentially by gathering/producing a tumbling
       "time_delta"-sized window of data, starting from 'start_date' and eventually
-      stopping at 'end_date'.
+      stopping at 'end_date', completing that measurement.
 
-    Once stopped, it processes the next measurement, until all are complete.
+    It then starts the next measurement, continuing until all are complete.
 
     If no 'end_date' is provided, it will run indefinitely for a single
       measurement (which means no other measurements will be processed!).


### PR DESCRIPTION
NOTE: This PR is primarily just me cleaning up code that was written by someone else; I largely tried to leave what they had in place while cleaning up what i could, or standardizing it to fit our framework.

Example use:

```
from quixstreams.sources.community.influxdb3 import InfluxDB3Source
from quixstreams import Application
import datetime
import uuid

source = InfluxDB3Source(
    host="http://localhost:8181",
    organization_id='abc123',
    database="connector5",
    token='123',
    start_date=datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=2),
    end_date=datetime.datetime.now(tz=datetime.timezone.utc),
    time_delta='24h',
    max_retries=2,
)

app = Application(
    broker_address="localhost:9092",
    consumer_group=str(uuid.uuid4()),
)
sdf = app.dataframe(source=source).print(metadata=True)


if __name__ == '__main__':
    app.run()
```