### PR TITLE
Sink: Elasticsearch

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - neo4j-python-driver >=5.27.0,<6
     - pymongo >=4.11,<5
     - pandas >=1.0.0,<3.0
+    - elasticsearch >=8.17,<9
     - rich >=13,<14
 
 test:

--- a/docs/connectors/sinks/elasticsearch-sink.md
+++ b/docs/connectors/sinks/elasticsearch-sink.md
@@ -170,7 +170,7 @@ if __name__ == "__main__":
     **Default**: 500
 - `max_bulk_retries`: number of retry attempts for each bulk batch  
     **Default**: 3
-- `document_id_setter`: how to select the document id.
+- `document_id_setter`: how to select the document id.  
     **Default**: `_id` set to the kafka message key.
 - `add_message_metadata`: include key, timestamp, and headers as `__{field}`    
     **Default**: False

--- a/docs/connectors/sinks/elasticsearch-sink.md
+++ b/docs/connectors/sinks/elasticsearch-sink.md
@@ -6,7 +6,7 @@
 
     To learn more about differences between Core and Community connectors, see the [Community and Core Connectors](../community-and-core.md) page.
 
-This sink writes data to a Elasticsearch Index, with a few ways to dump data.
+This sink writes data to a Elasticsearch Index, with a few options for dumping data.
 
 
 ## How To Install
@@ -19,20 +19,20 @@ pip install quixstreams[elasticsearch]
 
 ## How It Works
 
-`ElasticsearchSink` is a streaming sink that publishes messages to Elasticsearch in batches.
+`ElasticsearchSink` publishes messages to Elasticsearch in batches.
 
 You can customize how to handle/export them with `ElasticsearchSink`, but the most common
 (and default) approach is having a 1:1 correspondence between Kafka message `key` and 
 document `_id`, and field types automatically ("dynamically") inferred.
 
-Also, messages are sent to Elasticsearch in the same order they are received from Kafka
-for each specific partition.
+Messages are sent to Elasticsearch in the same order they are received from Kafka
+_for each topic partition_.
 
 
 ## Export Behavior
 
 How data is dumped with `ElasticsearchSink` primarily depends on two parameters: the 
-`document_id_setter` and `mapper`.
+`document_id_setter` and `mapper` (with sensible defaults already defined).
 
 ### Specifying Index Field Types
 
@@ -42,7 +42,7 @@ By default, a simple "dynamic" mapping is used, which determines a field's type 
 on the initial type encountered.
 
 > ex: if the first encountered instance of field `quantity` is `5`, then 
-that field is assumed to be an `integer` field.
+> that field is assumed to be an `integer` field.
 
 #### Using a Custom Mapping
 
@@ -160,23 +160,36 @@ if __name__ == "__main__":
     app.run()
 ```
 
+## Authenticating
+
+To provide the most amount of flexibility for authentication, `ElasticsearchSink` 
+forwards any unused`kwargs` directly to the underlying `Elasticsearch` client.
+
+[Check out the `Elasticsearch` connection documentation](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html) 
+to learn what authentication method applies to your use case.
+
 ## Configuration Options
+
+### Required
 
 - `url`: Elasticsearch url
 - `index`: Elasticsearch index name
+
+### Optional
+
 - `mapping`: a custom mapping  
     **Default**: Dynamically maps all field types
+- `document_id_setter`: how to select the document id.  
+    **Default**: `_id` set to the kafka message key.
 - `batch_size`: how large each chunk size is with bulk  
     **Default**: 500
 - `max_bulk_retries`: number of retry attempts for each bulk batch  
     **Default**: 3
-- `document_id_setter`: how to select the document id.  
-    **Default**: `_id` set to the kafka message key.
+- `ignore_bulk_upload_errors`: ignore any errors that occur when attempting an upload  
+    **Default**: False
 - `add_message_metadata`: include key, timestamp, and headers as `__{field}`    
     **Default**: False
 - `add_topic_metadata`: include topic, partition, and offset as `__{field}`    
-    **Default**: False
-- `ignore_bulk_upload_errors`: ignore any errors that occur when attempting an upload  
     **Default**: False
 
 Additional keyword arguments are passed to the `Elasticsearch` client.
@@ -203,4 +216,4 @@ You can test your application using a local Elasticsearch based on the
     )
     ```
 
