### PR TITLE
Add retry mechanism for Quix Portal API connection errors

### DIFF
--- a/quixstreams/platforms/quix/api.py
+++ b/quixstreams/platforms/quix/api.py
@@ -182,7 +182,6 @@ class QuixPortalApiService:
         workspace_id = workspace_id or self.default_workspace_id
         return self.client.get(f"/{workspace_id}/topics", timeout=timeout).json()
 
-    @retry_on_connection_error()
     def post_topic(
         self,
         topic_name: str,

--- a/quixstreams/platforms/quix/api.py
+++ b/quixstreams/platforms/quix/api.py
@@ -1,4 +1,7 @@
 import json
+import logging
+import time
+from functools import wraps
 from io import BytesIO
 from typing import List, Literal, Optional
 from zipfile import ZipFile
@@ -13,6 +16,40 @@ from .exceptions import (
 )
 
 __all__ = ("QuixPortalApiService",)
+
+logger = logging.getLogger(__name__)
+
+
+def retry_on_connection_error(max_retries: int = 5, base_delay: float = 1.0):
+    """
+    Retry decorator for httpx connection errors with exponential backoff.
+
+    :param max_retries: Maximum number of retry attempts (default: 5)
+    :param base_delay: Base delay in seconds for exponential backoff (default: 1.0)
+    """
+    start = 1
+    stop = max_retries + 1
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            for attempt in range(start, stop):
+                try:
+                    return func(*args, **kwargs)
+                except (httpx.ConnectError, httpx.TimeoutException) as e:
+                    delay = base_delay * (2**attempt)
+                    logger.warning(
+                        f"API request failed (attempt {attempt}/{max_retries}): {e}. "
+                        f"Retrying in {delay:.1f} seconds..."
+                    )
+                    time.sleep(delay)
+
+            # Final attempt without retrying
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 class QuixPortalApiService:
@@ -77,6 +114,7 @@ class QuixPortalApiService:
     def default_workspace_id(self, value):
         self._default_workspace_id = value
 
+    @retry_on_connection_error()
     def get_librdkafka_connection_config(
         self, workspace_id: Optional[str] = None, timeout: float = 30
     ) -> dict:
@@ -86,6 +124,7 @@ class QuixPortalApiService:
             timeout=timeout,
         ).json()
 
+    @retry_on_connection_error()
     def get_workspace_certificate(
         self, workspace_id: Optional[str] = None, timeout: float = 30
     ) -> Optional[bytes]:
@@ -109,19 +148,23 @@ class QuixPortalApiService:
             with z.open("ca.cert") as f:
                 return f.read()
 
+    @retry_on_connection_error()
     def get_auth_token_details(self, timeout: float = 30) -> dict:
         return self.client.get("/auth/token/details", timeout=timeout).json()
 
+    @retry_on_connection_error()
     def get_workspace(
         self, workspace_id: Optional[str] = None, timeout: float = 30
     ) -> dict:
         workspace_id = workspace_id or self.default_workspace_id
         return self.client.get(f"/workspaces/{workspace_id}", timeout=timeout).json()
 
+    @retry_on_connection_error()
     def get_workspaces(self, timeout: float = 30) -> List[dict]:
         # TODO: This seems only return [] with Personal Access Tokens as of Sept 7 '23
         return self.client.get("/workspaces", timeout=timeout).json()
 
+    @retry_on_connection_error()
     def get_topic(
         self, topic_name: str, workspace_id: Optional[str] = None, timeout: float = 30
     ) -> dict:
@@ -130,6 +173,7 @@ class QuixPortalApiService:
             f"/{workspace_id}/topics/{topic_name}", timeout=timeout
         ).json()
 
