### PR TITLE
Feature: dynamic target topic routing

### DIFF
--- a/docs/processing.md
+++ b/docs/processing.md
@@ -385,55 +385,65 @@ To publish the current value of the `StreamingDataFrame` to a topic, simply call
 from `Application.topic()`
 as an argument.
 
-Similarly to other methods, `.to_topic()` creates a new `StreamingDataFrame` object.
-
-### Splitting data into multiple topics
-
-You can dynamically route messages to different topics based on the message content by providing a callable that returns a `Topic` object to the `StreamingDataFrame.to_topic()` method.
-
-The callable receives four arguments: the current value, message key, timestamp, and headers, and must return a `Topic` object.
-
-**Important Considerations:**
-
-It is strongly advised to declare all `Topic` instances beforehand (before running the application) rather than creating them dynamically within the callable. Creating topics dynamically can lead to accidentally creating numerous topics if there are mistakes in your logic, potentially saturating Kafka's partition limits and degrading cluster performance.
-
-Even when reusing the same topics, declare them once rather than reinstantiating them repeatedly, as each `Topic` initialization checks if the topic exists in the cluster and attempts to create it if it doesn't.
-
-**Example:**
-
-Imagine you process sensor data and want to route high-priority alerts to a different topic based on temperature thresholds:
+Similarly to other methods, `.to_topic()` creates a new `StreamingDataFrame` object:
 
 ```python
 from quixstreams import Application
 
 app = Application(broker_address='localhost:9092')
 
-# Pre-declare topics
+# Declare input and output topics
+input_topic = app.topic('input', value_deserializer='json')
+output_topic = app.topic('output', value_serializer='json')
+
+sdf = app.dataframe(input_topic)
+ 
+# Produce data to the output topic
+sdf = sdf.to_topic(topic=output_topic)
+```
+
+### Splitting data into multiple topics
+
+To dynamically route messages to different topics based on the message content, you can provide a callable that returns a `Topic` object to the `StreamingDataFrame.to_topic()` method:
+
+```python
+from quixstreams import Application
+from typing import Any
+
+app = Application(broker_address='localhost:9092')
+
+# Declare topics
 input_topic = app.topic('sensor-data', value_deserializer='json')
 normal_topic = app.topic('normal-readings', value_serializer='json')
 alert_topic = app.topic('high-temp-alerts', value_serializer='json')
 
 sdf = app.dataframe(input_topic)
-
-# Route messages to different topics based on temperature
-def route_by_temperature(value, key, timestamp, headers):
+ 
+def route_by_temperature(value: Any, key: Any, timestamp: int, headers):
+    """
+    Send messages to different topics based on temperature sensor value
+    """
     if value.get('temperature', 0) > 80:
         return alert_topic
     else:
         return normal_topic
 
-sdf = sdf.to_topic(route_by_temperature)
-```
+sdf = sdf.to_topic(topic=route_by_temperature)
 
-You can also combine this with key transformation:
-
-```python
-# Route to different topics AND change the message key
+# You can also combine it together with `key` transformation to change the message key
 sdf = sdf.to_topic(
-    route_by_temperature,
+    topic=route_by_temperature,
     key=lambda value: f"sensor-{value['sensor_id']}"
 )
 ```
+
+!!! warning "Important Considerations"
+    
+    We recommend declaring all `Topic` instances before staring the application instead of creating them dynamically within the passed callback.
+    
+    Creating topics dynamically can lead to accidentally creating numerous topics and saturating the broker's partitions limits.  
+    Also, each `app.topic()` calls checks if the topic exists in the cluster and attempts to create the missing one when `auto_create_topics=True` is passed to the `Application`.
+
 
 ### Changing Message Key Before Producing
 

--- a/docs/processing.md
+++ b/docs/processing.md
@@ -387,6 +387,54 @@ as an argument.
 
 Similarly to other methods, `.to_topic()` creates a new `StreamingDataFrame` object.
 
