### PR TITLE
Feature: Collect duplicates in join-related store

### DIFF
--- a/quixstreams/dataframe/joins/join_asof.py
+++ b/quixstreams/dataframe/joins/join_asof.py
@@ -53,7 +53,7 @@ class JoinAsOf:
                 f"a callable to merge records manually."
             )
 
-        self._retention_ms = ensure_milliseconds(grace_ms)
+        self._grace_ms = ensure_milliseconds(grace_ms)
         self._store_name = store_name or "join"
 
     def join(
@@ -72,6 +72,7 @@ class JoinAsOf:
         right.processing_context.state_manager.register_timestamped_store(
             stream_id=right.stream_id,
             store_name=self._store_name,
+            grace_ms=self._grace_ms,
             changelog_config=changelog_config,
         )
 
@@ -101,12 +102,7 @@ class JoinAsOf:
                     store_name=self._store_name,
                 ),
             )
-            tx.set_for_timestamp(
-                timestamp=timestamp,
-                value=value,
-                prefix=key,
-                retention_ms=self._retention_ms,
-            )
+            tx.set_for_timestamp(timestamp=timestamp, value=value, prefix=key)
 
         right = right.update(right_func, metadata=True).filter(lambda value: False)
         left = left.apply(left_func, metadata=True).filter(

--- a/quixstreams/dataframe/joins/join_asof.py
+++ b/quixstreams/dataframe/joins/join_asof.py
@@ -73,7 +73,7 @@ class JoinAsOf:
             stream_id=right.stream_id,
             store_name=self._store_name,
             grace_ms=self._grace_ms,
-            collect_duplicates=False,
+            keep_duplicates=False,
             changelog_config=changelog_config,
         )
 

--- a/quixstreams/dataframe/joins/join_asof.py
+++ b/quixstreams/dataframe/joins/join_asof.py
@@ -73,6 +73,7 @@ class JoinAsOf:
             stream_id=right.stream_id,
             store_name=self._store_name,
             grace_ms=self._grace_ms,
+            collect_duplicates=False,
             changelog_config=changelog_config,
         )
 

--- a/quixstreams/state/base/transaction.py
+++ b/quixstreams/state/base/transaction.py
@@ -277,7 +277,7 @@ class PartitionTransaction(ABC, Generic[K, V]):
         return deserialize(value, loads=self._loads)
 
     def _serialize_key(self, key: K, prefix: bytes) -> bytes:
-        key_bytes = serialize(key, dumps=self._dumps)
+        key_bytes = key if isinstance(key, bytes) else serialize(key, dumps=self._dumps)
         prefix = prefix + SEPARATOR if prefix else b""
         return prefix + key_bytes
 

--- a/quixstreams/state/manager.py
+++ b/quixstreams/state/manager.py
@@ -213,7 +213,7 @@ class StateStoreManager:
         stream_id: str,
         store_name: str,
         grace_ms: int,
-        collect_duplicates: bool,
+        keep_duplicates: bool,
         changelog_config: Optional[TopicConfig] = None,
     ) -> None:
         if self._stores.get(stream_id, {}).get(store_name):
@@ -226,7 +226,7 @@ class StateStoreManager:
             stream_id=stream_id,
             base_dir=str(self._state_dir),
             grace_ms=grace_ms,
-            collect_duplicates=collect_duplicates,
+            keep_duplicates=keep_duplicates,
             changelog_producer_factory=self._setup_changelogs(
                 stream_id=stream_id,
                 store_name=store_name,

--- a/quixstreams/state/manager.py
+++ b/quixstreams/state/manager.py
@@ -212,6 +212,7 @@ class StateStoreManager:
         self,
         stream_id: str,
         store_name: str,
+        grace_ms: int,
         changelog_config: Optional[TopicConfig] = None,
     ) -> None:
         if self._stores.get(stream_id, {}).get(store_name):
@@ -223,6 +224,7 @@ class StateStoreManager:
             name=store_name,
             stream_id=stream_id,
             base_dir=str(self._state_dir),
+            grace_ms=grace_ms,
             changelog_producer_factory=self._setup_changelogs(
                 stream_id=stream_id,
                 store_name=store_name,

--- a/quixstreams/state/manager.py
+++ b/quixstreams/state/manager.py
@@ -213,6 +213,7 @@ class StateStoreManager:
         stream_id: str,
         store_name: str,
         grace_ms: int,
+        collect_duplicates: bool,
         changelog_config: Optional[TopicConfig] = None,
     ) -> None:
         if self._stores.get(stream_id, {}).get(store_name):
@@ -225,6 +226,7 @@ class StateStoreManager:
             stream_id=stream_id,
             base_dir=str(self._state_dir),
             grace_ms=grace_ms,
+            collect_duplicates=collect_duplicates,
             changelog_producer_factory=self._setup_changelogs(
                 stream_id=stream_id,
                 store_name=store_name,

--- a/quixstreams/state/rocksdb/cache.py
+++ b/quixstreams/state/rocksdb/cache.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 
 @dataclass
@@ -7,10 +7,3 @@ class Cache:
     key: bytes
     cf_name: str
     values: dict[bytes, Any] = field(default_factory=dict)
-
-
-@dataclass
-class CounterCache:
-    key: bytes
-    cf_name: str
-    counter: Optional[int] = None

--- a/quixstreams/state/rocksdb/cache.py
+++ b/quixstreams/state/rocksdb/cache.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Optional
 
 
 @dataclass
-class TimestampsCache:
+class Cache:
     key: bytes
     cf_name: str
-    timestamps: dict[bytes, Optional[int]] = field(default_factory=dict)
+    values: dict[bytes, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/quixstreams/state/rocksdb/metadata.py
+++ b/quixstreams/state/rocksdb/metadata.py
@@ -1,2 +1,5 @@
 PROCESSED_OFFSET_KEY = b"__topic_offset__"
 CHANGELOG_OFFSET_KEY = b"__changelog_offset__"
+
+GLOBAL_COUNTER_CF_NAME = "__global-counter__"
+GLOBAL_COUNTER_KEY = b"__global_counter__"

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -13,18 +13,16 @@ from typing import (
 from rocksdict import AccessType, ColumnFamily, Rdict, ReadOptions, WriteBatch
 
 from quixstreams.state.base import (
-    PartitionTransaction,
     PartitionTransactionCache,
     StorePartition,
 )
 from quixstreams.state.metadata import METADATA_CF_NAME, Marker
 from quixstreams.state.recovery import ChangelogProducer
+from quixstreams.state.rocksdb.transaction import RocksDBPartitionTransaction
 from quixstreams.state.serialization import int_from_bytes, int_to_bytes
 
 from .exceptions import RocksDBCorruptedError
-from .metadata import (
-    CHANGELOG_OFFSET_KEY,
-)
+from .metadata import CHANGELOG_OFFSET_KEY
 from .options import RocksDBOptions
 from .types import RocksDBOptionsType
 
@@ -200,8 +198,8 @@ class RocksDBStorePartition(StorePartition):
                     break
                 yield key, value
 
-    def begin(self) -> PartitionTransaction:
-        return PartitionTransaction(
+    def begin(self) -> RocksDBPartitionTransaction:
+        return RocksDBPartitionTransaction(
             partition=self,
             dumps=self._dumps,
             loads=self._loads,

--- a/quixstreams/state/rocksdb/store.py
+++ b/quixstreams/state/rocksdb/store.py
@@ -23,8 +23,6 @@ class RocksDBStore(Store):
     partitions' transactions.
     """
 
-    store_partition_class = RocksDBStorePartition
-
     def __init__(
         self,
         name: str,
@@ -63,6 +61,6 @@ class RocksDBStore(Store):
                 self._changelog_producer_factory.get_partition_producer(partition)
             )
 
-        return self.store_partition_class(
+        return RocksDBStorePartition(
             path=path, options=self._options, changelog_producer=changelog_producer
         )

--- a/quixstreams/state/rocksdb/timestamped.py
+++ b/quixstreams/state/rocksdb/timestamped.py
@@ -97,13 +97,13 @@ class TimestampedPartitionTransaction(RocksDBPartitionTransaction):
         prefix = self._ensure_bytes(prefix)
         lower_bound_bytes = self._get_min_eligible_timestamp(prefix)
         # +1 because upper bound is exclusive
-        upper_bount_bytes = int_to_bytes(timestamp + 1)
+        upper_bound_bytes = int_to_bytes(timestamp + 1)
 
-        if upper_bount_bytes <= lower_bound_bytes:
+        if upper_bound_bytes <= lower_bound_bytes:
             return None
 
         lower_bound = self._serialize_key(lower_bound_bytes, prefix)
-        upper_bound = self._serialize_key(upper_bount_bytes, prefix)
+        upper_bound = self._serialize_key(upper_bound_bytes, prefix)
 
         deletes = self._update_cache.get_deletes()
         updates = self._update_cache.get_updates().get(prefix, {})
@@ -224,7 +224,7 @@ class TimestampedPartitionTransaction(RocksDBPartitionTransaction):
         Defaults to 0 if no timestamp is found.
 
         :param prefix: The key prefix (bytes).
-        :return: The minimum eligible timestamp (int).
+        :return: The minimum eligible timestamp as bytes.
         """
         cache = self._min_eligible_timestamps
         cached = cache.values.get(prefix)

--- a/quixstreams/state/rocksdb/timestamped.py
+++ b/quixstreams/state/rocksdb/timestamped.py
@@ -157,7 +157,7 @@ class TimestampedPartitionTransaction(RocksDBPartitionTransaction):
         :param prefix: The key prefix.
         """
         prefix = self._ensure_bytes(prefix)
-        counter = self._increment_global_counter() if self._keep_duplicates else 0
+        counter = self._increment_counter() if self._keep_duplicates else 0
         key = encode_integer_pair(timestamp, counter)
         self.set(key, value, prefix)
         min_eligible_timestamp = max(

--- a/quixstreams/state/rocksdb/timestamped.py
+++ b/quixstreams/state/rocksdb/timestamped.py
@@ -157,7 +157,7 @@ class TimestampedPartitionTransaction(RocksDBPartitionTransaction):
         :param prefix: The key prefix.
         """
         prefix = self._ensure_bytes(prefix)
-        counter = self._get_next_count() if self._keep_duplicates else 0
+        counter = self._increment_global_counter() if self._keep_duplicates else 0
         key = encode_integer_pair(timestamp, counter)
         self.set(key, value, prefix)
         min_eligible_timestamp = max(

--- a/quixstreams/state/rocksdb/transaction.py
+++ b/quixstreams/state/rocksdb/transaction.py
@@ -1,15 +1,19 @@
 from typing import Any, Optional
 
 from quixstreams.state.base.partition import StorePartition
-from quixstreams.state.base.transaction import PartitionTransaction
-from quixstreams.state.exceptions import StateSerializationError
+from quixstreams.state.base.transaction import (
+    PartitionTransaction,
+    PartitionTransactionStatus,
+    validate_transaction_status,
+)
 from quixstreams.state.recovery import ChangelogProducer
 from quixstreams.state.serialization import DumpsFunc, LoadsFunc
 
-from .cache import CounterCache
 from .metadata import GLOBAL_COUNTER_CF_NAME, GLOBAL_COUNTER_KEY
 
 __all__ = ["RocksDBPartitionTransaction"]
+
+MAX_UINT64 = 2**64 - 1  # 18446744073709551615
 
 
 class RocksDBPartitionTransaction(PartitionTransaction[bytes, Any]):
@@ -26,38 +30,43 @@ class RocksDBPartitionTransaction(PartitionTransaction[bytes, Any]):
             loads=loads,
             changelog_producer=changelog_producer,
         )
-        self._global_counter = CounterCache(
-            key=GLOBAL_COUNTER_KEY,
-            cf_name=GLOBAL_COUNTER_CF_NAME,
-        )
+        self._counter: Optional[int] = None
 
-    def _increment_global_counter(self) -> int:
+    @validate_transaction_status(PartitionTransactionStatus.STARTED)
+    def prepare(self, processed_offsets: Optional[dict[str, int]] = None) -> None:
+        """
+        This method first persists the counter and then calls the parent class's
+        `prepare()` to prepare the transaction for flush.
+
+        :param processed_offsets: the dict with <topic: offset> of the latest processed message
+        """
+        self._persist_counter()
+        super().prepare(processed_offsets=processed_offsets)
+
+    def _increment_counter(self) -> int:
         """
         Increment the global counter.
-
-        This method maintains a global counter in RocksDB to ensure unique
-        identifiers for values collected within the same timestamp. The counter
-        is cached to reduce database reads.
 
         The counter will reset to 0 if it reaches the maximum unsigned 64-bit
         integer value (18446744073709551615) to prevent overflow.
 
         :return: Next sequential counter value
         """
-        cache = self._global_counter
-
-        if cache.counter is None:
-            cache.counter = self.get(
-                key=cache.key, prefix=b"", default=-1, cf_name=cache.cf_name
+        if self._counter is None:
+            self._counter = self.get(
+                key=GLOBAL_COUNTER_KEY,
+                prefix=b"",
+                default=-1,
+                cf_name=GLOBAL_COUNTER_CF_NAME,
             )
+        self._counter = self._counter + 1 if self._counter < MAX_UINT64 else 0
+        return self._counter
 
-        cache.counter += 1
-
-        try:
-            value = self._serialize_value(cache.counter)
-        except StateSerializationError:
-            cache.counter = 0
-            value = self._serialize_value(cache.counter)
-
-        self.set_bytes(value=value, key=cache.key, prefix=b"", cf_name=cache.cf_name)
-        return cache.counter
+    def _persist_counter(self) -> None:
+        if self._counter is not None:
+            self.set(
+                value=self._counter,
+                key=GLOBAL_COUNTER_KEY,
+                prefix=b"",
+                cf_name=GLOBAL_COUNTER_CF_NAME,
+            )

--- a/quixstreams/state/rocksdb/transaction.py
+++ b/quixstreams/state/rocksdb/transaction.py
@@ -1,0 +1,53 @@
+from typing import Any, Optional
+
+from quixstreams.state.base.partition import StorePartition
+from quixstreams.state.base.transaction import PartitionTransaction
+from quixstreams.state.recovery import ChangelogProducer
+from quixstreams.state.serialization import DumpsFunc, LoadsFunc
+
+from .cache import CounterCache
+from .metadata import GLOBAL_COUNTER_CF_NAME, GLOBAL_COUNTER_KEY
+
+__all__ = ["RocksDBPartitionTransaction"]
+
+
+class RocksDBPartitionTransaction(PartitionTransaction[bytes, Any]):
+    def __init__(
+        self,
+        partition: StorePartition,
+        dumps: DumpsFunc,
+        loads: LoadsFunc,
+        changelog_producer: Optional["ChangelogProducer"] = None,
+    ) -> None:
+        super().__init__(
+            partition=partition,
+            dumps=dumps,
+            loads=loads,
+            changelog_producer=changelog_producer,
+        )
+        self._global_counter = CounterCache(
+            key=GLOBAL_COUNTER_KEY,
+            cf_name=GLOBAL_COUNTER_CF_NAME,
+        )
+
+    def _get_next_count(self) -> int:
+        """
+        Get the next unique global counter value.
+
+        This method maintains a global counter in RocksDB to ensure unique
+        identifiers for values collected within the same timestamp. The counter
+        is cached to reduce database reads.
+
+        :return: Next sequential counter value
+        """
+        cache = self._global_counter
+
+        if cache.counter is None:
+            cache.counter = self.get(
+                key=cache.key, prefix=b"", default=-1, cf_name=cache.cf_name
+            )
+
+        cache.counter += 1
+
+        self.set(value=cache.counter, key=cache.key, prefix=b"", cf_name=cache.cf_name)
+        return cache.counter

--- a/quixstreams/state/rocksdb/transaction.py
+++ b/quixstreams/state/rocksdb/transaction.py
@@ -31,9 +31,9 @@ class RocksDBPartitionTransaction(PartitionTransaction[bytes, Any]):
             cf_name=GLOBAL_COUNTER_CF_NAME,
         )
 
-    def _get_next_count(self) -> int:
+    def _increment_global_counter(self) -> int:
         """
-        Get the next unique global counter value.
+        Increment the global counter.
 
         This method maintains a global counter in RocksDB to ensure unique
         identifiers for values collected within the same timestamp. The counter

--- a/quixstreams/state/rocksdb/windowed/metadata.py
+++ b/quixstreams/state/rocksdb/windowed/metadata.py
@@ -10,7 +10,4 @@ LATEST_DELETED_VALUE_TIMESTAMP_KEY = b"__value_deleted_start_gt__"
 LATEST_TIMESTAMPS_CF_NAME = "__latest-timestamps__"
 LATEST_TIMESTAMP_KEY = b"__latest_timestamp__"
 
-GLOBAL_COUNTER_CF_NAME = "__global-counter__"
-GLOBAL_COUNTER_KEY = b"__global_counter__"
-
 VALUES_CF_NAME = "__values__"

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -153,7 +153,7 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
         value: Any,
         prefix: bytes,
     ) -> int:
-        counter = self._get_next_count()
+        counter = self._increment_global_counter()
         if id is None:
             key = encode_integer_pair(counter, counter)
         else:

--- a/quixstreams/state/rocksdb/windowed/transaction.py
+++ b/quixstreams/state/rocksdb/windowed/transaction.py
@@ -153,7 +153,7 @@ class WindowedRocksDBPartitionTransaction(RocksDBPartitionTransaction):
         value: Any,
         prefix: bytes,
     ) -> int:
-        counter = self._increment_global_counter()
+        counter = self._increment_counter()
         if id is None:
             key = encode_integer_pair(counter, counter)
         else:

--- a/tests/test_quixstreams/test_state/fixtures.py
+++ b/tests/test_quixstreams/test_state/fixtures.py
@@ -120,6 +120,7 @@ def timestamped_store_factory(tmp_path):
             name=name,
             base_dir=str(tmp_path),
             grace_ms=grace_ms,
+            collect_duplicates=False,
             changelog_producer_factory=changelog_producer_factory,
         )
 

--- a/tests/test_quixstreams/test_state/fixtures.py
+++ b/tests/test_quixstreams/test_state/fixtures.py
@@ -120,7 +120,7 @@ def timestamped_store_factory(tmp_path):
             name=name,
             base_dir=str(tmp_path),
             grace_ms=grace_ms,
-            collect_duplicates=False,
+            keep_duplicates=False,
             changelog_producer_factory=changelog_producer_factory,
         )
 

--- a/tests/test_quixstreams/test_state/test_manager.py
+++ b/tests/test_quixstreams/test_state/test_manager.py
@@ -105,9 +105,9 @@ class TestStateStoreManager:
             state_manager.register_windowed_store("stream_id", "store")
 
     def test_register_timestamped_store_twice(self, state_manager):
-        state_manager.register_timestamped_store("stream_id", "store", 1)
+        state_manager.register_timestamped_store("stream_id", "store", 1, False)
         with pytest.raises(StoreAlreadyRegisteredError):
-            state_manager.register_timestamped_store("stream_id", "store", 1)
+            state_manager.register_timestamped_store("stream_id", "store", 1, False)
 
     def test_get_store_not_registered(self, state_manager):
         with pytest.raises(StoreNotRegisteredError):

--- a/tests/test_quixstreams/test_state/test_manager.py
+++ b/tests/test_quixstreams/test_state/test_manager.py
@@ -105,9 +105,9 @@ class TestStateStoreManager:
             state_manager.register_windowed_store("stream_id", "store")
 
     def test_register_timestamped_store_twice(self, state_manager):
-        state_manager.register_timestamped_store("stream_id", "store")
+        state_manager.register_timestamped_store("stream_id", "store", 1)
         with pytest.raises(StoreAlreadyRegisteredError):
-            state_manager.register_timestamped_store("stream_id", "store")
+            state_manager.register_timestamped_store("stream_id", "store", 1)
 
     def test_get_store_not_registered(self, state_manager):
         with pytest.raises(StoreNotRegisteredError):

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_timestamped.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_timestamped.py
@@ -1,8 +1,10 @@
 from contextlib import contextmanager
-from typing import Any
+from datetime import timedelta
+from typing import Any, Union
 
 import pytest
 
+from quixstreams.dataframe.utils import ensure_milliseconds
 from quixstreams.state.rocksdb.timestamped import (
     TimestampedPartitionTransaction,
     TimestampedStore,
@@ -20,7 +22,8 @@ def store_type():
 @pytest.fixture
 def transaction(store: TimestampedStore):
     @contextmanager
-    def _transaction():
+    def _transaction(grace_ms: Union[int, timedelta] = timedelta(days=7)):
+        store._grace_ms = ensure_milliseconds(grace_ms)
         store.assign_partition(0)
         with store.start_partition_transaction(0) as tx:
             yield tx
@@ -107,17 +110,11 @@ class TestTimestampedPartitionTransaction:
         self,
         transaction: TimestampedPartitionTransaction,
     ):
-        with transaction() as tx:
-            tx.set_for_timestamp(
-                timestamp=10, value="value10", prefix=b"key", retention_ms=5
-            )
+        with transaction(grace_ms=5) as tx:
+            tx.set_for_timestamp(timestamp=10, value="value10", prefix=b"key")
             assert tx.get_latest(timestamp=10, prefix=b"key") == "value10"
-            tx.set_for_timestamp(
-                timestamp=5, value="value5", prefix=b"key", retention_ms=5
-            )
-            tx.set_for_timestamp(
-                timestamp=4, value="value4", prefix=b"key", retention_ms=5
-            )
+            tx.set_for_timestamp(timestamp=5, value="value5", prefix=b"key")
+            tx.set_for_timestamp(timestamp=4, value="value4", prefix=b"key")
 
         with transaction() as tx:
             assert tx.get_latest(timestamp=5, prefix=b"key") == "value5"
@@ -134,44 +131,36 @@ class TestTimestampedPartitionTransaction:
             assert tx.get_latest(timestamp=10, prefix="key") == "value"
             assert tx.get_latest(timestamp=10, prefix=b'"key"') == "value"
 
-    def test_set_for_timestamp_with_retention_cached(
+    def test_set_for_timestamp_with_grace_cached(
         self,
         transaction: TimestampedPartitionTransaction,
     ):
-        with transaction() as tx:
-            tx.set_for_timestamp(timestamp=2, value="v2", prefix=b"key", retention_ms=2)
-            tx.set_for_timestamp(timestamp=5, value="v5", prefix=b"key", retention_ms=2)
+        with transaction(grace_ms=2) as tx:
+            tx.set_for_timestamp(timestamp=2, value="v2", prefix=b"key")
+            tx.set_for_timestamp(timestamp=5, value="v5", prefix=b"key")
             assert tx.get_latest(timestamp=2, prefix=b"key") is None
             assert tx.get_latest(timestamp=5, prefix=b"key") == "v5"
 
-    def test_set_for_timestamp_with_retention_stored(
+    def test_set_for_timestamp_with_grace_stored(
         self,
         transaction: TimestampedPartitionTransaction,
     ):
-        with transaction() as tx:
-            tx.set_for_timestamp(timestamp=2, value="v2", prefix=b"key", retention_ms=2)
-            tx.set_for_timestamp(timestamp=5, value="v5", prefix=b"key", retention_ms=2)
+        with transaction(grace_ms=2) as tx:
+            tx.set_for_timestamp(timestamp=2, value="v2", prefix=b"key")
+            tx.set_for_timestamp(timestamp=5, value="v5", prefix=b"key")
 
-        with transaction() as tx:
+        with transaction(grace_ms=2) as tx:
             assert tx.get_latest(timestamp=2, prefix=b"key") is None
             assert tx.get_latest(timestamp=5, prefix=b"key") == "v5"
 
     def test_expire_multiple_keys(self, transaction: TimestampedPartitionTransaction):
-        with transaction() as tx:
-            tx.set_for_timestamp(
-                timestamp=1, value="11", prefix=b"key1", retention_ms=10
-            )
-            tx.set_for_timestamp(
-                timestamp=1, value="21", prefix=b"key2", retention_ms=10
-            )
-            tx.set_for_timestamp(
-                timestamp=12, value="112", prefix=b"key1", retention_ms=10
-            )
-            tx.set_for_timestamp(
-                timestamp=12, value="212", prefix=b"key2", retention_ms=10
-            )
+        with transaction(grace_ms=10) as tx:
+            tx.set_for_timestamp(timestamp=1, value="11", prefix=b"key1")
+            tx.set_for_timestamp(timestamp=1, value="21", prefix=b"key2")
+            tx.set_for_timestamp(timestamp=12, value="112", prefix=b"key1")
+            tx.set_for_timestamp(timestamp=12, value="212", prefix=b"key2")
 
-        with transaction() as tx:
+        with transaction(grace_ms=10) as tx:
             assert tx.get(key=1, prefix=b"key1") is None
             assert tx.get(key=1, prefix=b"key2") is None
             assert tx.get(key=12, prefix=b"key1") == "112"

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_transaction.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_transaction.py
@@ -1,0 +1,26 @@
+from contextlib import contextmanager
+
+import pytest
+
+from quixstreams.state.rocksdb.store import RocksDBStore
+
+
+@pytest.fixture
+def transaction(store: RocksDBStore):
+    @contextmanager
+    def _transaction():
+        store.assign_partition(0)
+        with store.start_partition_transaction(0) as tx:
+            yield tx
+
+    return _transaction
+
+
+def test_get_next_count(transaction):
+    with transaction() as tx:
+        assert tx._get_next_count() == 0
+        assert tx._get_next_count() == 1
+
+    with transaction() as tx:
+        assert tx._get_next_count() == 2
+        assert tx._get_next_count() == 3

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_transaction.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_transaction.py
@@ -18,20 +18,20 @@ def transaction(store: RocksDBStore):
     return _transaction
 
 
-def test_get_next_count(transaction):
+def test_increment_global_counter(transaction):
     with transaction() as tx:
-        assert tx._get_next_count() == 0
-        assert tx._get_next_count() == 1
+        assert tx._increment_global_counter() == 0
+        assert tx._increment_global_counter() == 1
 
     with transaction() as tx:
-        assert tx._get_next_count() == 2
-        assert tx._get_next_count() == 3
+        assert tx._increment_global_counter() == 2
+        assert tx._increment_global_counter() == 3
 
 
-def test_get_next_count_reset_to_zero(transaction):
+def test_increment_global_counter_reset_to_zero(transaction):
     with transaction() as tx:
-        cache = tx._global_counter
-        tx.set(value=MAX_UINT64 - 1, key=cache.key, prefix=b"", cf_name=cache.cf_name)
+        # Set the counter to the maximum value
+        tx._global_counter.counter = MAX_UINT64 - 1
 
-        assert tx._get_next_count() == MAX_UINT64
-        assert tx._get_next_count() == 0
+        assert tx._increment_global_counter() == MAX_UINT64
+        assert tx._increment_global_counter() == 0

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_transaction.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_transaction.py
@@ -2,9 +2,12 @@ from contextlib import contextmanager
 
 import pytest
 
+from quixstreams.state.rocksdb.metadata import (
+    GLOBAL_COUNTER_CF_NAME,
+    GLOBAL_COUNTER_KEY,
+)
 from quixstreams.state.rocksdb.store import RocksDBStore
-
-MAX_UINT64 = 2**64 - 1  # 18446744073709551615
+from quixstreams.state.rocksdb.transaction import MAX_UINT64
 
 
 @pytest.fixture
@@ -18,20 +21,56 @@ def transaction(store: RocksDBStore):
     return _transaction
 
 
-def test_increment_global_counter(transaction):
+def test_increment_counter(transaction):
     with transaction() as tx:
-        assert tx._increment_global_counter() == 0
-        assert tx._increment_global_counter() == 1
+        assert tx._increment_counter() == 0
+        assert tx._counter == 0
+        assert tx._increment_counter() == 1
+        assert tx._counter == 1
 
     with transaction() as tx:
-        assert tx._increment_global_counter() == 2
-        assert tx._increment_global_counter() == 3
+        assert tx._increment_counter() == 2
+        assert tx._counter == 2
+        assert tx._increment_counter() == 3
+        assert tx._counter == 3
 
 
-def test_increment_global_counter_reset_to_zero(transaction):
+def test_increment_counter_reset_to_zero(transaction):
     with transaction() as tx:
         # Set the counter to the maximum value
-        tx._global_counter.counter = MAX_UINT64 - 1
+        tx._counter = MAX_UINT64 - 1
+        assert tx._increment_counter() == MAX_UINT64
+        assert tx._counter == MAX_UINT64
 
-        assert tx._increment_global_counter() == MAX_UINT64
-        assert tx._increment_global_counter() == 0
+        # Next increment is going to reset the counter to 0
+        assert tx._increment_counter() == 0
+        assert tx._counter == 0
+
+
+def test_persist_counter_called_only_once(transaction):
+    with transaction() as tx:
+        assert tx._increment_counter() == 0
+        assert tx._increment_counter() == 1
+        assert tx._increment_counter() == 2
+
+        # The counter is not yet persisted
+        assert (
+            tx.get(
+                key=GLOBAL_COUNTER_KEY,
+                prefix=b"",
+                default=None,
+                cf_name=GLOBAL_COUNTER_CF_NAME,
+            )
+            is None
+        )
+
+    with transaction() as tx:
+        assert (
+            tx.get(
+                key=GLOBAL_COUNTER_KEY,
+                prefix=b"",
+                default=None,
+                cf_name=GLOBAL_COUNTER_CF_NAME,
+            )
+            == 2
+        )

--- a/tests/test_quixstreams/test_state/test_transaction.py
+++ b/tests/test_quixstreams/test_state/test_transaction.py
@@ -26,6 +26,7 @@ TEST_KEYS = [
     123,
     123.123,
     (123, 456),
+    b"somebytes",
 ]
 
 TEST_VALUES = [
@@ -240,9 +241,7 @@ class TestPartitionTransaction:
             with pytest.raises(StateSerializationError):
                 tx.set_bytes(key="key", value="value", prefix=prefix)
 
-    @pytest.mark.parametrize(
-        "key", [object(), b"somebytes", datetime.now(timezone.utc)]
-    )
+    @pytest.mark.parametrize("key", [object(), datetime.now(timezone.utc)])
     def test_delete_serialization_error(self, key, store_partition):
         prefix = b"__key__"
         with store_partition.begin() as tx:
@@ -274,8 +273,6 @@ class TestPartitionTransaction:
         with store_partition.begin() as tx:
             with pytest.raises(StateSerializationError):
                 tx.get(string_, prefix=b"")
-            with pytest.raises(StateSerializationError):
-                tx.get(bytes_, prefix=b"")
 
     def test_set_key_different_prefixes(self, store_partition):
         prefix1, prefix2 = b"__key1__", b"__key2__"


### PR DESCRIPTION
* Rename retention_ms to grace_ms
* Pass grace_ms to the store constructor instead of later to the method
* Move global counter logic to a separate base class `RocksDBPartitionTransaction`
* Use the new class for both:
  * WindowedRocksDBPartitionTransaction
  * TimestampedPartitionTransaction
* Reset global counter if it overflows the unsigned 64bit integer
* Add param `collect_duplicates` to instruct `TimestampedStore` to collect all values for the same timestamp.
* Refactor `TimestampsCache` into a generic`Cache` that may accept any values because we need to store bytes.