+    @retry_on_connection_error()
     def get_topics(
         self,
         workspace_id: Optional[str] = None,
@@ -138,6 +182,7 @@ class QuixPortalApiService:
         workspace_id = workspace_id or self.default_workspace_id
         return self.client.get(f"/{workspace_id}/topics", timeout=timeout).json()
 
+    @retry_on_connection_error()
     def post_topic(
         self,
         topic_name: str,

--- a/tests/test_quixstreams/test_platforms/test_quix/test_api.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/test_api.py
@@ -2,7 +2,7 @@ import json
 import zipfile
 from io import BytesIO
 from unittest import mock
-from unittest.mock import create_autospec
+from unittest.mock import create_autospec, patch
 
 import httpx
 import pytest
@@ -87,3 +87,166 @@ class TestQuixPortalApiService:
         error_str = str(e.value)
         for s in [invalid_json.decode(), str(code), url]:
             assert s in error_str
+
+    @patch("time.sleep")  # Mock sleep to speed up the test
+    @patch("quixstreams.platforms.quix.api.httpx.Client")  # Mock the httpx.Client class
+    def test_retry_on_connection_error_success_after_retries(
+        self, mock_client_class, mock_sleep
+    ):
+        """Test that the retry decorator successfully retries on httpx.ConnectError and eventually succeeds."""
+        ws = "test-workspace"
+        expected_result = {"broker": "config"}
+
+        # Create a mock client instance
+        mock_client_instance = mock.Mock()
+        mock_client_class.return_value = mock_client_instance
+
+        # Mock response
+        mock_response = mock.Mock()
+        mock_response.json.return_value = expected_result
+
+        # Mock the client to fail twice with different connection errors, then succeed
+        mock_client_instance.get.side_effect = [
+            httpx.ConnectError(
+                "DNS resolution failed"
+            ),  # First attempt fails with DNS error
+            httpx.TimeoutException(
+                "Connection timeout"
+            ),  # Second attempt fails with timeout
+            mock_response,  # Third attempt succeeds
+        ]
+
+        api = QuixPortalApiService(
+            portal_api="http://portal.com", auth_token="token", default_workspace_id=ws
+        )
+
+        # Call the method that should retry
+        result = api.get_librdkafka_connection_config(ws)
+
+        # Verify the result
+        assert result == expected_result
+
+        # Verify it was called 3 times (2 failures + 1 success)
+        assert mock_client_instance.get.call_count == 3
+
+        # Verify sleep was called twice (for the 2 retries)
+        assert mock_sleep.call_count == 2
+
+        # Verify exponential backoff delays: 2s, 4s
+        expected_delays = [2.0, 4.0]  # base_delay * (2 ** attempt) for attempts 1,2
+        actual_delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert actual_delays == expected_delays
+
+    @patch("time.sleep")  # Mock sleep to speed up the test
+    @patch("quixstreams.platforms.quix.api.httpx.Client")  # Mock the httpx.Client class
+    def test_retry_on_connection_error_max_retries_exceeded(
+        self, mock_client_class, mock_sleep
+    ):
+        """Test that the retry decorator eventually gives up after max retries and raises the original error."""
+        ws = "test-workspace"
+
+        # Create a mock client instance
+        mock_client_instance = mock.Mock()
+        mock_client_class.return_value = mock_client_instance
+
+        # Mock the client to fail with alternating connection errors
+        mock_client_instance.get.side_effect = [
+            httpx.ConnectError("DNS resolution failed"),
+            httpx.TimeoutException("Connection timeout"),
+            httpx.ConnectError("DNS resolution failed"),
+            httpx.TimeoutException("Connection timeout"),
+            httpx.ConnectError("DNS resolution failed"),
+            httpx.TimeoutException("Final timeout"),  # Final attempt
+        ]
+
+        api = QuixPortalApiService(
+            portal_api="http://portal.com", auth_token="token", default_workspace_id=ws
+        )
+
+        # Call the method that should retry and eventually fail
+        with pytest.raises(httpx.TimeoutException, match="Final timeout"):
+            api.get_librdkafka_connection_config(ws)
+
+        # Verify it was called 6 times (5 retries + 1 final attempt)
+        assert mock_client_instance.get.call_count == 6
+
+        # Verify sleep was called 5 times (for the 5 retries)
+        assert mock_sleep.call_count == 5
+
+        # Verify exponential backoff delays: 2s, 4s, 8s, 16s, 32s
+        expected_delays = [2.0, 4.0, 8.0, 16.0, 32.0]  # base_delay * (2 ** attempt)
+        actual_delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert actual_delays == expected_delays
+
+    @patch("quixstreams.platforms.quix.api.httpx.Client")  # Mock the httpx.Client class
+    def test_retry_on_connection_error_no_retry_for_other_errors(
+        self, mock_client_class
+    ):
+        """Test that the retry decorator does not retry for non-connection errors like HTTPStatusError."""
+        ws = "test-workspace"
+
+        # Create a mock client instance
+        mock_client_instance = mock.Mock()
+        mock_client_class.return_value = mock_client_instance
+
+        # Mock the client to fail with HTTPStatusError (should not retry)
+        mock_response = mock.Mock()
+        mock_response.status_code = 404
+        http_error = httpx.HTTPStatusError(
+            "Not found", request=mock.Mock(), response=mock_response
+        )
+        mock_client_instance.get.side_effect = http_error
+
+        api = QuixPortalApiService(
+            portal_api="http://portal.com", auth_token="token", default_workspace_id=ws
+        )
+
+        # The HTTPStatusError should be caught by the response handler and converted to QuixApiRequestFailure
+        # But the retry decorator should not interfere with this
+        with pytest.raises(httpx.HTTPStatusError):
+            api.get_librdkafka_connection_config(ws)
+
+        # Verify it was only called once (no retries for HTTPStatusError)
+        assert mock_client_instance.get.call_count == 1
+
+    @patch("time.sleep")  # Mock sleep to speed up the test
+    @patch("quixstreams.platforms.quix.api.httpx.Client")  # Mock the httpx.Client class
+    def test_retry_on_timeout_exception_only(self, mock_client_class, mock_sleep):
+        """Test that the retry decorator works specifically with TimeoutException."""
+        ws = "test-workspace"
+        expected_result = {"broker": "config"}
+
+        # Create a mock client instance
+        mock_client_instance = mock.Mock()
+        mock_client_class.return_value = mock_client_instance
+
+        # Mock response
+        mock_response = mock.Mock()
+        mock_response.json.return_value = expected_result
+
+        # Mock the client to fail with TimeoutException, then succeed
+        mock_client_instance.get.side_effect = [
+            httpx.TimeoutException("Request timeout"),  # First attempt fails
+            mock_response,  # Second attempt succeeds
+        ]
+
+        api = QuixPortalApiService(
+            portal_api="http://portal.com", auth_token="token", default_workspace_id=ws
+        )
+
+        # Call the method that should retry
+        result = api.get_librdkafka_connection_config(ws)
+
+        # Verify the result
+        assert result == expected_result
+
+        # Verify it was called 2 times (1 failure + 1 success)
+        assert mock_client_instance.get.call_count == 2
+
+        # Verify sleep was called once (for the 1 retry)
+        assert mock_sleep.call_count == 1
+
+        # Verify exponential backoff delay: 2s
+        expected_delays = [2.0]  # base_delay * (2 ** attempt) for attempt 1
+        actual_delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert actual_delays == expected_delays


### PR DESCRIPTION
## Problem
The Quix Portal API calls were failing with DNS resolution errors (`httpx.ConnectError`) during temporary network issues, causing applications to crash instead of gracefully handling transient connectivity problems.

## Solution
Implemented a retry mechanism with exponential backoff for connection-related errors:

- **Retry decorator** with 5 attempts and exponential backoff (2s, 4s, 8s, 16s, 32s)
- **Applied to all 8 HTTP methods** in `QuixPortalApiService`
- **Handles both DNS errors and timeouts** while preserving fast-fail for legitimate API errors (404, 401, etc.)
- **Comprehensive logging** for retry attempts and failures

## Changes
- Added `retry_on_connection_error` decorator in `quixstreams/platforms/quix/api.py`
- Applied decorator to all Portal API methods (`get_librdkafka_connection_config`, `get_workspace`, etc.)
- Added 4 tests covering success scenarios, max retries, and different error types

This resolves intermittent DNS and connection timeout issues when connecting to Quix Cloud, making the SDK more resilient to network instability.