### PR TITLE
feat: add QuixDatalakeSink for writing Kafka data to blob storage in …

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -34,6 +34,8 @@ requirements:
     - pandas >=1.0.0,<3.0
     - elasticsearch >=8.17,<9
     - rich >=13,<15
+    - fsspec >=2025.5
+    - cramjam >=2.10,<3
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,9 @@ all = [
     "pymongo>=4.11,<5",
     "pandas>=1.0.0,<3.0",
     "elasticsearch>=8.17,<9",
-    "influxdb>=5.3,<6"
+    "influxdb>=5.3,<6",
+    "cramjam>=2.10,<3",
+    "fsspec>=2025.5",
 ]
 
 avro = ["fastavro>=1.8,<2.0"]
@@ -61,7 +63,7 @@ neo4j = ["neo4j>=5.27.0,<6"]
 mongodb = ["pymongo>=4.11,<5"]
 pandas = ["pandas>=1.0.0,<3.0"]
 elasticsearch = ["elasticsearch>=8.17,<9"]
-datalake = ["quixstreams[avro]", "cramjam>=2.10", "fsspec>=2025.5", "s3fs>=2025.5", "gcsfs>=2025.5", "adlfs>=2024.12"]
+datalake = ["quixstreams[avro]", "cramjam>=2.10,<3", "fsspec>=2025.5", "s3fs>=2025.5", "gcsfs>=2025.5", "adlfs>=2024.12"]
 
 # AWS dependencies are separated by service to support
 # different requirements in the future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ neo4j = ["neo4j>=5.27.0,<6"]
 mongodb = ["pymongo>=4.11,<5"]
 pandas = ["pandas>=1.0.0,<3.0"]
 elasticsearch = ["elasticsearch>=8.17,<9"]
+datalake = ["quixstreams[avro]", "cramjam>=2.10", "fsspec>=2025.5", "s3fs>=2025.5", "gcsfs>=2025.5", "adlfs>=2024.12"]
 
 # AWS dependencies are separated by service to support
 # different requirements in the future.
@@ -122,6 +123,7 @@ module = [
   "confluent_kafka.*",
   "pyarrow.*",
   "jsonpath_ng.*",
+  "fsspec.*",
 ]
 ignore_missing_imports = true
 

--- a/quixstreams/sinks/__init__.py
+++ b/quixstreams/sinks/__init__.py
@@ -7,6 +7,7 @@ from .base import (
     SinkBatch,
     SinkManager,
 )