+### Splitting data into multiple topics
+
+You can dynamically route messages to different topics based on the message content by providing a callable that returns a `Topic` object to the `StreamingDataFrame.to_topic()` method.
+
+The callable receives four arguments: the current value, message key, timestamp, and headers, and must return a `Topic` object.
+
+**Important Considerations:**
+
+It is strongly advised to declare all `Topic` instances beforehand (before running the application) rather than creating them dynamically within the callable. Creating topics dynamically can lead to accidentally creating numerous topics if there are mistakes in your logic, potentially saturating Kafka's partition limits and degrading cluster performance.
+
+Even when reusing the same topics, declare them once rather than reinstantiating them repeatedly, as each `Topic` initialization checks if the topic exists in the cluster and attempts to create it if it doesn't.
+
+**Example:**
+
+Imagine you process sensor data and want to route high-priority alerts to a different topic based on temperature thresholds:
+
+```python
+from quixstreams import Application
+
+app = Application(broker_address='localhost:9092')
+
+# Pre-declare topics
+input_topic = app.topic('sensor-data', value_deserializer='json')
+normal_topic = app.topic('normal-readings', value_serializer='json')
+alert_topic = app.topic('high-temp-alerts', value_serializer='json')
+
+sdf = app.dataframe(input_topic)
+
+# Route messages to different topics based on temperature
+def route_by_temperature(value, key, timestamp, headers):
+    if value.get('temperature', 0) > 80:
+        return alert_topic
+    else:
+        return normal_topic
+
+sdf = sdf.to_topic(route_by_temperature)
+```
+
+You can also combine this with key transformation:
+
+```python
+# Route to different topics AND change the message key
+sdf = sdf.to_topic(
+    route_by_temperature,
+    key=lambda value: f"sensor-{value['sensor_id']}"
+)
+```
+
 ### Changing Message Key Before Producing
 
 To change the outgoing message key (which defaults to the current consumed key),

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -668,7 +668,9 @@ class StreamingDataFrame:
         return StreamingSeries.from_apply_callback(callback, sdf_id=id(self))
 
     def to_topic(
-        self, topic: Topic, key: Optional[Callable[[Any], Any]] = None
+        self,
+        topic: Union[Topic, Callable[[Any], Topic]],
+        key: Optional[Callable[[Any], Any]] = None,
     ) -> "StreamingDataFrame":
         """
         Produce current value to a topic. You can optionally specify a new key.
@@ -703,7 +705,7 @@ class StreamingDataFrame:
         """
         return self._add_update(
             lambda value, orig_key, timestamp, headers: self._produce(
-                topic=topic,
+                topic=topic if isinstance(topic, Topic) else topic(value),
                 value=value,
                 key=orig_key if key is None else key(value),
                 timestamp=timestamp,

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -667,6 +667,20 @@ class StreamingDataFrame:
 
         return StreamingSeries.from_apply_callback(callback, sdf_id=id(self))
 
+    @overload
+    def to_topic(
+        self,
+        topic: Topic,
+        key: Optional[Callable[[Any], Any]] = None,
+    ) -> "StreamingDataFrame": ...
+
+    @overload
+    def to_topic(
+        self,
+        topic: Callable[[Any, Any, int, Any], Topic],
+        key: Optional[Callable[[Any], Any]] = None,
+    ) -> "StreamingDataFrame": ...
+
     def to_topic(
         self,
         topic: Union[Topic, Callable[[Any, Any, int, Any], Topic]],

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -722,11 +722,14 @@ class StreamingDataFrame:
             By default, the current message key will be used.
         :return: the updated StreamingDataFrame instance (reassignment NOT required).
         """
+        if isinstance(topic, Topic):
+            topic_callback = lambda value, orig_key, timestamp, headers: topic
+        else:
+            topic_callback = topic
+
         return self._add_update(
             lambda value, orig_key, timestamp, headers: self._produce(
-                topic=topic
-                if isinstance(topic, Topic)
-                else topic(value, orig_key, timestamp, headers),
+                topic=topic_callback(value, orig_key, timestamp, headers),
                 value=value,
                 key=orig_key if key is None else key(value),
                 timestamp=timestamp,

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -709,13 +709,11 @@ class StreamingDataFrame:
             If a callable is provided, it will receive four arguments:
             value, key, timestamp, and headers of the current message.
             The callable must return a `Topic` object.
-            **Important**: It is strongly advised to declare `Topic` instances
-            beforehand using `app.topic()` rather than creating them dynamically
-            within the callable to avoid accidentally creating numerous topics
-            and saturating Kafka's partition limits. Additionally, even when
-            reusing the same topics, declare them once rather than reinstantiating
-            them repeatedly, as each `Topic` initialization checks if the topic
-            exists in the cluster and attempts to create it if it doesn't.
+            **Important**: We recommend declaring all `Topic` instances before
+            staring the application instead of creating them dynamically
+            within the passed callback. Creating topics dynamically can lead
+            to accidentally creating numerous topics and
+            saturating the broker's partitions limits.
         :param key: a callable to generate a new message key, optional.
             If passed, the return type of this callable must be serializable
             by `key_serializer` defined for this Topic object.

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -795,7 +795,7 @@ class TestStreamingDataFrameToTopic:
             value_serializer="json", value_deserializer="json"
         )
 
-        def topic_callback(value: Any) -> Topic:
+        def topic_callback(value: Any, key: Any, timestamp: int, headers: Any) -> Topic:
             return topic_0 if value == 0 else topic_1
 
         producer = internal_producer_factory()


### PR DESCRIPTION
- Enhanced `StreamingDataFrame.to_topic()` to accept a callable that returns a `Topic` object based on message content (value, key, timestamp, headers).
- Enables dynamic message routing to different topics based on message content.
- Maintains backward compatibility with existing `Topic` object usage
- Includes performance guidance to prevent accidental topic proliferation