### PR TITLE
sink influxdb3: fix getting version

### DIFF
--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -200,7 +200,7 @@ class InfluxDB3Sink(BatchingSink):
         # This validates the token is valid regardless of version
         try:
             r = httpx.get(
-                httpx.URL(host=self._client_args["host"], path="ping"),
+                httpx.URL(url=self._client_args["host"], path="/ping"),
                 headers={"Authorization": f"Token {self._client_args['token']}"},
                 timeout=self._request_timeout_ms / 1000,
             )
@@ -209,7 +209,7 @@ class InfluxDB3Sink(BatchingSink):
             logger.error("Ping to InfluxDB failed, likely due to an invalid token.")
             raise
         version = r.headers.get("X-Influxdb-Version") or r.json()["version"]
-        return version.split(".")[0][-1]
+        return version.split(".")[0]
 
     def setup(self):
         self._client = InfluxDBClient3(**self._client_args)

--- a/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
@@ -568,7 +568,7 @@ class TestInfluxDB3Sink:
         sink._client_args["token"] = test_token
         response_mock = MagicMock(
             status_code=204,
-            headers={"X-Influxdb-Version": f"{test_version}.1.2"}
+            headers={"X-Influxdb-Version": f"{test_version}.1.2"},
         )
         with patch(
             "quixstreams.sinks.core.influxdb3.httpx.get",

--- a/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
@@ -1,6 +1,6 @@
 import datetime
 from typing import Optional
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import influxdb_client_3
 import pytest
@@ -551,3 +551,34 @@ class TestInfluxDB3Sink:
         error_str = str(e)
         assert precision in error_str
         assert "got 16" in error_str
+
+    def test_get_influx_version(self, influxdb3_sink_factory):
+        client_mock = MagicMock(spec_set=InfluxDBClient3)
+        measurement = "measurement"
+        sink = influxdb3_sink_factory(
+            client_mock=client_mock,
+            measurement=measurement,
+        )
+
+        test_host = "https://example.org"
+        test_token = "test-token"
+        test_version = 30
+
+        sink._client_args["host"] = test_host
+        sink._client_args["token"] = test_token
+        response_mock = MagicMock(
+            status_code=204,
+            headers={"X-Influxdb-Version": f"{test_version}.1.2"}
+        )
+        with patch(
+            "quixstreams.sinks.core.influxdb3.httpx.get",
+            return_value=response_mock,
+        ) as httpx_get_mock:
+            version = sink._get_influx_version()
+            httpx_get_mock.assert_called_once_with(
+                f"{test_host}/ping",
+                headers={"Authorization": f"Token {test_token}"},
+                timeout=sink._request_timeout_ms / 1000,
+            )
+            response_mock.raise_for_status.assert_called_once_with()
+            assert version == str(test_version)


### PR DESCRIPTION
### Issue

As I noticed switching from requests to httpx broke InfluxDB3 Sink.

### PR Summary

In this PR I tried to fix ping URL generation for getting InfluxDB server version and also added a unittest for that function.

### PR Details

1. Changed host `kwarg` to `url`, because `host` kwarg in httpx.URL for example httpx.URL(host="http://example.org", path="ping") raises two errors:
    - Unexpected '/' in 'http://example.org'
    - Invalid IPv6 address: '[http://example.org] 

2. Added leading forward slash to path string, because httpx.URL(url="http://example.org", path="ping") raises:
    - For absolute URLs, path must be empty or begin with '/'

3. Removed [-1] from end of return value computation, because it will fail with major versions greater than 9.
