### PR TITLE
Fix SyntaxWarning

### DIFF
--- a/quixstreams/dataframe/windows/count_based.py
+++ b/quixstreams/dataframe/windows/count_based.py
@@ -118,7 +118,7 @@ class CountWindow(Window):
             )
 
         if collect:
-            if collection_start_id is -1:
+            if collection_start_id == -1:
                 collection_start_id = (
                     self._get_collection_start_id(data["windows"][0])
                     + data["windows"][0]["count"]


### PR DESCRIPTION
Fixes this:

In [1]: from quixstreams import Application
/Users/remy/Library/CloudStorage/Dropbox/workspace/quix/quix-streams/quixstreams/dataframe/windows/count_based.py:121: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?
  if collection_start_id is -1: