### PR TITLE
Add proactive window timeout functionality

### DIFF
--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -1081,12 +1081,14 @@ class Application:
                                             topic_name, partition, key, result, dataframe
                                         )
                                         
-                                    # If any windows were expired, log it for debugging
+                                    # If any windows were expired, remove the key from tracking
                                     if expired_results:
                                         logger.info(
                                             f"Expired {len(expired_results)} windows for key {key} "
                                             f"in topic {topic_name}[{partition}]"
                                         )
+                                        # Remove the key from active tracking since its windows have expired
+                                        self.untrack_window_key(topic_name, partition, key)
                                         
                                 except Exception as e:
                                     # Log the error but continue processing other keys

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -992,6 +992,7 @@ class Application:
         than only reactively when new messages arrive.
         """
         
+        
         # Skip if timeout checking is disabled
         if not self._enable_window_timeout_checking:
             return
@@ -1028,12 +1029,15 @@ class Application:
         :param topic_name: Name of the topic
         :param dataframe: The dataframe to check for timeout-enabled windows
         """
+        logger.info(f"Entering _expire_dataframe_timeouts")
+        
         # Check if this topic has timeout-enabled windows
         if topic_name not in self._timeout_enabled_windows:
             return
             
         # Get active keys for all partitions of this topic
         topic_keys = self._active_window_keys.get(topic_name, {})
+        logger.info(f"Active keys for topic {topic_name}: {topic_keys}")
         if not topic_keys:
             return
             
@@ -1046,6 +1050,8 @@ class Application:
                 # Get stream IDs for this topic
                 stream_ids = self._dataframe_registry.get_stream_ids(topic_name)
                 if not stream_ids:
+                    logger.info(
+                        f"No streams found for topic {topic_name}, skipping timeout processing.")
                     continue
                     
                 # Process timeouts for each stream that uses this topic

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -1125,8 +1125,7 @@ class Application:
                 topic=topic_name,
                 partition=partition,
                 offset=-1,  # Synthetic offset for timeout events
-                timestamp=int(time.time() * 1000),  # Current timestamp
-                headers={},
+                size=0,  # No actual message size for timeout events
             )
             
             # Process the timeout result through the dataframe pipeline
@@ -1137,12 +1136,13 @@ class Application:
             # Get the composed dataframe executor for this topic
             dataframes_composed = self._dataframe_registry.compose_all()
             if topic_name in dataframes_composed:
+                current_timestamp = int(time.time() * 1000)
                 execution_context.run(
                     dataframes_composed[topic_name],
-                    result.value,  # The aggregated window result
+                    result[1],  # The aggregated window result (result is tuple[key, result_dict])
                     key,
-                    context.timestamp,
-                    context.headers,
+                    current_timestamp,  # Use current timestamp for the timeout event
+                    [],  # Empty headers list for timeout events
                 )
                 
         except Exception as e:

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -1049,6 +1049,7 @@ class Application:
             try:
                 # Get stream IDs for this topic
                 stream_ids = self._dataframe_registry.get_stream_ids(topic_name)
+                logger.info(f"Found {len(stream_ids) if stream_ids else 0} streams for topic {topic_name}: {stream_ids}")
                 if not stream_ids:
                     logger.info(
                         f"No streams found for topic {topic_name}, skipping timeout processing.")
@@ -1056,39 +1057,48 @@ class Application:
                     
                 # Process timeouts for each stream that uses this topic
                 for stream_id in stream_ids:
+                    logger.info(f"Processing stream {stream_id} for topic {topic_name}")
                     # Process timeouts for each timeout-enabled window definition
                     for window_def in self._timeout_enabled_windows[topic_name]:
+                        logger.info(f"Processing window definition: {window_def._name if hasattr(window_def, '_name') else 'unnamed'}")
                         # Get window name to identify the correct store
                         if hasattr(window_def, '_name') and window_def._name:
                             store_name = window_def._name
+                            logger.info(f"Using store name: {store_name}")
                         else:
                             # Skip if we can't identify the store name
+                            logger.info("Skipping window definition - no name found")
                             continue
                             
                         try:
                             # Get store transaction for this stream/partition/store
+                            logger.info(f"Getting store transaction for stream={stream_id}, partition={partition}, store={store_name}")
                             transaction = self._processing_context.checkpoint.get_store_transaction(
                                 stream_id=stream_id,
                                 partition=partition,
                                 store_name=store_name
                             )
+                            logger.info(f"Got transaction: {transaction}")
                             
                             # Expire timeouts for each active key
                             for key in list(active_keys):  # Copy to avoid modification during iteration
                                 try:
+                                    logger.info(f"Checking timeouts for key {key}")
                                     expired_results = list(window_def.expire_timeouts_for_key(
                                         key, transaction, collect=False
                                     ))
+                                    logger.info(f"Got {len(expired_results)} expired results for key {key}")
                                     
                                     # Process expired windows through the dataframe pipeline
                                     for result in expired_results:
+                                        logger.info(f"Processing expired result: {result}")
                                         self._process_window_timeout_result(
                                             topic_name, partition, key, result, dataframe
                                         )
                                         
                                     # If any windows were expired, log it for debugging
                                     if expired_results:
-                                        logger.debug(
+                                        logger.info(
                                             f"Expired {len(expired_results)} windows for key {key} "
                                             f"in topic {topic_name}[{partition}]"
                                         )

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -1137,12 +1137,6 @@ class StreamingDataFrame:
             timeout_ms=timeout_ms,
         )
         
-        # Register the window for timeout checking if it has a timeout and registrar is available
-        if (timeout_ms is not None and 
-            self._processing_context.window_timeout_registrar is not None):
-            for topic in self._topics:
-                self._processing_context.window_timeout_registrar(topic.name, window_def)
-        
         return window_def
 
     def tumbling_count_window(

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -1043,6 +1043,7 @@ class StreamingDataFrame:
         grace_ms: Union[int, timedelta] = 0,
         name: Optional[str] = None,
         on_late: Optional[WindowOnLateCallback] = None,
+        timeout_ms: Optional[Union[int, timedelta]] = None,
     ) -> TumblingTimeWindowDefinition:
         """
         Create a time-based tumbling window transformation on this StreamingDataFrame.
@@ -1109,6 +1110,14 @@ class StreamingDataFrame:
             (default behavior).
             Otherwise, no message will be logged.
 
+        :param timeout_ms: an optional timeout for windows based on wall clock time.
+            Windows will be closed when the specified time has passed since the
+            window was first created, even if no new data is received.
+            Can be specified as either an `int` representing milliseconds
+            or as a `timedelta` object.
+            >***NOTE:*** `timedelta` objects will be rounded to the closest millisecond
+            value.
+
         :return: `TumblingTimeWindowDefinition` instance representing the tumbling window
             configuration.
             This object can be further configured with aggregation functions
@@ -1117,6 +1126,7 @@ class StreamingDataFrame:
         """
         duration_ms = ensure_milliseconds(duration_ms)
         grace_ms = ensure_milliseconds(grace_ms)
+        timeout_ms = ensure_milliseconds(timeout_ms) if timeout_ms is not None else None
 
         return TumblingTimeWindowDefinition(
             duration_ms=duration_ms,
@@ -1124,6 +1134,7 @@ class StreamingDataFrame:
             dataframe=self,
             name=name,
             on_late=on_late,
+            timeout_ms=timeout_ms,
         )
 
     def tumbling_count_window(

--- a/quixstreams/dataframe/windows/definitions.py
+++ b/quixstreams/dataframe/windows/definitions.py
@@ -360,7 +360,7 @@ class TumblingTimeWindowDefinition(TimeWindowDefinition):
         else:
             window_type = TimeWindowMultiAggregation
 
-        return window_type(
+        window = window_type(
             duration_ms=self._duration_ms,
             grace_ms=self._grace_ms,
             name=self._get_name(func_name=func_name),
@@ -370,6 +370,14 @@ class TumblingTimeWindowDefinition(TimeWindowDefinition):
             on_late=self._on_late,
             timeout_ms=self._timeout_ms,
         )
+        
+        # Register the window for timeout checking if it has a timeout and registrar is available
+        if (self._timeout_ms is not None and 
+            self._dataframe._processing_context.window_timeout_registrar is not None):
+            for topic in self._dataframe._topics:
+                self._dataframe._processing_context.window_timeout_registrar(topic.name, window)
+        
+        return window
 
 
 class SlidingTimeWindowDefinition(TimeWindowDefinition):

--- a/quixstreams/dataframe/windows/definitions.py
+++ b/quixstreams/dataframe/windows/definitions.py
@@ -329,6 +329,7 @@ class TumblingTimeWindowDefinition(TimeWindowDefinition):
         dataframe: "StreamingDataFrame",
         name: Optional[str] = None,
         on_late: Optional[WindowOnLateCallback] = None,
+        timeout_ms: Optional[int] = None,
     ):
         super().__init__(
             duration_ms=duration_ms,
@@ -337,6 +338,7 @@ class TumblingTimeWindowDefinition(TimeWindowDefinition):
             name=name,
             on_late=on_late,
         )
+        self._timeout_ms = timeout_ms
 
     def _get_name(self, func_name: Optional[str]) -> str:
         prefix = f"{self._name}_tumbling_window" if self._name else "tumbling_window"
@@ -366,6 +368,7 @@ class TumblingTimeWindowDefinition(TimeWindowDefinition):
             aggregators=aggregators or {},
             collectors=collectors or {},
             on_late=self._on_late,
+            timeout_ms=self._timeout_ms,
         )
 
 

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -345,10 +345,8 @@ class TimeWindow(Window):
             logger.info(f"No timeout configured for key {key}, returning empty list")
             return []
 
-        logger.info(f"Checking timeout expiration for key {key}, timeout_ms={self._timeout_ms}")
         expired_windows = []
         timeout_threshold = current_time_ms - self._timeout_ms
-        logger.info(f"Current time: {current_time_ms}, timeout threshold: {timeout_threshold}")
         
         # Instead of scanning by window start time (which is based on message timestamp),
         # we need to scan through all windows and check their creation times.
@@ -357,25 +355,20 @@ class TimeWindow(Window):
         
         # Get the latest timestamp from state to determine a reasonable scan range
         latest_msg_timestamp = state.get_latest_timestamp() or 0
-        logger.info(f"Latest message timestamp: {latest_msg_timestamp}")
         
         # Scan a broad range of message timestamps to find all active windows
         # This is not optimal but works for the timeout feature
         scan_start = max(0, latest_msg_timestamp - self._timeout_ms - self._duration_ms)
         scan_end = latest_msg_timestamp + self._duration_ms
-        logger.info(f"Scanning window range: {scan_start} to {scan_end}")
         
         # Get windows in the scanning range
         windows = state.get_windows(scan_start, scan_end)
-        logger.info(f"Found {len(windows)} windows to check for key {key}")
         
         for (window_start, window_end), aggregated, _ in windows:
-            logger.info(f"Checking window [{window_start}, {window_end})")
             last_activity_time = self._get_window_last_activity_time(state, window_start, window_end)
-            logger.info(f"Last activity time for window [{window_start}, {window_end}): {last_activity_time}")
             if last_activity_time is not None and last_activity_time <= timeout_threshold:
                 # This window has timed out
-                logger.info(f"Window [{window_start}, {window_end}) has timed out! Expiring...")
+                logger.info(f"Window [{window_start}, {window_end}) for key {key} has timed out! Expiring...")
                 collected = []
                 if collect:
                     collected = state.get_from_collection(window_start, window_end)
@@ -388,14 +381,6 @@ class TimeWindow(Window):
                 expired_windows.append(
                     (key, self._results(aggregated, collected, window_start, window_end))
                 )
