### PR TITLE
Feature: Fill missing data

### DIFF
--- a/docs/missing-data.md
+++ b/docs/missing-data.md
@@ -1,0 +1,53 @@
+# Missing Data
+
+Handling missing data is a crucial aspect of data processing, especially in streaming environments. This document outlines what is considered missing data within the `StreamingDataFrame` class and how it is managed.
+
+## Types of Missing Data in Streaming
+
+- **Missing Column**: This occurs when a field is not present in the message at all. In streaming data, schemas can be dynamic, meaning that not all fields are required to be present in every message. This type of missing data is handled by the system's ability to adapt to changes in the schema over time.
+
+- **Missing Value**: This occurs when a field is present in the message, but its value is `None`. This indicates that the data for that field is missing, even though the field itself is part of the message schema.
+
+## Handling Missing Data in Aggregations
+
+- **Rows with `None` Values**: These rows are ignored during aggregation operations. This means that if a row contains a `None` value, it will not contribute to the aggregation result. This applies to the following aggregations: Sum, Mean, Min, and Max.
+
+- **`NaN` Values**: Unlike `None`, `NaN` values are propagated to the aggregation result. This is because `NaN` is not considered missing data in the same way as `None`. Instead, it represents a numerical value that is undefined or unrepresentable, and it is treated as such in calculations.
+
+## `StreamingDataFrame.fill` Method
+
+The `fill` method in the `StreamingDataFrame` class is used to fill missing data in the message value with a constant value.
+
+### Example Usage
+
+```python
+from quixstreams import Application
+
+# Initialize the Application
+app = Application(...)
+sdf = app.dataframe(...)
+```
+
+Fill missing data for a single column with `None`:
+```python
+# This would transform {"x": 1} to {"x": 1, "y": None}
+sdf.fill("y")
+```
+
+Fill missing data for multiple columns with `None`:
+```python
+# This would transform {"x": 1} to {"x": 1, "y": None, "z": None}
+sdf.fill("y", "z")
+```
+
+Fill missing data with a constant value using a dictionary:
+```python
+# This would transform {"x": None} to {"x": 1, "y": 2}
+sdf.fill(x=1, y=2)
+```
+
+Use a combination of positional and keyword arguments:
+```python
+# This would transform {"y": None} to {"x": None, "y": 2}
+sdf.fill("x", y=2)
+```

--- a/docs/missing-data.md
+++ b/docs/missing-data.md
@@ -16,7 +16,7 @@ Handling missing data is a crucial aspect of data processing, especially in stre
 
 ## `StreamingDataFrame.fill` Method
 
-The `fill` method in the `StreamingDataFrame` class is used to fill missing data in the message value with a constant value.
+The `fill` method in the `StreamingDataFrame` class is used to fill missing column and missing value in the message with a constant value.
 
 ### Example Usage
 

--- a/docs/missing-data.md
+++ b/docs/missing-data.md
@@ -10,7 +10,7 @@ Handling missing data is a crucial aspect of data processing, especially in stre
 
 ## Handling Missing Data in Aggregations
 
-- **Rows with `None` Values**: These rows are ignored during aggregation operations. This means that if a row contains a `None` value, it will not contribute to the aggregation result. This applies to the following aggregations: Sum, Mean, Min, and Max.
+- **Rows with `None` Values**: These rows are ignored during aggregation operations. This means that if a row contains a `None` value, it will not contribute to the aggregation result. This applies to the following aggregations: Count, Sum, Mean, Min, and Max.
 
 - **`NaN` Values**: Unlike `None`, `NaN` values are propagated to the aggregation result. This is because `NaN` is not considered missing data in the same way as `None`. Instead, it represents a numerical value that is undefined or unrepresentable, and it is treated as such in calculations.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
     - Produce Data to Kafka: producer.md
     - Process & Transform Data: processing.md
     - Inspecting Data & Debugging: debugging.md
