### PR TITLE
Deprecate default Quix portal API url

### DIFF
--- a/docs/quix-platform.md
+++ b/docs/quix-platform.md
@@ -54,8 +54,10 @@ app = Application(broker_address=None)
 ### Outside of Quix Cloud
 
 
-#### 1. Obtain SDK Token
+#### 1. Obtain SDK Token and Quix Portal API URL
 First, [get your SDK Token](https://quix.io/docs/develop/authentication/streaming-token.html#how-to-find).
+
+The **Quix Portal API URL** can be found on the "Settings > API and Tokens" tab inside Quix Platform.
 
 > NOTE: A `Personal Access Token` (PAT) is also accepted, but often requires more configuration 
 > due to raised privileges. We recommend using the `SDK Token`.
@@ -68,8 +70,9 @@ these approaches:
 
 - **Set Environment Variables** (***recommended***):
     - Set `Quix__Sdk__Token` (double underscores!) to your `SDK Token`
-    - Set `Quix__Portal__Api` to `https://portal.cloud.quix.io/`
-  > NOTE: `Quix__Sdk__Token` and `Quix__Portal__Api` are set automatically in Quix Cloud, thus is the recommended approach for an easy migration.
+    - Set `Quix__Portal__Api` to the URL obtained from your Quix Platform project settings. 
+
+  > NOTE: `Quix__Sdk__Token` and `Quix__Portal__Api` are set automatically in Quix Cloud and by [Quix CLI](https://quix.io/docs/quix-cli/overview.html).
   
 OR <br>
 

--- a/docs/quix-platform.md
+++ b/docs/quix-platform.md
@@ -62,13 +62,14 @@ First, [get your SDK Token](https://quix.io/docs/develop/authentication/streamin
 
 <br>
 
-#### 2. Pass SDK Token to Application
+#### 2. Pass SDK Token and Portal API URL to the Application
 With your `SDK Token` and a Quix Streams `Application`, you can pass it using one of
 these approaches:
 
-- **Set Environment Variable** (***recommended***):
-    - Simply set `Quix__Sdk__Token` (double underscores!) to your `SDK Token`
-  > NOTE: `Quix__Sdk__Token` is set automatically in Quix Cloud, thus is the recommended approach for an easy migration.
+- **Set Environment Variables** (***recommended***):
+    - Set `Quix__Sdk__Token` (double underscores!) to your `SDK Token`
+    - Set `Quix__Portal__Api` to `https://portal.cloud.quix.io/`
+  > NOTE: `Quix__Sdk__Token` and `Quix__Portal__Api` are set automatically in Quix Cloud, thus is the recommended approach for an easy migration.
   
 OR <br>
 
@@ -77,9 +78,12 @@ OR <br>
       ```python
       from quixstreams import Application
       
-      app = Application(quix_sdk_token="MY_TOKEN")
+      app = Application(
+          quix_sdk_token="MY_TOKEN",
+          quix_portal_api="https://portal.cloud.quix.io/",
+      )
       ```
-  > WARNING: This value is prioritized over `Quix__Sdk__Token`, which may cause ambiguity if both are set.
+  > WARNING: These values are prioritized over `Quix__Sdk__Token` and `Quix__Portal__Api`, which may cause ambiguity if both are set.
 
 <br>
 

--- a/quixstreams/platforms/quix/config.py
+++ b/quixstreams/platforms/quix/config.py
@@ -20,12 +20,10 @@ from .exceptions import (
     UndefinedQuixWorkspaceId,
 )
 
-__all__ = ("QuixKafkaConfigsBuilder", "QuixApplicationConfig", "DEFAULT_PORTAL_API_URL")
+__all__ = ("QuixKafkaConfigsBuilder", "QuixApplicationConfig")
 
 logger = logging.getLogger(__name__)
 
-
-DEFAULT_PORTAL_API_URL = "https://portal-api.platform.quix.io/"
 QUIX_CONNECTIONS_MAX_IDLE_MS = 3 * 60 * 1000
 QUIX_METADATA_MAX_AGE_MS = 3 * 60 * 1000
 
@@ -131,7 +129,7 @@ class QuixKafkaConfigsBuilder:
     def from_credentials(
         cls,
         quix_sdk_token: str,
-        quix_portal_api: str = DEFAULT_PORTAL_API_URL,
+        quix_portal_api: str,
         workspace_id: Optional[str] = None,
         timeout: float = 30,
         topic_create_timeout: float = 60,

--- a/quixstreams/sources/core/kafka/quix.py
+++ b/quixstreams/sources/core/kafka/quix.py
@@ -4,7 +4,7 @@ from quixstreams.error_callbacks import ConsumerErrorCallback, default_on_consum
 from quixstreams.kafka import AutoOffsetReset
 from quixstreams.models.serializers import DeserializerType
 from quixstreams.models.topics import Topic
-from quixstreams.platforms.quix import DEFAULT_PORTAL_API_URL, QuixKafkaConfigsBuilder
+from quixstreams.platforms.quix import QuixKafkaConfigsBuilder
 from quixstreams.sources import (
     ClientConnectFailureCallback,
     ClientConnectSuccessCallback,
@@ -57,7 +57,7 @@ class QuixEnvironmentSource(KafkaReplicatorSource):
         topic: str,
         quix_sdk_token: str,
         quix_workspace_id: str,
-        quix_portal_api: Optional[str] = None,
+        quix_portal_api: str,
         auto_offset_reset: Optional[AutoOffsetReset] = None,
         consumer_extra_config: Optional[dict] = None,
         consumer_poll_timeout: Optional[float] = None,
@@ -82,9 +82,10 @@ class QuixEnvironmentSource(KafkaReplicatorSource):
 
         self._short_topic = topic
         self._quix_workspace_id = quix_workspace_id
+
         self._quix_config = QuixKafkaConfigsBuilder.from_credentials(
             quix_sdk_token=quix_sdk_token,
-            quix_portal_api=quix_portal_api or DEFAULT_PORTAL_API_URL,
+            quix_portal_api=quix_portal_api,
             workspace_id=quix_workspace_id,
         )
 

--- a/tests/test_quixstreams/test_sources/test_core/test_kafka.py
+++ b/tests/test_quixstreams/test_sources/test_core/test_kafka.py
@@ -302,6 +302,7 @@ class TestQuixEnvironmentSource(Base):
             auto_offset_reset="earliest",
             quix_sdk_token="my_sdk_token",
             quix_workspace_id=self.QUIX_WORKSPACE_ID,
+            quix_portal_api="http://example.com",
         )
 
     def _get_librdkafka_connection_config(self, *args, **kwargs):


### PR DESCRIPTION
* The Quix portal API URL https://portal-api.platform.quix.io/ will no longer be set by default.
* The URL must be provided explicitly.