-            else:
-                if last_activity_time is None:
-                    logger.info(f"Window [{window_start}, {window_end}) has no activity time recorded")
-                else:
-                    time_until_timeout = (last_activity_time - timeout_threshold) / 1000.0
-                    logger.info(f"Window [{window_start}, {window_end}) not expired yet, {time_until_timeout:.1f}s remaining")
-                
-        logger.info(f"Returning {len(expired_windows)} expired windows for key {key}")
         return expired_windows
 
     def expire_timeouts_for_key(
@@ -413,18 +398,13 @@ class TimeWindow(Window):
         :param collect: Whether this is a collect-type window
         :return: Iterable of expired window results
         """
-        logger.info(f"expire_timeouts_for_key called for key {key}, timeout_ms={self._timeout_ms}")
         if self._timeout_ms is None:
-            logger.info(f"No timeout configured, returning empty list")
             return []
         
         state = transaction.as_state(prefix=key)
         current_wall_time_ms = int(time.time() * 1000)
-        logger.info(f"Current wall time: {current_wall_time_ms}")
         
-        result = self._expire_timeout_windows(key, state, current_wall_time_ms, collect)
-        logger.info(f"expire_timeouts_for_key returning {len(result)} results")
-        return result
+        return self._expire_timeout_windows(key, state, current_wall_time_ms, collect)
 
 
 class TimeWindowSingleAggregation(SingleAggregationWindowMixin, TimeWindow):

--- a/quixstreams/processing/context.py
+++ b/quixstreams/processing/context.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
 import time
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from quixstreams.checkpointing import Checkpoint
 from quixstreams.dataframe import DataFrameRegistry
@@ -36,6 +36,9 @@ class ProcessingContext:
     commit_every: int = 0
     exactly_once: bool = False
     printer: Printer = Printer()
+    
+    # Callback for registering timeout-enabled windows
+    window_timeout_registrar: Optional[Callable[[str, Any], None]] = None
 
     _checkpoint: Optional[Checkpoint] = dataclasses.field(
         init=False, repr=False, default=None

--- a/quixstreams/processing/context.py
+++ b/quixstreams/processing/context.py
@@ -39,6 +39,9 @@ class ProcessingContext:
     
     # Callback for registering timeout-enabled windows
     window_timeout_registrar: Optional[Callable[[str, Any], None]] = None
+    
+    # Callback for tracking active window keys
+    window_key_tracker: Optional[Callable[[str, int, Any], None]] = None
 
     _checkpoint: Optional[Checkpoint] = dataclasses.field(
         init=False, repr=False, default=None


### PR DESCRIPTION
 ## Summary
  This PR implements comprehensive proactive window timeout functionality that allows windows to expire based on wall-clock time even when no new messages arrive.

 ## Key Features
  - **Proactive Expiration**: Windows can expire based on wall-clock time without requiring new messages
  - **Application Integration**: Timeout checking integrated into the consumer polling loop
  - **Key Tracking**: Efficient tracking of active window keys and their last activity times
  - **Memory Safety**: Automatic cleanup of expired keys to prevent memory leaks
  - **Configurable**: Enable/disable timeout checking and adjust check intervals

 ## Changes Made

 ### Core Implementation
  - **Application timeout infrastructure** (`quixstreams/app.py`)
    - Added `enable_window_timeout_checking` and `window_timeout_check_interval` configuration
    - Implemented key tracking system with `track_window_key()` and `untrack_window_key()`
    - Added `_check_window_timeouts()` method integrated into consumer polling loop
    - Added automatic cleanup of stale keys to prevent memory leaks

  - **Window timeout methods** (`quixstreams/dataframe/windows/time_based.py`)
    - Enhanced `expire_timeouts_for_key()` for proactive timeout checking
    - Improved timeout logic to use last activity time instead of creation time
    - Added proper window state cleanup when timeouts occur

  - **Processing integration** (`quixstreams/dataframe/windows/base.py`, `quixstreams/processing/context.py`)
    - Added callback infrastructure for window registration and key tracking
    - Hooked into window processing pipeline to automatically track active keys

  - **Window registration** (`quixstreams/dataframe/windows/definitions.py`, `quixstreams/dataframe/dataframe.py`)
    - Fixed window registration to happen after aggregation when windows have proper names
    - Added automatic registration of timeout-enabled windows

 ### Fixes
  - **Fixed AttributeError**: Resolved `'DataFrameRegistry' object has no attribute 'items'` error
  - **Proper timeout semantics**: Changed from creation time to last activity time for timeout calculations
  - **Window name handling**: Fixed registration timing so windows have proper names for store access
  - **Result processing**: Fixed MessageContext creation and window result processing

 ## Test Plan
  - [x] Unit tests for Application timeout configuration and key tracking
  - [x] Integration tests for timeout checking logic and window expiration
  - [x] End-to-end testing with real applications
  - [x] Memory leak prevention testing with stale key cleanup
  - [x] Multiple topic and partition scenarios

  ## Usage Example
  ```python
  from quixstreams import Application

  # Create application with timeout checking enabled
  app = Application(
      broker_address="localhost:9092",
      consumer_group="my-group",
      enable_window_timeout_checking=True,  # Enable timeout checking (default: True)
      window_timeout_check_interval=5.0,    # Check every 5 seconds (default: 5.0)
  )

  # Create a window with 30-second timeout
  topic = app.topic("input-topic")
  sdf = app.dataframe(topic)
  sdf = sdf.tumbling_window(
      duration_ms=60000,      # 1-minute windows
      timeout_ms=30000        # Expire after 30 seconds of inactivity
  ).sum()

  # Windows will now expire proactively after 30 seconds even without new messages
  app.run()

```

## Compatibility

  - ✅ Fully backward compatible - existing code works unchanged
  - ✅ Timeout functionality is opt-in via timeout_ms parameter
  - ✅ No performance impact when timeouts are not used
  - ✅ Configurable timeout checking can be disabled if needed


  ### **Files Changed**:
  The PR includes changes to the following files:
  - `quixstreams/app.py` - Main timeout infrastructure and Application integration
  - `quixstreams/dataframe/windows/time_based.py` - Proactive expiration methods
  - `quixstreams/dataframe/windows/base.py` - Key tracking hooks
  - `quixstreams/processing/context.py` - Callback infrastructure
  - `quixstreams/dataframe/dataframe.py` - Window registration integration
  - `quixstreams/dataframe/windows/definitions.py` - Window creation and registration
  - `tests/test_quixstreams/test_dataframe/test_windows/test_tumbling.py` - Comprehensive tests