### PR TITLE
Fix Influxdb3 sink extra timeout argument

### DIFF
--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -2,7 +2,6 @@ import logging
 import sys
 import time
 from datetime import datetime, timezone
-from importlib import metadata
 from typing import Any, Callable, Iterable, Literal, Mapping, Optional, Union, get_args
 
 import httpx
@@ -172,38 +171,20 @@ class InfluxDB3Sink(BatchingSink):
                     f'Keys {overlap_str} are present in both "fields_keys" and "tags_keys"'
                 )
 
-        major, minor, _ = map(int, metadata.version("influxdb3-python").split("."))
-
-        if (major, minor) >= (0, 17):
-            self._client_args = {
-                "token": token,
-                "host": host,
-                "org": organization_id,
-                "database": database,
-                "debug": debug,
-                "enable_gzip": enable_gzip,
-                "write_client_options": {
-                    "write_options": WriteOptions(
-                        write_type=WriteType.synchronous,
-                        timeout=self._request_timeout_ms,
-                    )
-                },
-            }
-        else:
-            self._client_args = {
-                "token": token,
-                "host": host,
-                "org": organization_id,
-                "database": database,
-                "debug": debug,
-                "enable_gzip": enable_gzip,
-                "timeout": self._request_timeout_ms,
-                "write_client_options": {
-                    "write_options": WriteOptions(
-                        write_type=WriteType.synchronous,
-                    )
-                },
-            }
+        self._client_args = {
+            "token": token,
+            "host": host,
+            "org": organization_id,
+            "database": database,
+            "debug": debug,
+            "enable_gzip": enable_gzip,
+            "write_client_options": {
+                "write_options": WriteOptions(
+                    write_type=WriteType.synchronous,
+                    timeout=self._request_timeout_ms,
+                )
+            },
+        }
         self._client: Optional[InfluxDBClient3] = None
         self._measurement = _measurement_callable(measurement)
         self._fields_keys = _fields_callable(fields_keys)

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import time
 from datetime import datetime, timezone
+from importlib import metadata
 from typing import Any, Callable, Iterable, Literal, Mapping, Optional, Union, get_args
 
 import httpx
@@ -171,21 +172,38 @@ class InfluxDB3Sink(BatchingSink):
                     f'Keys {overlap_str} are present in both "fields_keys" and "tags_keys"'
                 )
 
-        self._client_args = {
-            "token": token,
-            "host": host,
-            "org": organization_id,
-            "database": database,
-            "debug": debug,
-            "enable_gzip": enable_gzip,
-            "write_client_options": {
-                "write_options": WriteOptions(
-                    write_type=WriteType.synchronous,
-                    timeout=self._request_timeout_ms,
-                )
-            },
-        }
+        major, minor, _ = map(int, metadata.version("influxdb3-python").split("."))
 
+        if (major, minor) >= (0, 17):
+            self._client_args = {
+                "token": token,
+                "host": host,
+                "org": organization_id,
+                "database": database,
+                "debug": debug,
+                "enable_gzip": enable_gzip,
+                "write_client_options": {
+                    "write_options": WriteOptions(
+                        write_type=WriteType.synchronous,
+                        timeout=self._request_timeout_ms,
+                    )
+                },
+            }
+        else:
+            self._client_args = {
+                "token": token,
+                "host": host,
+                "org": organization_id,
+                "database": database,
+                "debug": debug,
+                "enable_gzip": enable_gzip,
+                "timeout": self._request_timeout_ms,
+                "write_client_options": {
+                    "write_options": WriteOptions(
+                        write_type=WriteType.synchronous,
+                    )
+                },
+            }
         self._client: Optional[InfluxDBClient3] = None
         self._measurement = _measurement_callable(measurement)
         self._fields_keys = _fields_callable(fields_keys)

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -2,7 +2,6 @@ import logging
 import sys
 import time
 from datetime import datetime, timezone
-from importlib import metadata
 from typing import Any, Callable, Iterable, Literal, Mapping, Optional, Union, get_args
 
 import httpx