+from .core.datalake import QuixDatalakeSink, QuixDatalakeSinkConfig
 
 __all__ = [
     "BaseSink",
@@ -16,4 +17,6 @@ __all__ = [
     "SinkManager",
     "ClientConnectSuccessCallback",
     "ClientConnectFailureCallback",
+    "QuixDatalakeSink",
+    "QuixDatalakeSinkConfig",
 ]

--- a/quixstreams/sinks/__init__.py
+++ b/quixstreams/sinks/__init__.py
@@ -7,7 +7,7 @@ from .base import (
     SinkBatch,
     SinkManager,
 )
-from .core.datalake import QuixDatalakeSink, QuixDatalakeSinkConfig
+from .core.datalake import QuixDatalakeSink
 
 __all__ = [
     "BaseSink",
@@ -18,5 +18,4 @@ __all__ = [
     "ClientConnectSuccessCallback",
     "ClientConnectFailureCallback",
     "QuixDatalakeSink",
-    "QuixDatalakeSinkConfig",
 ]

--- a/quixstreams/sinks/core/datalake/__init__.py
+++ b/quixstreams/sinks/core/datalake/__init__.py
@@ -1,6 +1,5 @@
-from .sink import QuixDatalakeSink, QuixDatalakeSinkConfig
+from .sink import QuixDatalakeSink
 
 __all__ = [
     "QuixDatalakeSink",
-    "QuixDatalakeSinkConfig",
 ]

--- a/quixstreams/sinks/core/datalake/__init__.py
+++ b/quixstreams/sinks/core/datalake/__init__.py
@@ -1,0 +1,6 @@
+from .sink import QuixDatalakeSink, QuixDatalakeSinkConfig
+
+__all__ = [
+    "QuixDatalakeSink",
+    "QuixDatalakeSinkConfig",
+]

--- a/quixstreams/sinks/core/datalake/sink.py
+++ b/quixstreams/sinks/core/datalake/sink.py
@@ -82,9 +82,6 @@ class FileMetadata(TypedDict):
     created_at: int
 
 
-BufferKey = tuple[str, int, bytes]  # (topic, partition, key)
-
-
 class QuixDatalakeSink(BaseSink):
     """
     Sink for persisting raw Kafka topic data to Blob Storage in Avro format, with Hive-style partitioning and Parquet metadata for Quix DataLake (DuckDB-compatible).

--- a/quixstreams/sinks/core/datalake/sink.py
+++ b/quixstreams/sinks/core/datalake/sink.py
@@ -1,0 +1,251 @@
+import logging
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, TypedDict, Union
+
+import fsspec
+import pyarrow as pa
+import pyarrow.parquet as pq
+import requests
+from fastavro import writer as avro_writer
+
+from quixstreams.models.types import HeadersTuples
+from quixstreams.sinks.base.sink import BaseSink
+
+logger = logging.getLogger(__name__)
+
+AVRO_SCHEMA = {
+    "type": "record",
+    "name": "KafkaMessage",
+    "fields": [
+        {"name": "timestamp", "type": "long"},
+        {"name": "key", "type": ["null", "bytes"]},
+        {
+            "name": "headers",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "record",
+                    "name": "Header",
+                    "fields": [
+                        {"name": "key", "type": "string"},
+                        {"name": "value", "type": ["string", "bytes"]},
+                    ],
+                },
+            },
+        },
+        {"name": "value", "type": "bytes"},
+        {"name": "offset", "type": "long"},
+    ],
+}
+
+
+@dataclass
+class QuixDatalakeSinkConfig:
+    storage_url: str  # fsspec URL (e.g., abfs://, s3://, etc)
+    storage_options: Optional[Dict[str, Any]] = None
+    datacatalog_api_url: Optional[str] = None
+    avro_compression: str = "snappy"
+    datacatalog_timeout_sec: int = 5
+
+
+class AvroItem(TypedDict):
+    value: Any
+    key: bytes
+    timestamp: int
+    headers: list[dict[str, Union[str, bytes]]]
+    offset: int
+
+
+class Batch(TypedDict):
+    topic: str
+    partition: int
+    min_ts: int
+    max_ts: int
+    start_offset: int
+    end_offset: int
+    keys: Dict[bytes, list[AvroItem]]  # key -> list of items with that key
+
+
+class FileMetadata(TypedDict):
+    path: str
+    topic: str
+    key: str
+    partition: int
+    timestamp_start: int
+    timestamp_end: int
+    start_offset: int
+    end_offset: int
+    record_count: int
+    file_size_bytes: int
+    created_at: int
+
+
+BufferKey = tuple[str, int, bytes]  # (topic, partition, key)
+
+
+class QuixDatalakeSink(BaseSink):
+    """
+    Sink for persisting raw Kafka topic data to Blob Storage in Avro format, with Hive-style partitioning and Parquet metadata for Quix DataLake (DuckDB-compatible).
+    """
+
+    def __init__(self, config: QuixDatalakeSinkConfig) -> None:
+        super().__init__()
+        self.config = config
+
+        self.fs: fsspec.AbstractFileSystem = fsspec.filesystem(
+            self._get_protocol(config.storage_url), **(config.storage_options or {})
+        )
+        self._http_session = requests.Session()
+        # Change: topic -> partition -> Batch
+        self._topic_partition_data: dict[str, dict[int, Batch]] = defaultdict(dict)
+
+    def _get_protocol(self, url: str) -> str:
+        return url.split(":")[0]
+
+    def add(
+        self,
+        value: Any,
+        key: Union[str, bytes],
+        timestamp: int,
+        headers: HeadersTuples,
+        topic: str,
+        partition: int,
+        offset: int,
+    ) -> None:
+        if partition not in self._topic_partition_data[topic]:
+            self._topic_partition_data[topic][partition] = {
+                "topic": topic,
+                "partition": partition,
+                "min_ts": timestamp,
+                "max_ts": timestamp,
+                "start_offset": offset,
+                "end_offset": offset,
+                "keys": defaultdict(list),
+            }
+        else:
+            meta = self._topic_partition_data[topic][partition]
+            meta["min_ts"] = min(meta["min_ts"], timestamp)
+            meta["max_ts"] = max(meta["max_ts"], timestamp)
+            meta["end_offset"] = offset
+
+        k: bytes = key.encode() if isinstance(key, str) else key
+        self._topic_partition_data[topic][partition]["keys"][k].append(
+            {
+                "value": value,
+                "key": k,
+                "timestamp": timestamp,
+                "headers": [{"key": k, "value": v} for k, v in headers],
+                "offset": offset,
+            }
+        )
+
+    def flush(self) -> None:
+        if not self._topic_partition_data:
+            logger.debug("No records to flush")
+            return
+
+        for topic, partitions in self._topic_partition_data.items():
+            for partition, batch in partitions.items():
+                start = time.time()
+
+                created_files = self._flush_batch(batch)
+                self._update_metadata(
+                    topic=topic,
+                    partition=partition,
+                    start_offset=batch["start_offset"],
+                    end_offset=batch["end_offset"],
+                    files=created_files,
+                )
+
+                elapsed = time.time() - start
+                logger.info(
+                    f"Persisted records from {topic}[{partition}]{batch['start_offset']}..{batch['end_offset']} in {elapsed:.3f}s with {len(batch['keys'])} unique keys"
+                )
+
+            self._notify_datacatalog(topic)
+
+        self._topic_partition_data.clear()
+
+    def _flush_batch(self, batch: Batch) -> list[FileMetadata]:
+        created_files = []
+        for key, records in batch["keys"].items():
+            start = time.time()
+            metadata = self._write_avro_file(
+                batch,
+                key,
+                records,
+            )
+            elapsed = time.time() - start
+            logger.debug(
+                f"Flushed {metadata['record_count']} records to {metadata['path']} "
+                f"offsets {metadata['start_offset']}..{metadata['end_offset']} "
+                f"in {elapsed:.3f}s, {metadata['file_size_bytes']} bytes"
+            )
+            created_files.append(metadata)
+        return created_files
+
+    def _write_avro_file(
+        self,
+        batch: Batch,
+        key: bytes,
+        records: list[AvroItem],
+    ) -> FileMetadata:
+        record_count = len(records)
+        start_date = time.strftime("%Y-%m-%d", time.gmtime(batch["min_ts"] // 1000))
+        decoded_key = key.decode("utf-8", errors="backslashreplace")
+        avro_fname = f"ts_{batch['min_ts']}_{batch['max_ts']}_part_{batch['partition']}_off_{batch['start_offset']}_{batch['end_offset']}.avro.{self.config.avro_compression}"
+        avro_path = f"Raw/Topic={batch['topic']}/Key={decoded_key}/Start={start_date}/{avro_fname}"
+        full_path = f"{self.config.storage_url.rstrip('/')}/{avro_path}"
+
+        with self.fs.open(full_path, "wb") as f:
+            avro_writer(f, AVRO_SCHEMA, records, codec=self.config.avro_compression)
+
+        # Get file size after closing the file
+        file_size: Optional[int] = self.fs.size(full_path)
+
+        file: FileMetadata = {
+            "path": avro_path,
+            "topic": batch["topic"],
+            "key": decoded_key,
+            "partition": batch["partition"],
+            "timestamp_start": batch["min_ts"],
+            "timestamp_end": batch["max_ts"],
+            "start_offset": batch["start_offset"],
+            "end_offset": batch["end_offset"],
+            "record_count": record_count,
+            "file_size_bytes": 0 if file_size is None else file_size,
+            "created_at": round(time.time() * 1000),  # Store as milliseconds
+        }
+        return file
+
+    def _update_metadata(
+        self,
+        topic: str,
+        partition: int,
+        start_offset: int,
+        end_offset: int,
+        files: list[FileMetadata],
+    ) -> None:
+        index_path = f"Metadata/Topic={topic}/index_{partition}_{start_offset}_{end_offset}.parquet"
+        full_index_path = f"{self.config.storage_url.rstrip('/')}/{index_path}"
+
+        # Write all metadata rows at once, overwriting the file
+        with self.fs.open(full_index_path, "wb") as f:
+            pq.write_table(pa.Table.from_pylist(files), f)
+
+    def _notify_datacatalog(self, topic: str) -> None:
+        if not self.config.datacatalog_api_url:
+            return
+        logger.debug(f"Notifying Data Catalog for topic: {topic}")
+        url = f"{self.config.datacatalog_api_url}/{topic}/refresh-cache"
+        try:
+            resp = self._http_session.post(
+                url, timeout=self.config.datacatalog_timeout_sec
+            )
+            resp.raise_for_status()
+        except Exception as e:
+            logger.warning(f"Data Catalog notification failed: {url} error={e}")
+            return
+        logger.debug(f"Notified Data Catalog at: {url}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ jsonschema>=4.3.0
 jsonlines>=4,<5
 rich>=13,<15
 jsonpath_ng>=1.7.0,<2
+cramjam>=2.10,<3
+fsspec>=2025.5

--- a/tests/test_quixstreams/test_sinks/test_core/test_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_datalake_sink.py
@@ -1,0 +1,185 @@
+import os
+import shutil
+import tempfile
+from unittest import mock
+
+import pyarrow.parquet as pq
+import pytest
+from fastavro import reader as avro_reader
+
+from quixstreams.sinks.core.datalake.sink import (
+    QuixDatalakeSink,
+    QuixDatalakeSinkConfig,
+)
+
+
+class DummyFS:
+    """A dummy fsspec filesystem for local testing."""
+
+    def _path(self, path):
+        if path.startswith("dummy://"):
+            return path[len("dummy://") :]
+        return path
+
+    def open(self, path, mode):
+        full_path = self._path(path)
+        parent = os.path.dirname(full_path)
+        os.makedirs(parent, exist_ok=True)
+        return open(full_path, mode)
+
+    def size(self, path):
+        return os.path.getsize(self._path(path))
+
+
+@pytest.fixture
+def tmp_dir():
+    tmpdir = tempfile.mkdtemp()
+    with mock.patch("fsspec.filesystem", return_value=DummyFS()):
+        yield tmpdir
+    shutil.rmtree(tmpdir)
+
+
+@pytest.fixture
+def sink(tmp_dir):
+    """Fixture to create a QuixDatalakeSink instance."""
+    config = QuixDatalakeSinkConfig(
+        storage_url=f"dummy://{tmp_dir}/ws1",
+        storage_options=None,
+        datacatalog_api_url=None,
+    )
+    return QuixDatalakeSink(config)
+
+
+def walk(directory):
+    """A simple generator to walk through files in a directory."""
+
+    avro_files = []
+    parquet_files = []
+    for root, dirs, files in os.walk(directory):
+        for file in files:
+            if file.endswith(".avro.snappy"):
+                avro_files.append(os.path.join(root, file))
+            elif file.endswith(".parquet"):
+                parquet_files.append(os.path.join(root, file))
+
+    return avro_files, parquet_files
+
+
+def test_quix_datalake_sink_basic(tmp_dir, sink):
+    # Add two records with different keys
+    sink.add(b"val1", b"key1", 1000, [], "testtopic", 0, 1)
+    sink.add(b"val2", b"key2", 2000, [], "testtopic", 0, 2)
+    sink.flush()
+
+    avro_files, parquet_files = walk(os.path.join(tmp_dir, "ws1"))
+
+    # Check Avro content
+    assert len(avro_files) == 2
+    for avro_path in avro_files:
+        with open(avro_path, "rb") as f:
+            records = list(avro_reader(f))
+            assert records
+            assert len(records) == 1
+
+    # Check Parquet files: only one per topic/partition per flush
+    assert len(parquet_files) == 1
+    for parquet_path in parquet_files:
+        table = pq.read_table(parquet_path)
+        # Should have one row per Avro file
+        assert table.num_rows == 2
+
+
+def test_quix_datalake_sink_multiple_partitions(tmp_dir, sink):
+    # Add records to two partitions
+    sink.add(b"val1", b"key1", 1000, [], "testtopic", 0, 1)
+    sink.add(b"val2", b"key1", 2000, [], "testtopic", 1, 2)
+    sink.flush()
+
+    avro_files, parquet_files = walk(os.path.join(tmp_dir, "ws1"))
+
+    assert len(avro_files) == 2
+    for avro_path in avro_files:
+        with open(avro_path, "rb") as f:
+            records = list(avro_reader(f))
+            assert records
+            assert len(records) == 1
+
+    assert len(parquet_files) == 2
+    for parquet_path in parquet_files:
+        table = pq.read_table(parquet_path)
+        # Each should have one row (one Avro file per partition)
+        assert table.num_rows == 1
+
+
+def test_quix_datalake_sink_empty_flush(tmp_dir, sink):
+    # Flush without adding any records should not raise
+    sink.flush()
+    # No files should be created
+    raw_dir = os.path.join(tmp_dir, "ws1/Raw/Topic=testtopic")
+    assert not os.path.exists(raw_dir)
+
+
+def test_quix_datalake_sink_headers(tmp_dir, sink):
+    # Add a record with headers
+    sink.add(b"val1", b"key1", 1000, [("h1", b"v1"), ("h2", "v2")], "testtopic", 0, 1)
+    sink.flush()
+
+    avro_files, _ = walk(os.path.join(tmp_dir, "ws1"))
+
+    assert len(avro_files) == 1
+    for avro_path in avro_files:
+        with open(avro_path, "rb") as f:
+            records = list(avro_reader(f))
+            assert records
+            assert len(records) == 1
+            assert records[0]["headers"] == [
+                {"key": "h1", "value": b"v1"},
+                {"key": "h2", "value": "v2"},
+            ]
+
+
+def test_quix_datalake_sink_multiple_records(tmp_dir, sink):
+    # Add multiple records with the same key and partition
+    for i in range(5):
+        sink.add(f"val{i}".encode(), b"key1", 1000 + i, [], "testtopic", 0, i)
+    sink.flush()
+
+    avro_files, parquet_files = walk(os.path.join(tmp_dir, "ws1"))
+
+    # Should be a single Avro file for the key/partition
+    assert len(avro_files) == 1
+    for avro_path in avro_files:
+        with open(avro_path, "rb") as f:
+            records = list(avro_reader(f))
+            assert len(records) == 5
+            for idx, rec in enumerate(records):
+                assert rec["value"] == f"val{idx}".encode()
+
+    # Parquet index should have one file and one row
+    assert len(parquet_files) == 1
+    for parquet_path in parquet_files:
+        table = pq.read_table(parquet_path)
+        assert table.num_rows == 1
+
+
+def test_quix_datalake_sink_multiple_flush(tmp_dir, sink):
+    # Add records, flush, add more, flush again
+    sink.add(b"val1", b"key1", 1000, [], "testtopic", 0, 1)
+    sink.flush()
+    sink.add(b"val2", b"key1", 2000, [], "testtopic", 0, 2)
+    sink.flush()
+
+    avro_files, parquet_files = walk(os.path.join(tmp_dir, "ws1"))
+
+    # Should be two Avro files (one per flush)
+    assert len(avro_files) == 2
+    for avro_path in avro_files:
+        with open(avro_path, "rb") as f:
+            records = list(avro_reader(f))
+            assert len(records) == 1
+
+    # Parquet index should have two files (one per flush), each with one row
+    assert len(parquet_files) == 2
+    for parquet_path in parquet_files:
+        table = pq.read_table(parquet_path)
+        assert table.num_rows == 1


### PR DESCRIPTION
…Avro format

- Introduce QuixDatalakeSink and QuixDatalakeSinkConfig for persisting raw Kafka topic data to blob storage (S3, ADLS, GCS, etc.) using fsspec.
- Store data in Avro format with Hive-style partitioning and maintain Parquet metadata indexes for efficient querying.
- Add integration with Quix Data Catalog for cache refresh.
- Update pyproject.toml with new dependencies for datalake support.
- Add comprehensive tests for sink functionality, including partitioning, headers, multiple flushes, and empty flushes.