### PR TITLE
Fix influxdb3 sink retention policy handling and timestamps len

### DIFF
--- a/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
@@ -28,6 +28,7 @@ def influxdb3_sink_factory():
         time_precision: TimePrecision = "ms",
         convert_ints_to_floats: bool = False,
         include_metadata_tags: bool = False,
+        raise_on_retention_violation: bool = False,
     ) -> InfluxDB3Sink:
         sink = InfluxDB3Sink(
             token="",
@@ -42,6 +43,7 @@ def influxdb3_sink_factory():
             include_metadata_tags=include_metadata_tags,
             convert_ints_to_floats=convert_ints_to_floats,
             batch_size=batch_size,
+            raise_on_retention_violation=raise_on_retention_violation,
         )
         sink._client = client_mock
         return sink
@@ -582,3 +584,72 @@ class TestInfluxDB3Sink:
             )
             response_mock.raise_for_status.assert_called_once_with()
             assert version == str(test_version)
+
+    def test_write_422_continues_by_default(self, influxdb3_sink_factory, caplog):
+        """422 errors should be logged but not raise by default"""
+
+        class Response:
+            status = 422
+
+        influx_422_err = influxdb_client_3.InfluxDBError(
+            message="retention policy violation"
+        )
+        influx_422_err.response = Response()
+        influx_422_err.retry_after = None
+
+        client_mock = MagicMock(spec_set=InfluxDBClient3)
+        client_mock.write.side_effect = influx_422_err
+
+        sink = influxdb3_sink_factory(
+            client_mock=client_mock,
+            measurement="measurement",
+            raise_on_retention_violation=False,
+        )
+
+        sink.add(
+            value={"key": "value1"},
+            key="key",
+            timestamp=1234567890123,
+            headers=[],
+            topic="test-topic",
+            partition=0,
+            offset=1,
+        )
+
+        with caplog.at_level("WARNING"):
+            sink.flush()
+            assert "retention policy or schema violation" in caplog.text
+
+    def test_write_422_raises_when_strict_mode(self, influxdb3_sink_factory):
+        """422 errors should raise when raise_on_retention_violation=True"""
+
+        class Response:
+            status = 422
+
+        influx_422_err = influxdb_client_3.InfluxDBError(
+            message="retention policy violation"
+        )
+        influx_422_err.response = Response()
+        influx_422_err.retry_after = None
+
+        client_mock = MagicMock(spec_set=InfluxDBClient3)
+        client_mock.write.side_effect = influx_422_err
+
+        sink = influxdb3_sink_factory(
+            client_mock=client_mock,
+            measurement="measurement",
+            raise_on_retention_violation=True,
+        )
+
+        sink.add(
+            value={"key": "value1"},
+            key="key",
+            timestamp=1234567890123,
+            headers=[],
+            topic="test-topic",
+            partition=0,
+            offset=1,
+        )
+
+        with pytest.raises(influxdb_client_3.InfluxDBError):
+            sink.flush()


### PR DESCRIPTION
### Summary
Adds graceful handling of InfluxDB retention policy violations (HTTP 422 errors) to prevent pipeline crashes when writing data outside the configured retention period. And fixes timestamps len

### Changes
- ✅ Added `raise_on_retention_violation` parameter (default: `False`) for optional strict mode
- ✅ HTTP 422 errors with "retention policy" message are logged as warnings and skipped by default
- ✅ Kafka offsets are committed, preventing infinite retry loops
- ✅ Other 422 errors (schema conflicts, etc.) still raise exceptions
- ✅ Added comprehensive test coverage for both default and strict modes
- ✅ Updated documentation
- ✅ Fixed timestamp lens