+    - Missing Data: missing-data.md
     - GroupBy Operation: groupby.md
     - Windows: windowing.md
     - Aggregations: aggregations.md

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -1450,6 +1450,13 @@ class StreamingDataFrame:
         """
         mapping = {**{column: None for column in columns}, **mapping}
 
+        if not mapping:
+            warnings.warn(
+                "No columns or mapping provided to fill(). "
+                "No changes will be made to the data."
+            )
+            return self
+
         def _fill(value: Any) -> Any:
             if not isinstance(value, dict):
                 return value

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -1454,8 +1454,8 @@ class StreamingDataFrame:
             if not isinstance(value, dict):
                 return value
             for column, fill_value in mapping.items():
-                incoming_value = value.get(column)
-                value[column] = fill_value if incoming_value is None else incoming_value
+                if value.get(column) is None:
+                    value[column] = fill_value
             return value
 
         return self._add_update(_fill, metadata=False)

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -1451,11 +1451,7 @@ class StreamingDataFrame:
         mapping = {**{column: None for column in columns}, **mapping}
 
         if not mapping:
-            warnings.warn(
-                "No columns or mapping provided to fill(). "
-                "No changes will be made to the data."
-            )
-            return self
+            raise ValueError("No columns or mapping provided to fill().")
 
         def _fill(value: Any) -> Any:
             if not isinstance(value, dict):

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -930,8 +930,8 @@ class StreamingDataFrame:
     def test(
         self,
         value: Any,
-        key: Any,
-        timestamp: int,
+        key: Any = b"key",
+        timestamp: int = 0,
         headers: Optional[Any] = None,
         ctx: Optional[MessageContext] = None,
         topic: Optional[Topic] = None,

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -435,6 +435,30 @@ class TestStreamingDataFrame:
         )  # fmt: skip
 
     @pytest.mark.parametrize(
+        ["columns", "mapping", "value", "expected"],
+        [
+            (["x"], {}, {"x": 1}, {"x": 1}),
+            (["x"], {}, {}, {"x": None}),
+            (["x"], {}, 1, 1),
+            (["x", "y"], {}, {"x": 1, "y": 2}, {"x": 1, "y": 2}),
+            (["x", "y"], {}, {"x": 1}, {"x": 1, "y": None}),
+            (["x", "y"], {}, {}, {"x": None, "y": None}),
+            ([], {"x": 1, "y": 2}, {"x": 3, "y": 4}, {"x": 3, "y": 4}),
+            ([], {"x": 1, "y": 2}, {"x": 3}, {"x": 3, "y": 2}),
+            ([], {"x": 1, "y": 2}, {}, {"x": 1, "y": 2}),
+            ([], {"x": 1, "y": 2}, {"x": None}, {"x": 1, "y": 2}),
+            ([], {"x": 1, "y": None}, {"x": 2}, {"x": 2, "y": None}),
+            (["x"], {"y": 2}, {"y": None}, {"x": None, "y": 2}),
+            # overlapping column names, kwargs take precedence
+            (["x"], {"x": 2}, {"x": None}, {"x": 2}),
+        ],
+    )
+    def test_fill(self, dataframe_factory, columns, mapping, value, expected):
+        sdf = dataframe_factory()
+        sdf.fill(*columns, **mapping)
+        assert sdf.test(value=value)[0][0] == expected
+
+    @pytest.mark.parametrize(
         "columns, expected",
         [
             ("col_a", {"col_b": 2, "col_c": 3}),

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -437,7 +437,6 @@ class TestStreamingDataFrame:
     @pytest.mark.parametrize(
         ["columns", "mapping", "value", "expected"],
         [
-            ([], {}, {"x": 1}, {"x": 1}),
             (["x"], {}, 1, 1),  # value is not a dict, fill ignored
             (["x"], {}, {"x": 1}, {"x": 1}),
             (["x"], {}, {}, {"x": None}),
@@ -459,6 +458,13 @@ class TestStreamingDataFrame:
         sdf = dataframe_factory()
         sdf.fill(*columns, **mapping)
         assert sdf.test(value=value)[0][0] == expected
+
+    def test_fill_no_columns_or_mapping(self, dataframe_factory):
+        sdf = dataframe_factory()
+        with pytest.raises(
+            ValueError, match="No columns or mapping provided to fill()."
+        ):
+            sdf.fill()
 
     @pytest.mark.parametrize(
         "columns, expected",

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -437,6 +437,7 @@ class TestStreamingDataFrame:
     @pytest.mark.parametrize(
         ["columns", "mapping", "value", "expected"],
         [
+            ([], {}, {"x": 1}, {"x": 1}),
             (["x"], {}, {"x": 1}, {"x": 1}),
             (["x"], {}, {}, {"x": None}),
             (["x"], {}, 1, 1),

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -438,6 +438,7 @@ class TestStreamingDataFrame:
         ["columns", "mapping", "value", "expected"],
         [
             ([], {}, {"x": 1}, {"x": 1}),
+            (["x"], {}, 1, 1),  # value is not a dict, fill ignored
             (["x"], {}, {"x": 1}, {"x": 1}),
             (["x"], {}, {}, {"x": None}),
             (["x"], {}, 1, 1),


### PR DESCRIPTION
## Summary

This pull request introduces a new fill method to the StreamingDataFrame class, enabling users to fill missing values in their data streams with specified constants. This enhancement provides more flexibility in data preprocessing and ensures that data streams can be standardized before further processing.

## Key Features

1. **Fill Missing Values**: The fill method allows users to specify columns and their corresponding fill values. If a column is missing or contains None, it will be replaced with the specified fill value.
2. **Flexible Usage**: Users can fill multiple columns at once using either positional arguments (for default None values) or keyword arguments (for specific fill values).

## Example Usage
Fill missing values for a single column with a None:
```python
# This would transform {"x": 1} to {"x": 1, "y": None}
sdf.fill("y")
```

Fill missing values for multiple columns with a None:
```python
# This would transform {"x": 1} to {"x": 1, "y": None, "z": None}
sdf.fill("y", "z")
```

Fill missing values in the value with a constant value using a dictionary:
```python
# This would transform {"x": None} to {"x": 1, "y": 2}
sdf.fill(x=1, y=2)
```

Use a combination of positional and keyword arguments:
```python
# This would transform {"y": None} to {"x": None, "y": 2}
sdf.fill("x", y=2)
```