@@ -172,38 +171,20 @@ class InfluxDB3Sink(BatchingSink):
                     f'Keys {overlap_str} are present in both "fields_keys" and "tags_keys"'
                 )
 
-        major, minor, _ = map(int, metadata.version("influxdb3-python").split("."))
-
-        if (major, minor) >= (0, 17):
-            self._client_args = {
-                "token": token,
-                "host": host,
-                "org": organization_id,
-                "database": database,
-                "debug": debug,
-                "enable_gzip": enable_gzip,
-                "write_client_options": {
-                    "write_options": WriteOptions(
-                        write_type=WriteType.synchronous,
-                        timeout=self._request_timeout_ms,
-                    )
-                },
-            }
-        else:
-            self._client_args = {
-                "token": token,
-                "host": host,
-                "org": organization_id,
-                "database": database,
-                "debug": debug,
-                "enable_gzip": enable_gzip,
-                "timeout": self._request_timeout_ms,
-                "write_client_options": {
-                    "write_options": WriteOptions(
-                        write_type=WriteType.synchronous,
-                    )
-                },
-            }
+        self._client_args = {
+            "token": token,
+            "host": host,
+            "org": organization_id,
+            "database": database,
+            "debug": debug,
+            "enable_gzip": enable_gzip,
+            "write_client_options": {
+                "write_options": WriteOptions(
+                    write_type=WriteType.synchronous,
+                    timeout=self._request_timeout_ms,
+                )
+            },
+        }
 
         self._client: Optional[InfluxDBClient3] = None
         self._measurement = _measurement_callable(measurement)

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import time
 from datetime import datetime, timezone
+from importlib import metadata
 from typing import Any, Callable, Iterable, Literal, Mapping, Optional, Union, get_args
 
 import httpx
@@ -171,20 +172,39 @@ class InfluxDB3Sink(BatchingSink):
                     f'Keys {overlap_str} are present in both "fields_keys" and "tags_keys"'
                 )
 
-        self._client_args = {
-            "token": token,
-            "host": host,
-            "org": organization_id,
-            "database": database,
-            "debug": debug,
-            "enable_gzip": enable_gzip,
-            "timeout": self._request_timeout_ms,
-            "write_client_options": {
-                "write_options": WriteOptions(
-                    write_type=WriteType.synchronous,
-                )
-            },
-        }
+        major, minor, _ = map(int, metadata.version("influxdb3-python").split("."))
+
+        if (major, minor) >= (0, 17):
+            self._client_args = {
+                "token": token,
+                "host": host,
+                "org": organization_id,
+                "database": database,
+                "debug": debug,
+                "enable_gzip": enable_gzip,
+                "write_client_options": {
+                    "write_options": WriteOptions(
+                        write_type=WriteType.synchronous,
+                        timeout=self._request_timeout_ms,
+                    )
+                },
+            }
+        else:
+            self._client_args = {
+                "token": token,
+                "host": host,
+                "org": organization_id,
+                "database": database,
+                "debug": debug,
+                "enable_gzip": enable_gzip,
+                "timeout": self._request_timeout_ms,
+                "write_client_options": {
+                    "write_options": WriteOptions(
+                        write_type=WriteType.synchronous,
+                    )
+                },
+            }
+
         self._client: Optional[InfluxDBClient3] = None
         self._measurement = _measurement_callable(measurement)
         self._fields_keys = _fields_callable(fields_keys)


### PR DESCRIPTION
Fixes #1071 and #1072.

The `WriteOptions` class in `influxdb3-python` v0.17+ added a `timeout` parameter. Previously, `timeout` was passed at the top level to `InfluxDBClient3`, but in v0.17 this causes a "got multiple values for keyword argument 'timeout'" error because:

1. The top-level `timeout` is passed to `_InfluxDBClient` via `**kwargs`
2. The `timeout` inside `write_client_options` is spread and passed to `_WriteApi`
3. Both clients now receive `timeout`, causing a conflict

This PR moves the `timeout` parameter into the `WriteOptions` object to be compatible with v0.17+.

**Breaking change:** This requires `influxdb3-python>=0.17.0`. Users who have pinned to v0.16 to quick fix this will need to update.