### PR TITLE
Fix key deserialization propagation in windows

### DIFF
--- a/quixstreams/dataframe/windows/sliding.py
+++ b/quixstreams/dataframe/windows/sliding.py
@@ -279,7 +279,7 @@ class SlidingWindow(TimeWindow):
         # build a complete list otherwise expired windows could be deleted
         # in state.delete_windows() and never be fetched.
         expired_windows = list(
-            self._expired_windows(state, max_expired_window_start, collect)
+            self._expired_windows(key, state, max_expired_window_start, collect)
         )
 
         state.delete_windows(
@@ -289,14 +289,14 @@ class SlidingWindow(TimeWindow):
 
         return reversed(updated_windows), expired_windows
 
-    def _expired_windows(self, state, max_expired_window_start, collect):
+    def _expired_windows(self, key, state, max_expired_window_start, collect):
         for window in state.expire_windows(
             max_start_time=max_expired_window_start,
             delete=False,
             collect=collect,
             end_inclusive=True,
         ):
-            (start, end), (max_timestamp, aggregated), collected, key = window
+            (start, end), (max_timestamp, aggregated), collected, _ = window
             if end == max_timestamp:
                 yield key, self._results(aggregated, collected, start, end)
 

--- a/quixstreams/dataframe/windows/sliding.py
+++ b/quixstreams/dataframe/windows/sliding.py
@@ -296,7 +296,7 @@ class SlidingWindow(TimeWindow):
             collect=collect,
             end_inclusive=True,
         ):
-            (start, end), (max_timestamp, aggregated), collected, _ = window
+            (start, end), (max_timestamp, aggregated), collected = window
             if end == max_timestamp:
                 yield key, self._results(aggregated, collected, start, end)
 

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -229,7 +229,7 @@ class TimeWindow(Window):
 
     def expire_by_key(
         self,
-        key: bytes,
+        key: Any,
         state: WindowedState,
         max_expired_start: int,
         collect: bool,

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -237,10 +237,7 @@ class TimeWindow(Window):
         start = time.monotonic()
         count = 0
 
-        for (
-            window_start,
-            window_end,
-        ), aggregated, collected, _ in state.expire_windows(
+        for (window_start, window_end), aggregated, collected in state.expire_windows(
             max_start_time=max_expired_start,
             collect=collect,
         ):

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -12,6 +12,9 @@ WindowDetail: TypeAlias = tuple[
     tuple[int, int], V, bytes
 ]  # (start, end), aggregated, key
 ExpiredWindowDetail: TypeAlias = tuple[
+    tuple[int, int], V, list[V]
+]  # (start, end), aggregated, collected
+ExpiredWindowDetailWithKey: TypeAlias = tuple[
     tuple[int, int], V, list[V], Any
 ]  # (start, end), aggregated, collected, key
 
@@ -378,7 +381,7 @@ class WindowedPartitionTransaction(Protocol[K, V]):
         step_ms: int,
         delete: bool = True,
         collect: bool = False,
-    ) -> Iterable[ExpiredWindowDetail[V]]:
+    ) -> Iterable[ExpiredWindowDetailWithKey[V]]:
         """
         Get all expired windows for all prefix from RocksDB up to the specified `max_start_time` timestamp.
 

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -12,7 +12,7 @@ WindowDetail: TypeAlias = tuple[
     tuple[int, int], V, bytes
 ]  # (start, end), aggregated, key
 ExpiredWindowDetail: TypeAlias = tuple[
-    tuple[int, int], V, list[V], bytes
+    tuple[int, int], V, list[V], Any
 ]  # (start, end), aggregated, collected, key
 
 

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_state.py
@@ -71,8 +71,8 @@ def test_expire_windows(transaction_state, delete):
 
     assert len(expired) == 2
     assert expired == [
-        ((0, 10), 1, [], b"__key__"),
-        ((10, 20), 2, [], b"__key__"),
+        ((0, 10), 1, []),
+        ((10, 20), 2, []),
     ]
 
     with transaction_state() as state:
@@ -112,8 +112,8 @@ def test_expire_windows_with_collect(transaction_state, end_inclusive):
     window_1_value = ["a", "b"] if end_inclusive else ["a"]
     window_2_value = ["b", "c"] if end_inclusive else ["b"]
     assert expired == [
-        ((0, 10), None, window_1_value, b"__key__"),
-        ((10, 20), [777, None], window_2_value, b"__key__"),
+        ((0, 10), None, window_1_value),
+        ((10, 20), [777, None], window_2_value),
     ]
 
 
@@ -132,7 +132,7 @@ def test_same_keys_in_db_and_update_cache(transaction_state):
         expired = list(state.expire_windows(max_start_time=max_start_time))
 
         # Value from the cache takes precedence over the value in the db
-        assert expired == [((0, 10), 3, [], b"__key__")]
+        assert expired == [((0, 10), 3, [])]
 
 
 def test_get_latest_timestamp(windowed_rocksdb_store_factory):

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_transaction.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_windowed/test_transaction.py
@@ -78,8 +78,8 @@ class TestWindowedRocksDBPartitionTransaction:
 
         assert len(expired) == 2
         assert expired == [
-            ((0, 10), 1, [], prefix),
-            ((10, 20), 2, [], prefix),
+            ((0, 10), 1, []),
+            ((10, 20), 2, []),
         ]
 
         with store.start_partition_transaction(0) as tx:
@@ -131,8 +131,8 @@ class TestWindowedRocksDBPartitionTransaction:
             )
             assert len(expired) == 2
             assert expired == [
-                ((0, 10), 1, [], prefix),
-                ((10, 20), 2, [], prefix),
+                ((0, 10), 1, []),
+                ((10, 20), 2, []),
             ]
             assert (
                 tx.get_window(start_ms=0, end_ms=10, prefix=prefix) == None
@@ -193,7 +193,7 @@ class TestWindowedRocksDBPartitionTransaction:
             )
 
         assert len(expired) == 1
-        assert expired == [((0, 10), 1, [], prefix)]
+        assert expired == [((0, 10), 1, [])]
 
     def test_expire_windows_with_grace_empty(self, windowed_rocksdb_store_factory):
         store = windowed_rocksdb_store_factory()
@@ -328,9 +328,9 @@ class TestWindowedRocksDBPartitionTransaction:
             )
 
         assert len(expired) == 3
-        assert expired[0] == ((0, 10), 1, [], prefix)
-        assert expired[1] == ((10, 20), 1, [], prefix)
-        assert expired[2] == ((20, 30), 1, [], prefix)
+        assert expired[0] == ((0, 10), 1, [])
+        assert expired[1] == ((10, 20), 1, [])
+        assert expired[2] == ((20, 30), 1, [])
 
     def test_get_latest_timestamp_update(self, windowed_rocksdb_store_factory):
         store = windowed_rocksdb_store_factory()


### PR DESCRIPTION
Despite `key_deserializer` being set to `json`, after windowing, the deserialization is gone, and the key is served back as bytes. Affected windows:
* sliding
* tumbling and hopping in closing strategy "partition" mode

Tumbling and hopping windows with the closing strategy "key" are unaffected.

* The fix for the sliding window was rather trivial. All we need is to use the deserialized key coming directly from `process_window` instead of the serialized one coming from the store.
  * As a side effect, turns out nothing is utilizing the key from `state.expire_windows`, so it doesn't need to return it.
* The fix for the "partition" expiration mode is less elegant; refer to the docstring of `_deserialize_prefix` for a detailed explanation.