-3. Optionally, try out the included `Kibana` frontend to see your data.
+3. Optionally, try out the included `Kibana` frontend to see your uploaded data.

--- a/docs/connectors/sinks/elasticsearch-sink.md
+++ b/docs/connectors/sinks/elasticsearch-sink.md
@@ -1,0 +1,206 @@
+# Elasticsearch Sink
+
+!!! info
+
+    This is a **Community** connector. Test it before using in production.
+
+    To learn more about differences between Core and Community connectors, see the [Community and Core Connectors](../community-and-core.md) page.
+
+This sink writes data to a Elasticsearch Index, with a few ways to dump data.
+
+
+## How To Install
+
+To use the Elasticsearch sink, you need to install the required dependencies:
+
+```bash
+pip install quixstreams[elasticsearch]
+```
+
+## How It Works
+
+`ElasticsearchSink` is a streaming sink that publishes messages to Elasticsearch in batches.
+
+You can customize how to handle/export them with `ElasticsearchSink`, but the most common
+(and default) approach is having a 1:1 correspondence between Kafka message `key` and 
+document `_id`, and field types automatically ("dynamically") inferred.
+
+Also, messages are sent to Elasticsearch in the same order they are received from Kafka
+for each specific partition.
+
+
+## Export Behavior
+
+How data is dumped with `ElasticsearchSink` primarily depends on two parameters: the 
+`document_id_setter` and `mapper`.
+
+### Specifying Index Field Types
+
+To specify an Index's field types, you generally pass an Elasticsearch `mapping` dict.
+
+By default, a simple "dynamic" mapping is used, which determines a field's type based 
+on the initial type encountered.
+
+> ex: if the first encountered instance of field `quantity` is `5`, then 
+that field is assumed to be an `integer` field.
+
+#### Using a Custom Mapping
+
+You can override (or add to) the default behavior by passing your own mapping.
+
+#### Mapping Example
+
+Here we specify that the field `host` should be a `keyword`, otherwise 
+keep the default behavior:
+
+```python
+custom_mapping = {
+    "mappings": {
+        "dynamic": "true",  # keeps default behavior
+        "properties": {
+            "host": {  # enforce type for `host` field
+                "type": "keyword"
+            }
+        },
+    },
+}
+elasticsearch_sink = ElasticsearchSink(
+    # ... other args here ...
+    mapping=custom_mapping,
+)
+```
+
+To learn more, check out the [Elasticsearch mappings docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html).
+
+
+### Document ID setting
+
+The default `document_id_setter` assumes the message `key` corresponds to an equivalently 
+named document `_id`, so it attempts to match on that for updating.
+
+If no such `_id` exists (and `ElasticsearchSink` has `upsert=True`), the document will instead 
+be created with that `_id`.
+
+
+#### Using A Custom `_id`
+
+A custom `_id` can be used by simply providing your own 
+`document_id_setter` to `ElasticsearchSink` (which should return a string, or `None`).
+
+If no match is found, the document will instead be created with that `_id`.
+
+If no `document_id_setter` or `_id` specification is specified, Elasticsearch will 
+create a new document with a random unique `_id`.
+
+
+#### id setter Example
+```python
+from quixstreams.sinks.community.elasticsearch import ElasticsearchSink
+from quixstreams.sinks.base.item import SinkItem
+
+def get_last_name(batch_item: SinkItem) -> str:
+    return batch_item.value["name"]["last"]
+
+sink = ElasticsearchSink(
+    ..., # other required stuff
+    document_id_setter=get_last_name,
+)
+```
+
+### Include Message Metadata
+
+You can include `topic` (topic, partition, offset) and `message` 
+(key, headers, timestamp) metadata using the flags 
+`add_topic_metadata=True` and `add_message_metadata=True` for `ElasticsearchSink`. 
+
+They will be included as
+`__{field}` in the document.
+
+#### Example document with `add_message_metadata=True`:
+```python
+{
+    "field_x": "value_a",
+    "field_y": "value_b",
+    "__key": b"my_key",
+    "__headers": {},
+    "__timestamp": 1234567890,
+}
+
+```
+
+## How To Use
+
+Create an instance of `ElasticsearchSink` and pass it to the `StreamingDataFrame.sink()` method:
+
+```python
+import os
+from quixstreams import Application
+from quixstreams.sinks.community.elasticsearch import ElasticsearchSink
+
+app = Application(broker_address="localhost:9092")
+topic = app.topic("topic-name")
+
+# Message structured as:
+# key: "CID_12345"
+# value: {"name": {"first": "John", "last": "Doe"}, "age": 28, "city": "Los Angeles"}
+
+# Configure the sink
+elasticsearch_sink = ElasticsearchSink(
+    url="http://localhost:9200",
+    index="my_index",
+)
+
+sdf = app.dataframe(topic=topic)
+sdf.sink(elasticsearch_sink)
+
+# Elasticsearch Document: 
+# {"_id": "CID_12345", "name": {"first": "John", "last": "Doe"}, "age": 28, "city": "Los Angeles"}
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## Configuration Options
+
+- `url`: Elasticsearch url
+- `index`: Elasticsearch index name
+- `mapping`: a custom mapping  
+    **Default**: Dynamically maps all field types
+- `batch_size`: how large each chunk size is with bulk  
+    **Default**: 500
+- `max_bulk_retries`: number of retry attempts for each bulk batch  
+    **Default**: 3
+- `document_id_setter`: how to select the document id.
+    **Default**: `_id` set to the kafka message key.
+- `add_message_metadata`: include key, timestamp, and headers as `__{field}`    
+    **Default**: False
+- `add_topic_metadata`: include topic, partition, and offset as `__{field}`    
+    **Default**: False
+- `ignore_bulk_upload_errors`: ignore any errors that occur when attempting an upload  
+    **Default**: False
+
+Additional keyword arguments are passed to the `Elasticsearch` client.
+
+## Testing Locally
+
+You can test your application using a local Elasticsearch based on the 
+[Elasticsearch running locally guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/run-elasticsearch-locally.html):
+
+1. Execute in terminal from a desired folder:
+
+    ```bash
+    curl -fsSL https://elastic.co/start-local | sh
+    ```
+
+2. Connect using the `api_key` printed by the output from step 1:
+    ```python
+    from quixstreams.sinks.community.elasticsearch import ElasticsearchSink
+   
+    elasticsearch_sink = ElasticsearchSink(
+        host="http://localhost:9200",
+        index="<YOUR INDEX>",
+        api_key="<PRINTED IN TERMINAL>",
+    )
+    ```
+
+3. Optionally, try out the included `Kibana` frontend to see your data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ all = [
     "azure-storage-blob>=12.24.0,<12.25",
     "neo4j>=5.27.0,<6",
     "pymongo>=4.11,<5",
-    "pandas>=1.0.0,<3.0"
+    "pandas>=1.0.0,<3.0",
+    "elasticsearch>=8.17,<9",
+    "confluent-kafka[avro,json,protobuf,schemaregistry]>=2.8.2,<2.9",
 ]
 
 avro = ["fastavro>=1.8,<2.0"]
@@ -57,6 +59,8 @@ azure = ["azure-storage-blob>=12.24.0,<12.25"]
 neo4j = ["neo4j>=5.27.0,<6"]
 mongodb = ["pymongo>=4.11,<5"]
 pandas = ["pandas>=1.0.0,<3.0"]
+elasticsearch = ["elasticsearch>=8.17,<9"]
+schema_registry = ["confluent-kafka[avro,json,protobuf,schemaregistry]>=2.8.2,<2.9"]
 
 # AWS dependencies are separated by service to support
 # different requirements in the future.

--- a/quixstreams/sinks/community/elasticsearch.py
+++ b/quixstreams/sinks/community/elasticsearch.py
@@ -1,0 +1,189 @@
+try:
+    from elasticsearch import Elasticsearch
+    from elasticsearch import helpers as es_helpers
+except ImportError as exc:
+    raise ImportError(
+        f"Package {exc.name} is missing: "
+        'run "pip install quixstreams[elasticsearch]" to use ElasticSearchSink'
+    ) from exc
+import logging
+import sys
+import time
+from functools import partial
+from typing import Callable, Optional
+
+from quixstreams.sinks import SinkBatch
+from quixstreams.sinks.base import (
+    BatchingSink,
+    ClientConnectFailureCallback,
+    ClientConnectSuccessCallback,
+)
+from quixstreams.sinks.base.item import SinkItem
+
+__all__ = ("ElasticsearchSink",)
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_MAPPING = {"mappings": {"dynamic": "true"}}
+
+
+def _default_document_id_setter(item: SinkItem) -> str:
+    key = item.key
+    if isinstance(key, bytes):
+        return str(key.decode())
+    return str(key)
+
+
+class ElasticsearchSink(BatchingSink):
+    """
+    Pushes data to an ElasticSearch index.
+
+    By default, uses the kafka message key as the document ID, and dynamically generates
+    the field types.
+
+    You can pass your own type mapping or document ID setter for custom behavior.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        index: str,
+        mapping: Optional[dict] = None,
+        document_id_setter: Optional[
+            Callable[[SinkItem], Optional[str]]
+        ] = _default_document_id_setter,
+        batch_size: int = 500,
+        add_message_metadata: bool = False,
+        add_topic_metadata: bool = False,
+        ignore_bulk_upload_errors: bool = False,
+        max_bulk_retries: int = 3,
+        on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
+        on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
+        **kwargs,
+    ):
+        """
+        :param url: the ElasticSearch host url
+        :param index: the ElasticSearch index name
+        :param mapping: a custom mapping; the default dynamically maps all field types
+        :param document_id_setter: how to select the document id; the default is the Kafka message key
+        :param batch_size: how large each chunk size is with bulk
+        :param max_bulk_retries: number of retry attempts for each bulk batch
+        :param add_message_metadata: add key, timestamp, and headers as `__{field}`
+        :param add_topic_metadata: add topic, partition, and offset as `__{field}`
+        :param ignore_bulk_upload_errors: ignore any errors that occur when attempting an upload
+        :param on_client_connect_success: An optional callback made after successful
+            client authentication, primarily for additional logging.
+        :param on_client_connect_failure: An optional callback made after failed
+            client authentication (which should raise an Exception).
+            Callback should accept the raised Exception as an argument.
+            Callback must resolve (or propagate/re-raise) the Exception.
+        :param kwargs: additional kwargs that are passed to the ElasticSearch client
+        """
+        super().__init__(
+            on_client_connect_success=on_client_connect_success,
+            on_client_connect_failure=on_client_connect_failure,
+        )
+
+        self._client_kwargs = {"hosts": url, **kwargs}
+        self._url = url
+        self._index = index
+        self._batch_size = batch_size
+        self._max_bulk_retries = max_bulk_retries
+        self._ignore_bulk_errors = ignore_bulk_upload_errors
+        self._document_id_setter = document_id_setter
+        self._mapping = mapping or DEFAULT_MAPPING
+        self._add_message_metadata = add_message_metadata
+        self._add_topic_metadata = add_topic_metadata
+        self._client: Optional[Elasticsearch] = None
+
+    def setup(self):
+        self._client = Elasticsearch(**self._client_kwargs)
+        self._client.info()
+        self._create_index()
+
+    def _create_index(self):
+        """Create index if it doesn't exist."""
+        if not self._client.indices.exists(index=self._index):
+            logging.info(
+                f"Creating Index '{self._index}' created with mapping: '{self._mapping}'..."
+            )
+            self._client.indices.create(index=self._index, body=self._mapping)
+        else:
+            logging.debug(f"Index '{self._index}' already exists.")
+
+    def _add_metadata(self, topic: str, partition: int, record: SinkItem) -> dict:
+        value = record.value
+        if self._add_message_metadata:
+            # tuples and bytes are one of the few unsupported common types, so we
+            # convert them so users don't need to manage it.
+            key = record.key
+            if isinstance(key, tuple):
+                key = [k.decode() if isinstance(k, bytes) else k for k in key]
+            elif isinstance(key, bytes):
+                key = key.decode()
+            value["__key"] = key
+            value["__headers"] = {
+                k: v.decode() if isinstance(v, bytes) else v
+                for k, v in dict(record.headers or {}).items()
+            }
+            value["__timestamp"] = record.timestamp
+        if self._add_topic_metadata:
+            value["__topic"] = topic
+            value["__partition"] = partition
+            value["__offset"] = record.offset
+        return value
+
+    def write(self, batch: SinkBatch) -> None:
+        start = time.monotonic()
+        min_timestamp = sys.maxsize
+        max_timestamp = -1
+
+        if self._add_message_metadata or self._add_topic_metadata:
+            add_metadata = partial(self._add_metadata, batch.topic, batch.partition)
+        else:
+            add_metadata = None
+
+        for chunk in batch.iter_chunks(n=self._batch_size):
+            records = []
+            for item in chunk:
+                ts = item.timestamp
+                records.append(
+                    {
+                        # TODO: Allow users to select their own index
+                        # _index: custom_index_function,
+                        "_id": self._document_id_setter(item)
+                        if self._document_id_setter
+                        else None,
+                        "_source": add_metadata(item) if add_metadata else item.value,
+                    }
+                )
+                min_timestamp = min(ts, min_timestamp)
+                max_timestamp = max(ts, max_timestamp)
+
+            success, failure = es_helpers.bulk(
+                client=self._client,
+                actions=records,
+                index=self._index,
+                max_retries=self._max_bulk_retries,
+                max_backoff=30,
+                raise_on_exception=not self._ignore_bulk_errors,
+            )
+            # Note: this will only occur when self._ignore_bulk_errors is True,
+            # as failures should otherwise raise.
+            if failure:
+                logger.warning(
+                    f"Ignoring ElasticSearch upload errors "
+                    f'due to "ignore_bulk_errors" setting: {failure}'
+                )
+
+        logger.info(
+            "Sent documents to ElasticSearch; "
+            f"messages_processed={batch.size} "
+            f"host_address={self._url} "
+            f"index={self._index} "
+            f"min_timestamp={min_timestamp} "
+            f"max_timestamp={max_timestamp} "
+            f"time_elapsed={round(time.monotonic() - start, 2)}s"
+        )


### PR DESCRIPTION
Tomas needed something ASAP so this is a simple (and a little rough) version of an Elasticsearch sink.

Here's an example using the connect instructions found in the included doc file in this PR

```
from quixstreams import Application
from quixstreams.sources import Source
from datetime import datetime, timedelta
from quixstreams.sinks.community.elasticsearch import ElasticsearchSink


class MemoryUsageGenerator(Source):
    time = datetime.utcnow()

    memory_allocation_data = [
        {"m": "mem", "host": "host1", "used_percent": 64.56, "time": (time + timedelta(seconds=1)).isoformat()},
        {"m": "mem", "host": "host2", "used_percent": 71.89, "time": (time + timedelta(seconds=2)).isoformat()},
        {"m": "mem", "host": "host1", "used_percent": 63.27, "time": (time + timedelta(seconds=3)).isoformat()},
        {"m": "mem", "host": "host2", "used_percent": 73.45, "time": (time + timedelta(seconds=4)).isoformat()},
    ]

    def run(self):
        data = iter(self.memory_allocation_data)
        while self.running:
            try:
                event = next(data)
                event_serialized = self.serialize(key=event["host"], value=event)
                self.produce(key=event_serialized.key, value=event_serialized.value)
            except StopIteration:
                return


def main():
    app = Application(
        broker_address="localhost:9092",
        consumer_group="data_producer",
        auto_create_topics=True,
        loglevel="DEBUG",
    )
    
    # OPTIONAL, used for example purposes
    custom_es_mapping = {
        "mappings": {
            "dynamic": "true",
            "properties": {
                "host": {
                    "type": "keyword"
                }
            },
        },
    }

    memory_usage_source = MemoryUsageGenerator(name="memory-usage-producer")
    elasticsearch_sink = ElasticsearchSink(
        url="http://localhost:9200",
        index="memory-usage-producer",
        mapping=custom_es_mapping,  # optional, otherwise defaults to dynamic mapping
        batch_size=2,
        add_message_metadata=True,
        # The below argument is a kwarg passed to the normal ElasticSearch
        # class object for authentication. Pass any necessary keywords as required.
        api_key="<TERMINAL KEY HERE>",
    )
    app.dataframe(source=memory_usage_source).sink(elasticsearch_sink)
    app.run()


if __name__ == "__main__":
    main()
```